### PR TITLE
Added new framework skills for quickstarts

### DIFF
--- a/plugins/auth0-sdks/skills/auth0-aspnet-core/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-aspnet-core/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: auth0-aspnet-core
+description: Use when adding authentication to ASP.NET Core MVC web applications (login, logout, user sessions, protected routes) - integrates Auth0.AspNetCore.Authentication SDK for server-rendered apps
+---
+
+# Auth0 ASP.NET Core MVC Integration
+
+Add authentication to ASP.NET Core MVC web applications using Auth0.AspNetCore.Authentication SDK.
+
+---
+
+## Prerequisites
+
+- .NET 6.0+ SDK installed
+- ASP.NET Core MVC knowledge
+- Auth0 account and application configured
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **Blazor Server apps** - Use `auth0-blazor-server` skill
+- **Web APIs without sessions** - Use `auth0-aspnet-webapi` skill for JWT validation
+- **Blazor WebAssembly** - Use client-side authentication approach
+- **Single Page Applications** - Use JavaScript SDK instead
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+dotnet add package Auth0.AspNetCore.Authentication
+```
+
+### 2. Configure Environment
+
+**For automated setup with Auth0 CLI**, see [Setup Guide](references/setup.md) for complete scripts.
+
+**For manual setup:**
+
+Update `appsettings.json`:
+
+```json
+{
+  "Auth0": {
+    "Domain": "your-tenant.auth0.com",
+    "ClientId": "your-client-id",
+    "ClientSecret": "your-client-secret"
+  }
+}
+```
+
+### 3. Register Auth0 Services
+
+Update `Program.cs`:
+
+```csharp
+using Auth0.AspNetCore.Authentication;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add Auth0 authentication
+builder.Services
+    .AddAuth0WebAppAuthentication(options =>
+    {
+        options.Domain = builder.Configuration["Auth0:Domain"];
+        options.ClientId = builder.Configuration["Auth0:ClientId"];
+        options.ClientSecret = builder.Configuration["Auth0:ClientSecret"];
+    });
+
+builder.Services.AddControllersWithViews();
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+
+// Enable authentication middleware
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller=Home}/{action=Index}/{id?}");
+
+app.Run();
+```
+
+### 4. Add Login/Logout Controller
+
+Create `AccountController.cs`:
+
+```csharp
+using Auth0.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+public class AccountController : Controller
+{
+    public async Task Login(string returnUrl = "/")
+    {
+        var authenticationProperties = new LoginAuthenticationPropertiesBuilder()
+            .WithRedirectUri(returnUrl)
+            .Build();
+
+        await HttpContext.ChallengeAsync(
+            Auth0Constants.AuthenticationScheme,
+            authenticationProperties);
+    }
+
+    [Authorize]
+    public async Task Logout()
+    {
+        var authenticationProperties = new LogoutAuthenticationPropertiesBuilder()
+            .WithRedirectUri(Url.Action("Index", "Home"))
+            .Build();
+
+        await HttpContext.SignOutAsync(
+            Auth0Constants.AuthenticationScheme,
+            authenticationProperties);
+
+        await HttpContext.SignOutAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme);
+    }
+
+    [Authorize]
+    public IActionResult Profile()
+    {
+        return View(new
+        {
+            Name = User.Identity.Name,
+            EmailAddress = User.Claims.FirstOrDefault(c => c.Type == "email")?.Value,
+            ProfileImage = User.Claims.FirstOrDefault(c => c.Type == "picture")?.Value
+        });
+    }
+}
+```
+
+### 5. Test Authentication
+
+Run your application:
+
+```bash
+dotnet run
+```
+
+Visit `https://localhost:5001/Account/Login` to test authentication.
+
+---
+
+## Detailed Documentation
+
+- **[Setup Guide](references/setup.md)** - Automated setup scripts, CLI commands, manual configuration
+- **[Integration Guide](references/integration.md)** - Protected routes, claims, authorization policies
+- **[API Reference](references/api.md)** - Complete SDK API, configuration options
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgot to add callback URL in Auth0 Dashboard | Add `https://localhost:5001/callback` to Allowed Callback URLs |
+| Missing ClientSecret | Regular Web Applications require client secret - ensure it's in appsettings.json |
+| Wrong application type | Use "Regular Web Application" not "Single Page Application" in Auth0 Dashboard |
+| UseAuthentication() in wrong order | Call `UseAuthentication()` before `UseAuthorization()` |
+| Missing [Authorize] attribute | Add `[Authorize]` to controllers/actions that require authentication |
+| Not calling SignOutAsync twice | Must sign out from both Auth0 and Cookie schemes |
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` - Basic Auth0 setup
+- `auth0-migration` - Migrate from another auth provider
+- `auth0-mfa` - Add Multi-Factor Authentication
+- `auth0-blazor-server` - For Blazor Server apps
+- `auth0-aspnet-webapi` - For Web APIs
+
+---
+
+## Quick Reference
+
+**Core Methods:**
+- `AddAuth0WebAppAuthentication()` - Register Auth0 services
+- `ChallengeAsync()` - Initiate login
+- `SignOutAsync()` - Log out user
+- `[Authorize]` - Protect controllers/actions
+
+**User Claims:**
+- `User.Identity.Name` - User's name
+- `User.Claims` - All user claims
+- `User.IsInRole()` - Check role membership
+
+**Common Use Cases:**
+- Login/Logout → See Step 4 above
+- Protected routes → [Integration Guide](references/integration.md#protected-routes)
+- Custom claims → [Integration Guide](references/integration.md#claims)
+- Authorization policies → [Integration Guide](references/integration.md#policies)
+
+---
+
+## References
+
+- [Auth0.AspNetCore.Authentication Documentation](https://github.com/auth0/auth0-aspnetcore-authentication)
+- [Auth0 ASP.NET Core Quickstart](https://auth0.com/docs/quickstart/webapp/aspnet-core)
+- [ASP.NET Core Security Documentation](https://docs.microsoft.com/aspnet/core/security/)

--- a/plugins/auth0-sdks/skills/auth0-aspnet-core/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-aspnet-core/references/api.md
@@ -1,0 +1,65 @@
+# Auth0 ASP.NET Core API Reference
+
+Complete API reference for Auth0.AspNetCore.Authentication SDK.
+
+---
+
+## Configuration
+
+### AddAuth0WebAppAuthentication()
+
+```csharp
+builder.Services.AddAuth0WebAppAuthentication(options =>
+{
+    options.Domain = "your-tenant.auth0.com";
+    options.ClientId = "your-client-id";
+    options.ClientSecret = "your-client-secret";
+    options.Scope = "openid profile email";
+});
+```
+
+---
+
+## Authentication
+
+### Login
+
+```csharp
+var authProperties = new LoginAuthenticationPropertiesBuilder()
+    .WithRedirectUri("/")
+    .Build();
+
+await HttpContext.ChallengeAsync(
+    Auth0Constants.AuthenticationScheme,
+    authProperties);
+```
+
+### Logout
+
+```csharp
+var authProperties = new LogoutAuthenticationPropertiesBuilder()
+    .WithRedirectUri("/")
+    .Build();
+
+await HttpContext.SignOutAsync(Auth0Constants.AuthenticationScheme, authProperties);
+await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+```
+
+---
+
+## User Information
+
+### Access User Claims
+
+```csharp
+var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+var email = User.FindFirst(ClaimTypes.Email)?.Value;
+var name = User.Identity.Name;
+```
+
+---
+
+## References
+
+- [SDK GitHub Repository](https://github.com/auth0/auth0-aspnetcore-authentication)
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-aspnet-core/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-aspnet-core/references/integration.md
@@ -1,0 +1,89 @@
+# Auth0 ASP.NET Core Integration Guide
+
+Advanced patterns for Auth0 in ASP.NET Core MVC.
+
+---
+
+## Protected Routes
+
+### Using [Authorize] Attribute
+
+```csharp
+[Authorize]
+public class DashboardController : Controller
+{
+    public IActionResult Index()
+    {
+        return View();
+    }
+}
+```
+
+### Protect Specific Actions
+
+```csharp
+public class HomeController : Controller
+{
+    public IActionResult Index() => View();
+
+    [Authorize]
+    public IActionResult Profile()
+    {
+        return View();
+    }
+}
+```
+
+---
+
+## Working with Claims
+
+### Access User Claims
+
+```csharp
+[Authorize]
+public IActionResult Profile()
+{
+    var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+    var email = User.FindFirst(ClaimTypes.Email)?.Value;
+    var name = User.Identity.Name;
+
+    return View(new ProfileViewModel
+    {
+        UserId = userId,
+        Email = email,
+        Name = name
+    });
+}
+```
+
+---
+
+## Authorization Policies
+
+### Define Policies
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("RequireAdminRole", policy =>
+        policy.RequireRole("Admin"));
+});
+```
+
+### Use Policies
+
+```csharp
+[Authorize(Policy = "RequireAdminRole")]
+public IActionResult AdminDashboard()
+{
+    return View();
+}
+```
+
+---
+
+## References
+
+- Return to [main skill guide](../SKILL.md)
+- [ASP.NET Core Authorization](https://docs.microsoft.com/aspnet/core/security/authorization/)

--- a/plugins/auth0-sdks/skills/auth0-aspnet-core/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-aspnet-core/references/setup.md
@@ -1,0 +1,46 @@
+# Auth0 ASP.NET Core Setup Guide
+
+Complete setup instructions for Auth0 with ASP.NET Core MVC.
+
+---
+
+## Quick Setup (Manual)
+
+### Step 1: Install SDK
+
+```bash
+dotnet add package Auth0.AspNetCore.Authentication
+```
+
+### Step 2: Create Auth0 Application
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **Applications**
+3. Click **Create Application**
+4. Choose:
+   - Name: Your app name
+   - Type: **Regular Web Applications**
+5. Configure:
+   - **Allowed Callback URLs**: `https://localhost:5001/callback`
+   - **Allowed Logout URLs**: `https://localhost:5001/`
+   - **Allowed Web Origins**: `https://localhost:5001`
+
+### Step 3: Update appsettings.json
+
+```json
+{
+  "Auth0": {
+    "Domain": "your-tenant.auth0.com",
+    "ClientId": "your-client-id",
+    "ClientSecret": "your-client-secret"
+  }
+}
+```
+
+---
+
+## Next Steps
+
+1. Return to [main skill guide](../SKILL.md)
+2. See [Integration Guide](integration.md) for protected routes
+3. Check [API Reference](api.md) for complete SDK documentation

--- a/plugins/auth0-sdks/skills/auth0-aspnet-webapi/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-aspnet-webapi/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: auth0-aspnet-webapi
+description: Use when adding JWT authentication to ASP.NET Core Web APIs (protect endpoints, validate tokens, check scopes) - integrates Auth0.AspNetCore.Authentication.Api SDK for stateless API authentication
+---
+
+# Auth0 ASP.NET Core Web API Integration
+
+Add JWT authentication to ASP.NET Core Web APIs using Auth0.AspNetCore.Authentication.Api SDK.
+
+---
+
+## Prerequisites
+
+- .NET 6.0+ SDK installed
+- ASP.NET Core Web API knowledge
+- Auth0 account and API configured
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **Web applications with sessions** - Use `auth0-aspnet-core` skill for MVC apps
+- **Blazor Server** - Use `auth0-blazor-server` skill
+- **Single Page Applications** - Use JavaScript SDK client-side
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+dotnet add package Auth0.AspNetCore.Authentication.Api
+```
+
+### 2. Configure Environment
+
+Update `appsettings.json`:
+
+```json
+{
+  "Auth0": {
+    "Domain": "your-tenant.auth0.com",
+    "Audience": "your-api-identifier"
+  }
+}
+```
+
+### 3. Register Auth0 Services
+
+Update `Program.cs`:
+
+```csharp
+using Auth0.AspNetCore.Authentication;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+// Add Auth0 JWT validation
+builder.Services
+    .AddAuthentication()
+    .AddJwtBearer(options =>
+    {
+        options.Authority = $"https://{builder.Configuration["Auth0:Domain"]}";
+        options.Audience = builder.Configuration["Auth0:Audience"];
+    });
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+```
+
+### 4. Protect API Endpoints
+
+Add `[Authorize]` to controllers or actions:
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PrivateController : ControllerBase
+{
+    [HttpGet]
+    [Authorize]
+    public IActionResult GetPrivateData()
+    {
+        return Ok(new
+        {
+            Message = "This is private data",
+            UserId = User.FindFirst("sub")?.Value
+        });
+    }
+}
+```
+
+### 5. Check Scopes
+
+Protect endpoints with specific scopes:
+
+```csharp
+[HttpGet("admin")]
+[Authorize("read:admin")]
+public IActionResult GetAdminData()
+{
+    return Ok("Admin data");
+}
+```
+
+To enable scope checking, configure authorization policies:
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("read:admin", policy =>
+        policy.RequireClaim("scope", "read:admin"));
+});
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Missing Audience | API requires audience parameter - set in appsettings.json |
+| Wrong Auth0 resource type | Create "API" (not Application) in Auth0 Dashboard |
+| Missing [Authorize] attribute | Add to controllers/actions that require authentication |
+| Not checking scopes | Add authorization policies for scope-based access control |
+| UseAuthentication() in wrong order | Call before UseAuthorization() |
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` - Basic Auth0 setup
+- `auth0-aspnet-core` - For web applications with sessions
+- `auth0-mfa` - Add Multi-Factor Authentication
+
+---
+
+## Quick Reference
+
+**Core Methods:**
+- `AddJwtBearer()` - Configure JWT validation
+- `[Authorize]` - Protect endpoints
+- `[Authorize("policy")]` - Require specific scope
+- `User.FindFirst()` - Access token claims
+
+**Common Use Cases:**
+- Protect endpoints → See Step 4 above
+- Scope-based authorization → See Step 5 above
+- Access token claims → [Integration Guide](references/integration.md#claims)
+- CORS configuration → [Integration Guide](references/integration.md#cors)
+
+---
+
+## References
+
+- [Auth0.AspNetCore.Authentication.Api Documentation](https://github.com/auth0/auth0-aspnetcore-authentication)
+- [Auth0 ASP.NET Core Web API Quickstart](https://auth0.com/docs/quickstart/backend/aspnet-core-webapi)
+- [ASP.NET Core API Security](https://docs.microsoft.com/aspnet/core/security/authorization/)

--- a/plugins/auth0-sdks/skills/auth0-aspnet-webapi/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-aspnet-webapi/references/api.md
@@ -1,0 +1,49 @@
+# Auth0 ASP.NET Core Web API API Reference
+
+API reference for JWT authentication in Web APIs.
+
+---
+
+## Configuration
+
+```csharp
+builder.Services
+    .AddAuthentication()
+    .AddJwtBearer(options =>
+    {
+        options.Authority = $"https://{domain}";
+        options.Audience = audience;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true
+        };
+    });
+```
+
+---
+
+## Authorization
+
+### Protect Endpoints
+
+```csharp
+[Authorize]
+[HttpGet]
+public IActionResult Protected() => Ok("Protected");
+```
+
+### Require Scopes
+
+```csharp
+[Authorize("read:admin")]
+[HttpGet("admin")]
+public IActionResult AdminOnly() => Ok("Admin");
+```
+
+---
+
+## References
+
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-aspnet-webapi/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-aspnet-webapi/references/integration.md
@@ -1,0 +1,72 @@
+# Auth0 ASP.NET Core Web API Integration Guide
+
+Advanced patterns for Web API authentication.
+
+---
+
+## Access Token Claims
+
+```csharp
+[Authorize]
+[HttpGet]
+public IActionResult GetUserInfo()
+{
+    var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+    var scopes = User.FindAll("scope").Select(c => c.Value);
+
+    return Ok(new { UserId = userId, Scopes = scopes });
+}
+```
+
+---
+
+## Scope-Based Authorization
+
+### Define Policies
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("read:messages", policy =>
+        policy.RequireClaim("scope", "read:messages"));
+
+    options.AddPolicy("write:messages", policy =>
+        policy.RequireClaim("scope", "write:messages"));
+});
+```
+
+### Use Policies
+
+```csharp
+[HttpGet]
+[Authorize("read:messages")]
+public IActionResult GetMessages() => Ok(messages);
+
+[HttpPost]
+[Authorize("write:messages")]
+public IActionResult CreateMessage([FromBody] Message msg) => Created("", msg);
+```
+
+---
+
+## CORS Configuration
+
+```csharp
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowSPA", builder =>
+    {
+        builder.WithOrigins("http://localhost:3000")
+               .AllowAnyMethod()
+               .AllowAnyHeader();
+    });
+});
+
+app.UseCors("AllowSPA");
+```
+
+---
+
+## References
+
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-aspnet-webapi/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-aspnet-webapi/references/setup.md
@@ -1,0 +1,41 @@
+# Auth0 ASP.NET Core Web API Setup Guide
+
+Setup instructions for Auth0 with ASP.NET Core Web API.
+
+---
+
+## Quick Setup
+
+### Step 1: Install SDK
+
+```bash
+dotnet add package Auth0.AspNetCore.Authentication.Api
+```
+
+### Step 2: Create Auth0 API
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **APIs**
+3. Click **Create API**
+4. Enter:
+   - **Name**: Your API name
+   - **Identifier**: `https://your-api-identifier` (this is your audience)
+5. Click **Create**
+
+### Step 3: Configure appsettings.json
+
+```json
+{
+  "Auth0": {
+    "Domain": "your-tenant.auth0.com",
+    "Audience": "https://your-api-identifier"
+  }
+}
+```
+
+---
+
+## Next Steps
+
+- Return to [main skill guide](../SKILL.md)
+- See [Integration Guide](integration.md) for scopes

--- a/plugins/auth0-sdks/skills/auth0-blazor-server/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-blazor-server/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: auth0-blazor-server
+description: Use when adding authentication to Blazor Server applications (login, logout, user sessions, protected pages) - integrates Auth0.AspNetCore.Authentication SDK for server-side Blazor apps
+---
+
+# Auth0 Blazor Server Integration
+
+Add authentication to Blazor Server applications using Auth0.AspNetCore.Authentication SDK.
+
+---
+
+## Prerequisites
+
+- .NET 6.0+ SDK installed
+- Blazor Server knowledge
+- Auth0 account and application configured
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **Blazor WebAssembly** - Use client-side authentication with @auth0/auth0-spa-js
+- **ASP.NET Core MVC** - Use `auth0-aspnet-core` skill
+- **Web APIs** - Use `auth0-aspnet-webapi` skill for JWT validation
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+dotnet add package Auth0.AspNetCore.Authentication
+```
+
+### 2. Configure Environment
+
+Update `appsettings.json`:
+
+```json
+{
+  "Auth0": {
+    "Domain": "your-tenant.auth0.com",
+    "ClientId": "your-client-id",
+    "ClientSecret": "your-client-secret"
+  }
+}
+```
+
+### 3. Register Auth0 Services
+
+Update `Program.cs`:
+
+```csharp
+using Auth0.AspNetCore.Authentication;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+
+// Add Auth0 authentication
+builder.Services.AddAuth0WebAppAuthentication(options =>
+{
+    options.Domain = builder.Configuration["Auth0:Domain"];
+    options.ClientId = builder.Configuration["Auth0:ClientId"];
+    options.ClientSecret = builder.Configuration["Auth0:ClientSecret"];
+});
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();
+```
+
+### 4. Add Login/Logout Pages
+
+Create `Pages/Account/Login.cshtml`:
+
+```cshtml
+@page
+@using Auth0.AspNetCore.Authentication
+@using Microsoft.AspNetCore.Authentication
+
+@{
+    await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme,
+        new LoginAuthenticationPropertiesBuilder()
+            .WithRedirectUri("/")
+            .Build());
+}
+```
+
+Create `Pages/Account/Logout.cshtml`:
+
+```cshtml
+@page
+@using Auth0.AspNetCore.Authentication
+@using Microsoft.AspNetCore.Authentication
+@using Microsoft.AspNetCore.Authentication.Cookies
+
+@{
+    await HttpContext.SignOutAsync(Auth0Constants.AuthenticationScheme,
+        new LogoutAuthenticationPropertiesBuilder()
+            .WithRedirectUri("/")
+            .Build());
+    await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+}
+```
+
+### 5. Protect Blazor Components
+
+Use `<AuthorizeView>` in components:
+
+```razor
+<AuthorizeView>
+    <Authorized>
+        <p>Hello, @context.User.Identity.Name!</p>
+        <a href="/Account/Logout">Logout</a>
+    </Authorized>
+    <NotAuthorized>
+        <a href="/Account/Login">Login</a>
+    </NotAuthorized>
+</AuthorizeView>
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgot callback URL | Add `https://localhost:5001/callback` to Auth0 Dashboard |
+| Missing ClientSecret | Blazor Server requires client secret in appsettings.json |
+| Wrong app type | Use "Regular Web Application" in Auth0 Dashboard |
+| UseAuthentication() missing | Call before UseAuthorization() in Program.cs |
+
+---
+
+## Related Skills
+
+- `auth0-aspnet-core` - For ASP.NET Core MVC
+- `auth0-aspnet-webapi` - For Web APIs
+
+---
+
+## References
+
+- [Auth0.AspNetCore.Authentication Documentation](https://github.com/auth0/auth0-aspnetcore-authentication)
+- [Blazor Server Security](https://docs.microsoft.com/aspnet/core/blazor/security/server/)

--- a/plugins/auth0-sdks/skills/auth0-blazor-server/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-blazor-server/references/api.md
@@ -1,0 +1,39 @@
+# Auth0 Blazor Server API Reference
+
+API reference for Blazor Server authentication.
+
+---
+
+## Configuration
+
+```csharp
+builder.Services.AddAuth0WebAppAuthentication(options =>
+{
+    options.Domain = "your-tenant.auth0.com";
+    options.ClientId = "your-client-id";
+    options.ClientSecret = "your-client-secret";
+});
+```
+
+---
+
+## Components
+
+### AuthorizeView
+
+```razor
+<AuthorizeView>
+    <Authorized>
+        @context.User.Identity.Name
+    </Authorized>
+    <NotAuthorized>
+        Not logged in
+    </NotAuthorized>
+</AuthorizeView>
+```
+
+---
+
+## References
+
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-blazor-server/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-blazor-server/references/integration.md
@@ -1,0 +1,56 @@
+# Auth0 Blazor Server Integration Guide
+
+Advanced patterns for Blazor Server authentication.
+
+---
+
+## Protected Components
+
+### Using AuthorizeView
+
+```razor
+<AuthorizeView>
+    <Authorized>
+        <h3>Welcome @context.User.Identity.Name</h3>
+    </Authorized>
+    <NotAuthorized>
+        <p>Please log in</p>
+    </NotAuthorized>
+</AuthorizeView>
+```
+
+### Authorize Attribute on Pages
+
+```razor
+@page "/profile"
+@attribute [Authorize]
+
+<h3>User Profile</h3>
+```
+
+---
+
+## Access User Claims
+
+```razor
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+        if (user.Identity.IsAuthenticated)
+        {
+            var email = user.FindFirst("email")?.Value;
+        }
+    }
+}
+```
+
+---
+
+## References
+
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-blazor-server/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-blazor-server/references/setup.md
@@ -1,0 +1,40 @@
+# Auth0 Blazor Server Setup Guide
+
+Setup instructions for Auth0 with Blazor Server.
+
+---
+
+## Quick Setup
+
+### Step 1: Install SDK
+
+```bash
+dotnet add package Auth0.AspNetCore.Authentication
+```
+
+### Step 2: Configure appsettings.json
+
+```json
+{
+  "Auth0": {
+    "Domain": "your-tenant.auth0.com",
+    "ClientId": "your-client-id",
+    "ClientSecret": "your-client-secret"
+  }
+}
+```
+
+### Step 3: Create Auth0 Application
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Create **Regular Web Application**
+3. Configure:
+   - **Allowed Callback URLs**: `https://localhost:5001/callback`
+   - **Allowed Logout URLs**: `https://localhost:5001/`
+
+---
+
+## Next Steps
+
+- Return to [main skill guide](../SKILL.md)
+- See [Integration Guide](integration.md)

--- a/plugins/auth0-sdks/skills/auth0-capnweb/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-capnweb/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: auth0-capnweb
+description: Use when adding authentication to Cap'n Web RPC applications (login, logout, secure WebSocket RPC calls) - integrates @auth0/auth0-spa-js client-side with JWT validation for WebSocket connections
+---
+
+# Auth0 Cap'n Web RPC Integration
+
+Add authentication to Cap'n Web RPC applications using @auth0/auth0-spa-js with secure WebSocket RPC.
+
+---
+
+## Prerequisites
+
+- Node.js 18+ installed
+- Cap'n Web RPC knowledge
+- Auth0 account configured with both Application and API
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **REST APIs** - Use standard HTTP authentication
+- **Traditional SPAs without RPC** - Use `auth0-vanilla-js` or framework-specific skills
+- **Server-side rendered apps** - Use server-side authentication
+
+---
+
+## Quick Start Workflow
+
+### 1. Install Dependencies
+
+```bash
+npm install capnweb ws @auth0/auth0-spa-js jsonwebtoken jwks-rsa dotenv
+```
+
+### 2. Configure Environment
+
+Create `.env` file:
+
+```bash
+VITE_AUTH0_DOMAIN=your-tenant.auth0.com
+VITE_AUTH0_CLIENT_ID=your-client-id
+VITE_AUTH0_AUDIENCE=your-api-identifier
+```
+
+### 3. Create Client Authentication
+
+Create `client/auth.js`:
+
+```javascript
+import { Auth0Client } from '@auth0/auth0-spa-js';
+
+const auth0Client = new Auth0Client({
+  domain: import.meta.env.VITE_AUTH0_DOMAIN,
+  clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
+  authorizationParams: {
+    redirect_uri: window.location.origin,
+    audience: import.meta.env.VITE_AUTH0_AUDIENCE
+  }
+});
+
+export async function login() {
+  await auth0Client.loginWithRedirect();
+}
+
+export async function logout() {
+  await auth0Client.logout({
+    logoutParams: {
+      returnTo: window.location.origin
+    }
+  });
+}
+
+export async function getAccessToken() {
+  return await auth0Client.getTokenSilently();
+}
+
+export async function isAuthenticated() {
+  return await auth0Client.isAuthenticated();
+}
+```
+
+### 4. Create Secure RPC Client
+
+Create `client/rpc.js`:
+
+```javascript
+import { createClient } from 'capnweb';
+import { getAccessToken } from './auth.js';
+
+export async function createSecureRPCClient() {
+  const token = await getAccessToken();
+
+  const client = createClient({
+    url: 'ws://localhost:3000',
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
+  return client;
+}
+```
+
+### 5. Create Secure RPC Server
+
+Create `server/auth.js`:
+
+```javascript
+import jwt from 'jsonwebtoken';
+import jwksClient from 'jwks-rsa';
+
+const client = jwksClient({
+  jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`
+});
+
+function getKey(header, callback) {
+  client.getSigningKey(header.kid, (err, key) => {
+    const signingKey = key.publicKey || key.rsaPublicKey;
+    callback(null, signingKey);
+  });
+}
+
+export function verifyToken(token) {
+  return new Promise((resolve, reject) => {
+    jwt.verify(
+      token,
+      getKey,
+      {
+        audience: process.env.AUTH0_AUDIENCE,
+        issuer: `https://${process.env.AUTH0_DOMAIN}/`,
+        algorithms: ['RS256']
+      },
+      (err, decoded) => {
+        if (err) reject(err);
+        else resolve(decoded);
+      }
+    );
+  });
+}
+```
+
+Create `server/index.js`:
+
+```javascript
+import { createServer } from 'capnweb';
+import { verifyToken } from './auth.js';
+
+const server = createServer({
+  port: 3000,
+
+  // Middleware to verify JWT on connection
+  onConnect: async (connection, request) => {
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new Error('Missing or invalid authorization header');
+    }
+
+    const token = authHeader.substring(7);
+
+    try {
+      const decoded = await verifyToken(token);
+      connection.user = decoded; // Attach user to connection
+    } catch (error) {
+      throw new Error('Invalid token');
+    }
+  }
+});
+
+// Define RPC methods
+server.methods({
+  async getPrivateData(connection) {
+    return {
+      message: 'Private data',
+      userId: connection.user.sub
+    };
+  }
+});
+
+server.start();
+console.log('Secure RPC server running on ws://localhost:3000');
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Missing Audience | Set audience in both client and server configuration |
+| No JWT validation on server | Always verify tokens on WebSocket connection |
+| Hardcoded credentials | Use environment variables for all Auth0 config |
+| Missing Authorization header | Send token in WebSocket connection headers |
+| Not handling token expiry | Implement token refresh on client side |
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` - Basic Auth0 setup
+- `auth0-vanilla-js` - For standard SPA authentication
+- `auth0-mfa` - Add Multi-Factor Authentication
+
+---
+
+## Quick Reference
+
+**Client Functions:**
+- `login()` - Initiate login
+- `logout()` - Log out user
+- `getAccessToken()` - Get JWT for RPC calls
+- `isAuthenticated()` - Check auth status
+
+**Server Functions:**
+- `verifyToken()` - Validate JWT
+- `onConnect()` - Middleware for WebSocket auth
+- `connection.user` - Access authenticated user data
+
+**Common Use Cases:**
+- Secure RPC methods → See Step 5 above
+- Client authentication → See Step 3 above
+- Token refresh → [Integration Guide](references/integration.md#token-refresh)
+- Permission checks → [Integration Guide](references/integration.md#permissions)
+
+---
+
+## References
+
+- [@auth0/auth0-spa-js Documentation](https://auth0.com/docs/libraries/auth0-spa-js)
+- [Cap'n Web Documentation](https://capnweb.dev/)
+- [WebSocket Security Best Practices](https://auth0.com/blog/real-time-apps-websockets-authentication/)

--- a/plugins/auth0-sdks/skills/auth0-capnweb/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-capnweb/references/api.md
@@ -1,0 +1,67 @@
+# Auth0 Cap'n Web API Reference
+
+API reference for Cap'n Web RPC authentication.
+
+---
+
+## Client Configuration
+
+```javascript
+import { Auth0Client } from '@auth0/auth0-spa-js';
+
+const auth0 = new Auth0Client({
+  domain: 'your-tenant.auth0.com',
+  clientId: 'your-client-id',
+  authorizationParams: {
+    redirect_uri: window.location.origin,
+    audience: 'https://your-api-identifier'
+  }
+});
+```
+
+---
+
+## Server JWT Validation
+
+```javascript
+import jwt from 'jsonwebtoken';
+import jwksClient from 'jwks-rsa';
+
+const client = jwksClient({
+  jwksUri: 'https://your-tenant.auth0.com/.well-known/jwks.json'
+});
+
+function getKey(header, callback) {
+  client.getSigningKey(header.kid, (err, key) => {
+    callback(null, key.publicKey || key.rsaPublicKey);
+  });
+}
+
+jwt.verify(token, getKey, {
+  audience: 'your-audience',
+  issuer: 'https://your-tenant.auth0.com/',
+  algorithms: ['RS256']
+}, (err, decoded) => {
+  // Handle result
+});
+```
+
+---
+
+## RPC Method Definition
+
+```javascript
+server.methods({
+  async methodName(connection, ...args) {
+    // connection.user contains decoded JWT
+    return { result: 'data' };
+  }
+});
+```
+
+---
+
+## References
+
+- [jsonwebtoken Documentation](https://github.com/auth0/node-jsonwebtoken)
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-capnweb/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-capnweb/references/integration.md
@@ -1,0 +1,80 @@
+# Auth0 Cap'n Web Integration Guide
+
+Advanced patterns for Cap'n Web RPC authentication.
+
+---
+
+## Token Refresh
+
+```javascript
+// Client-side
+let rpcClient;
+
+async function ensureValidToken() {
+  try {
+    const token = await getAccessToken();
+
+    if (!rpcClient || tokenExpired(token)) {
+      rpcClient = await createSecureRPCClient();
+    }
+
+    return rpcClient;
+  } catch (error) {
+    // Token refresh failed, redirect to login
+    await login();
+  }
+}
+
+// Use before RPC calls
+const client = await ensureValidToken();
+await client.call('getPrivateData');
+```
+
+---
+
+## Permission-Based RPC Methods
+
+```javascript
+// Server-side
+server.methods({
+  async adminMethod(connection) {
+    const permissions = connection.user.permissions || [];
+
+    if (!permissions.includes('read:admin')) {
+      throw new Error('Insufficient permissions');
+    }
+
+    return { data: 'admin data' };
+  }
+});
+```
+
+---
+
+## Connection State Management
+
+```javascript
+// Server-side
+const activeConnections = new Map();
+
+server.onConnect = async (connection, request) => {
+  // Verify token
+  const token = extractToken(request);
+  const user = await verifyToken(token);
+
+  connection.user = user;
+  activeConnections.set(user.sub, connection);
+};
+
+server.onDisconnect = (connection) => {
+  if (connection.user) {
+    activeConnections.delete(connection.user.sub);
+  }
+};
+```
+
+---
+
+## References
+
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-capnweb/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-capnweb/references/setup.md
@@ -1,0 +1,48 @@
+# Auth0 Cap'n Web Setup Guide
+
+Setup instructions for Auth0 with Cap'n Web RPC.
+
+---
+
+## Quick Setup
+
+### Step 1: Install Dependencies
+
+```bash
+npm install capnweb ws @auth0/auth0-spa-js jsonwebtoken jwks-rsa dotenv
+```
+
+### Step 2: Create Auth0 Resources
+
+**Create Application (SPA):**
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Create **Single Page Application**
+3. Configure:
+   - **Allowed Callback URLs**: `http://localhost:5173`
+   - **Allowed Logout URLs**: `http://localhost:5173`
+   - **Allowed Web Origins**: `http://localhost:5173`
+
+**Create API:**
+1. Navigate to **Applications** → **APIs**
+2. Click **Create API**
+3. Enter identifier: `https://your-api-identifier`
+
+### Step 3: Configure Environment
+
+```bash
+# Client (.env)
+VITE_AUTH0_DOMAIN=your-tenant.auth0.com
+VITE_AUTH0_CLIENT_ID=your-client-id
+VITE_AUTH0_AUDIENCE=https://your-api-identifier
+
+# Server (.env)
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_AUDIENCE=https://your-api-identifier
+```
+
+---
+
+## Next Steps
+
+- Return to [main skill guide](../SKILL.md)
+- See [Integration Guide](integration.md)

--- a/plugins/auth0-sdks/skills/auth0-fastapi-backend/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-fastapi-backend/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: auth0-fastapi-backend
+description: Use when adding JWT authentication to FastAPI backend APIs (protect endpoints, validate tokens, check permissions) - uses python-jose for stateless API authentication with Auth0
+---
+
+# Auth0 FastAPI Backend API Integration
+
+Add JWT authentication to FastAPI backend APIs using python-jose for token validation.
+
+---
+
+## Prerequisites
+
+- Python 3.8+ installed
+- FastAPI knowledge
+- Auth0 account and API configured
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **Web applications with sessions** - Use `auth0-fastapi` skill for session-based auth
+- **Single Page Applications** - Use JavaScript SDK client-side
+- **Express APIs** - Use express-jwt middleware
+
+---
+
+## Quick Start Workflow
+
+### 1. Install Dependencies
+
+```bash
+pip install "fastapi[all]" python-jose[cryptography] python-dotenv requests
+```
+
+### 2. Configure Environment
+
+Create `.env` file:
+
+```bash
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_AUDIENCE=your-api-identifier
+```
+
+### 3. Create JWT Validation
+
+Create `auth.py`:
+
+```python
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from jose import jwt, JWTError
+import requests
+import os
+from functools import lru_cache
+
+security = HTTPBearer()
+
+AUTH0_DOMAIN = os.getenv("AUTH0_DOMAIN")
+AUTH0_AUDIENCE = os.getenv("AUTH0_AUDIENCE")
+ALGORITHMS = ["RS256"]
+
+@lru_cache()
+def get_jwks():
+    """Get JSON Web Key Set from Auth0"""
+    jwks_url = f"https://{AUTH0_DOMAIN}/.well-known/jwks.json"
+    return requests.get(jwks_url).json()
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Verify and decode JWT token"""
+    token = credentials.credentials
+
+    try:
+        # Get signing key
+        jwks = get_jwks()
+        unverified_header = jwt.get_unverified_header(token)
+        rsa_key = {}
+
+        for key in jwks["keys"]:
+            if key["kid"] == unverified_header["kid"]:
+                rsa_key = {
+                    "kty": key["kty"],
+                    "kid": key["kid"],
+                    "use": key["use"],
+                    "n": key["n"],
+                    "e": key["e"]
+                }
+
+        if rsa_key:
+            # Validate token
+            payload = jwt.decode(
+                token,
+                rsa_key,
+                algorithms=ALGORITHMS,
+                audience=AUTH0_AUDIENCE,
+                issuer=f"https://{AUTH0_DOMAIN}/"
+            )
+            return payload
+
+    except JWTError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid token: {str(e)}"
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Unable to validate credentials"
+    )
+```
+
+### 4. Protect API Endpoints
+
+Create `main.py`:
+
+```python
+from fastapi import FastAPI, Depends
+from dotenv import load_dotenv
+from auth import verify_token
+
+load_dotenv()
+
+app = FastAPI()
+
+@app.get("/api/public")
+def public():
+    return {"message": "Public endpoint"}
+
+@app.get("/api/private")
+def private(token: dict = Depends(verify_token)):
+    return {
+        "message": "Private endpoint",
+        "user_id": token.get("sub")
+    }
+
+@app.get("/api/admin")
+def admin(token: dict = Depends(verify_token)):
+    # Check for specific permission
+    permissions = token.get("permissions", [])
+    if "read:admin" not in permissions:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    return {"message": "Admin endpoint"}
+```
+
+### 5. Run Application
+
+```bash
+uvicorn main:app --reload
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Missing Audience | Set AUTH0_AUDIENCE environment variable |
+| Wrong Auth0 resource type | Create "API" (not Application) in Auth0 Dashboard |
+| Not caching JWKS | Use `@lru_cache()` decorator on get_jwks() |
+| Missing permissions in token | Enable RBAC and add permissions to API in Auth0 Dashboard |
+| Virtual environment not activated | Run `source venv/bin/activate` before pip install |
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` - Basic Auth0 setup
+- `auth0-fastapi` - For web applications with sessions
+- `auth0-mfa` - Add Multi-Factor Authentication
+
+---
+
+## Quick Reference
+
+**Core Functions:**
+- `verify_token()` - Validate JWT and return payload
+- `Depends(verify_token)` - Protect endpoints
+- `token.get("permissions")` - Check permissions
+
+**Common Use Cases:**
+- Protect endpoints → See Step 4 above
+- Permission-based access → [Integration Guide](references/integration.md#permissions)
+- Custom claims → [Integration Guide](references/integration.md#claims)
+- CORS configuration → [Integration Guide](references/integration.md#cors)
+
+---
+
+## References
+
+- [python-jose Documentation](https://python-jose.readthedocs.io/)
+- [Auth0 FastAPI Backend Quickstart](https://auth0.com/docs/quickstart/backend/fastapi)
+- [FastAPI Security](https://fastapi.tiangolo.com/tutorial/security/)

--- a/plugins/auth0-sdks/skills/auth0-fastapi-backend/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-fastapi-backend/references/api.md
@@ -1,0 +1,46 @@
+# Auth0 FastAPI Backend API Reference
+
+API reference for JWT validation in FastAPI.
+
+---
+
+## JWT Validation
+
+```python
+from jose import jwt
+
+payload = jwt.decode(
+    token,
+    rsa_key,
+    algorithms=["RS256"],
+    audience=AUTH0_AUDIENCE,
+    issuer=f"https://{AUTH0_DOMAIN}/"
+)
+```
+
+---
+
+## Dependency Injection
+
+```python
+from fastapi import Depends
+from fastapi.security import HTTPBearer
+
+security = HTTPBearer()
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    token = credentials.credentials
+    # Validation logic
+    return payload
+
+@app.get("/protected")
+def protected(token: dict = Depends(verify_token)):
+    return {"user": token["sub"]}
+```
+
+---
+
+## References
+
+- [python-jose Documentation](https://python-jose.readthedocs.io/)
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-fastapi-backend/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-fastapi-backend/references/integration.md
@@ -1,0 +1,62 @@
+# Auth0 FastAPI Backend Integration Guide
+
+Advanced patterns for FastAPI backend authentication.
+
+---
+
+## Permission-Based Access
+
+```python
+from fastapi import HTTPException
+
+def require_permission(permission: str):
+    def check_permission(token: dict = Depends(verify_token)):
+        permissions = token.get("permissions", [])
+        if permission not in permissions:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Missing required permission: {permission}"
+            )
+        return token
+    return check_permission
+
+@app.get("/api/admin")
+def admin_endpoint(token: dict = Depends(require_permission("read:admin"))):
+    return {"message": "Admin data"}
+```
+
+---
+
+## Custom Claims
+
+```python
+@app.get("/api/user")
+def user_info(token: dict = Depends(verify_token)):
+    return {
+        "user_id": token.get("sub"),
+        "email": token.get("email"),
+        "custom_claim": token.get("https://your-namespace/custom_claim")
+    }
+```
+
+---
+
+## CORS Configuration
+
+```python
+from fastapi.middleware.cors import CORSMiddleware
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+---
+
+## References
+
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-fastapi-backend/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-fastapi-backend/references/setup.md
@@ -1,0 +1,39 @@
+# Auth0 FastAPI Backend Setup Guide
+
+Setup instructions for Auth0 with FastAPI backend APIs.
+
+---
+
+## Quick Setup
+
+### Step 1: Install Dependencies
+
+```bash
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+pip install "fastapi[all]" python-jose[cryptography] python-dotenv requests
+```
+
+### Step 2: Create Auth0 API
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **APIs**
+3. Click **Create API**
+4. Enter:
+   - **Name**: Your API name
+   - **Identifier**: `https://your-api-identifier`
+5. Click **Create**
+
+### Step 3: Configure .env
+
+```bash
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_AUDIENCE=https://your-api-identifier
+```
+
+---
+
+## Next Steps
+
+- Return to [main skill guide](../SKILL.md)
+- See [Integration Guide](integration.md) for permissions

--- a/plugins/auth0-sdks/skills/auth0-fastapi/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-fastapi/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: auth0-fastapi
+description: Use when adding authentication to FastAPI web applications (login, logout, user sessions, protected routes) - integrates auth0-fastapi SDK for Python server-side apps
+---
+
+# Auth0 FastAPI Integration
+
+Add authentication to FastAPI web applications using the auth0-fastapi SDK.
+
+---
+
+## Prerequisites
+
+- Python 3.8+ installed
+- FastAPI knowledge
+- Auth0 account and application configured
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **REST APIs without sessions** - Use JWT validation instead (`python-jose` with FastAPI dependencies)
+- **Flask applications** - Use `flask-openid-connect` instead
+- **Django applications** - Use `django-auth0` or `python-social-auth`
+- **Single-page applications** - Use `@auth0/auth0-spa-js` client-side SDK
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+# Activate virtual environment first
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install dependencies
+pip install auth0-fastapi "uvicorn[standard]" python-dotenv itsdangerous
+```
+
+**Note:** Quote `"uvicorn[standard]"` to prevent shell glob expansion.
+
+### 2. Configure Environment
+
+**For automated setup with Auth0 CLI**, see [Setup Guide](references/setup.md) for complete scripts.
+
+**For manual setup:**
+
+Create `.env` file:
+
+```bash
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_CLIENT_ID=your-client-id
+AUTH0_CLIENT_SECRET=your-client-secret
+SESSION_SECRET=$(openssl rand -hex 64)
+APP_BASE_URL=http://localhost:3000
+```
+
+### 3. Create FastAPI Application
+
+Create `main.py`:
+
+```python
+import os
+from fastapi import FastAPI, Depends, Request, Response
+from fastapi.responses import HTMLResponse
+from starlette.middleware.sessions import SessionMiddleware
+from dotenv import load_dotenv
+
+from auth0_fastapi.config import Auth0Config
+from auth0_fastapi.auth.auth_client import AuthClient
+from auth0_fastapi.server.routes import router, register_auth_routes
+
+# Load environment variables
+load_dotenv()
+
+app = FastAPI(title="Auth0 FastAPI Example")
+
+# Add Session Middleware - required for cookie handling
+app.add_middleware(SessionMiddleware, secret_key=os.getenv("SESSION_SECRET"))
+
+# Create Auth0Config
+config = Auth0Config(
+    domain=os.getenv("AUTH0_DOMAIN"),
+    client_id=os.getenv("AUTH0_CLIENT_ID"),
+    client_secret=os.getenv("AUTH0_CLIENT_SECRET"),
+    app_base_url=os.getenv("APP_BASE_URL", "http://localhost:3000"),
+    secret=os.getenv("SESSION_SECRET"),
+)
+
+# Instantiate the AuthClient
+auth_client = AuthClient(config)
+
+# Attach to FastAPI app state
+app.state.config = config
+app.state.auth_client = auth_client
+
+# Register authentication routes
+register_auth_routes(router, config)
+app.include_router(router)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request, response: Response):
+    """Home page with login/logout buttons"""
+    store_options = {"request": request, "response": response}
+    session = await auth_client.client.get_session(store_options=store_options)
+
+    if session:
+        user = await auth_client.client.get_user(store_options=store_options)
+        return f"""
+        <html>
+        <body>
+            <h1>Welcome, {user.get('name')}!</h1>
+            <p>Email: {user.get('email')}</p>
+            <a href="/auth/logout">Logout</a>
+        </body>
+        </html>
+        """
+    else:
+        return """
+        <html>
+        <body>
+            <h1>Auth0 FastAPI Example</h1>
+            <a href="/auth/login">Login</a>
+        </body>
+        </html>
+        """
+```
+
+### 4. Create Protected Route
+
+Add protected endpoint:
+
+```python
+from auth0_fastapi.auth.dependencies import requires_auth
+
+@app.get("/protected")
+@requires_auth
+async def protected(request: Request, response: Response):
+    """Protected route - requires authentication"""
+    store_options = {"request": request, "response": response}
+    user = await auth_client.client.get_user(store_options=store_options)
+
+    return {
+        "message": "This is a protected route",
+        "user": user
+    }
+```
+
+### 5. Run Application
+
+```bash
+uvicorn main:app --reload --port 3000
+```
+
+Visit `http://localhost:3000` and test authentication.
+
+---
+
+## Detailed Documentation
+
+- **[Setup Guide](references/setup.md)** - Automated setup scripts, CLI commands, manual configuration
+- **[Integration Guide](references/integration.md)** - Protected routes, API endpoints, error handling, advanced patterns
+- **[API Reference](references/api.md)** - Complete SDK API, configuration options, testing strategies
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgot to add callback URL in Auth0 Dashboard | Add `http://localhost:3000/auth/callback` to Allowed Callback URLs in Auth0 Dashboard |
+| Missing SessionMiddleware | Add `app.add_middleware(SessionMiddleware, secret_key=...)` before registering routes |
+| Not quoting uvicorn[standard] | Use quotes: `pip install "uvicorn[standard]"` |
+| Missing itsdangerous dependency | Install: `pip install itsdangerous` |
+| Virtual environment not activated | Run `source venv/bin/activate` before pip install |
+| Wrong application type | Use "Regular Web Application" not "Single Page Application" in Auth0 Dashboard |
+| Missing CLIENT_SECRET | Server-side apps require client secret - ensure it's in .env |
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` - Basic Auth0 setup
+- `auth0-migration` - Migrate from another auth provider
+- `auth0-mfa` - Add Multi-Factor Authentication
+
+---
+
+## Quick Reference
+
+**Core Components:**
+- `Auth0Config` - Configuration object
+- `AuthClient` - Authentication client
+- `register_auth_routes()` - Add /auth/login, /auth/callback, /auth/logout routes
+- `@requires_auth` - Decorator for protected routes
+
+**Built-in Routes:**
+- `/auth/login` - Initiate login
+- `/auth/callback` - Auth0 callback endpoint
+- `/auth/logout` - Log out user
+
+**Common Use Cases:**
+- Login/Logout buttons → See Step 3 above
+- Protected routes → See Step 4 above
+- API endpoints → [Integration Guide](references/integration.md#api-endpoints)
+- Error handling → [Integration Guide](references/integration.md#error-handling)
+
+---
+
+## References
+
+- [Auth0 FastAPI SDK Documentation](https://github.com/auth0/auth0-fastapi)
+- [Auth0 FastAPI Quickstart](https://auth0.com/docs/quickstart/webapp/fastapi)
+- [FastAPI Documentation](https://fastapi.tiangolo.com/)

--- a/plugins/auth0-sdks/skills/auth0-fastapi/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-fastapi/references/api.md
@@ -1,0 +1,141 @@
+# Auth0 FastAPI API Reference
+
+Complete API reference for auth0-fastapi SDK.
+
+---
+
+## Configuration
+
+### Auth0Config
+
+```python
+from auth0_fastapi.config import Auth0Config
+
+config = Auth0Config(
+    domain="your-tenant.auth0.com",        # Required
+    client_id="your-client-id",            # Required
+    client_secret="your-client-secret",    # Required
+    app_base_url="http://localhost:3000",  # Required
+    secret="session-secret-key",           # Required
+)
+```
+
+---
+
+## AuthClient
+
+### Initialization
+
+```python
+from auth0_fastapi.auth.auth_client import AuthClient
+
+auth_client = AuthClient(config)
+```
+
+### Methods
+
+**get_session()**
+```python
+store_options = {"request": request, "response": response}
+session = await auth_client.client.get_session(store_options=store_options)
+```
+
+**get_user()**
+```python
+store_options = {"request": request, "response": response}
+user = await auth_client.client.get_user(store_options=store_options)
+# Returns: dict with user profile (sub, name, email, etc.)
+```
+
+---
+
+## Route Registration
+
+### register_auth_routes()
+
+```python
+from auth0_fastapi.server.routes import router, register_auth_routes
+
+register_auth_routes(router, config)
+app.include_router(router)
+```
+
+**Creates routes:**
+- `/auth/login` - Initiate login
+- `/auth/callback` - Auth0 callback
+- `/auth/logout` - Log out user
+
+---
+
+## Decorators
+
+### @requires_auth
+
+```python
+from auth0_fastapi.auth.dependencies import requires_auth
+
+@app.get("/protected")
+@requires_auth
+async def protected_route(request: Request, response: Response):
+    # Only accessible to authenticated users
+    pass
+```
+
+---
+
+## Dependencies
+
+### get_current_user
+
+```python
+from fastapi import Depends
+from auth0_fastapi.auth.dependencies import get_current_user
+
+@app.get("/profile")
+async def profile(user: dict = Depends(get_current_user)):
+    return {"user": user}
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `AUTH0_DOMAIN` | Your Auth0 tenant domain | `tenant.auth0.com` |
+| `AUTH0_CLIENT_ID` | Application client ID | `abc123...` |
+| `AUTH0_CLIENT_SECRET` | Application client secret | `xyz789...` |
+| `SESSION_SECRET` | Session encryption key | `openssl rand -hex 64` |
+| `APP_BASE_URL` | Base URL of your app | `http://localhost:3000` |
+
+---
+
+## Session Middleware
+
+```python
+from starlette.middleware.sessions import SessionMiddleware
+
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=os.getenv("SESSION_SECRET"),
+    max_age=3600  # Optional: session timeout in seconds
+)
+```
+
+---
+
+## Security Best Practices
+
+1. **Use environment variables** - Never hardcode credentials
+2. **Use HTTPS in production** - Required for secure cookies
+3. **Rotate session secrets** - Change SESSION_SECRET periodically
+4. **Set appropriate session timeouts** - Configure max_age in SessionMiddleware
+5. **Validate on server** - Don't trust client-side validation alone
+
+---
+
+## References
+
+- [Auth0 FastAPI SDK GitHub](https://github.com/auth0/auth0-fastapi)
+- [FastAPI Documentation](https://fastapi.tiangolo.com/)
+- [Starlette Middleware](https://www.starlette.io/middleware/)

--- a/plugins/auth0-sdks/skills/auth0-fastapi/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-fastapi/references/integration.md
@@ -1,0 +1,148 @@
+# Auth0 FastAPI Integration Guide
+
+Advanced patterns for Auth0 integration in FastAPI.
+
+---
+
+## Protected Routes
+
+### Using Decorator
+
+```python
+from auth0_fastapi.auth.dependencies import requires_auth
+
+@app.get("/api/protected")
+@requires_auth
+async def protected_endpoint(request: Request, response: Response):
+    store_options = {"request": request, "response": response}
+    user = await auth_client.client.get_user(store_options=store_options)
+
+    return {"message": "Protected data", "user": user}
+```
+
+### Using Dependency
+
+```python
+from fastapi import Depends
+from auth0_fastapi.auth.dependencies import get_current_user
+
+@app.get("/api/profile")
+async def profile(user: dict = Depends(get_current_user)):
+    return {"user": user}
+```
+
+---
+
+## API Endpoints
+
+### JSON API with Session Auth
+
+```python
+@app.get("/api/data")
+@requires_auth
+async def get_data(request: Request, response: Response):
+    store_options = {"request": request, "response": response}
+    user = await auth_client.client.get_user(store_options=store_options)
+
+    # Fetch user-specific data
+    data = fetch_user_data(user["sub"])
+
+    return {"data": data}
+```
+
+---
+
+## Error Handling
+
+### Custom Error Handler
+
+```python
+from fastapi import HTTPException
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+@app.exception_handler(StarletteHTTPException)
+async def custom_exception_handler(request: Request, exc: StarletteHTTPException):
+    if exc.status_code == 401:
+        return RedirectResponse(url="/auth/login")
+
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": str(exc.detail)}
+    )
+```
+
+---
+
+## User Management
+
+### Get User Profile
+
+```python
+@app.get("/profile")
+@requires_auth
+async def user_profile(request: Request, response: Response):
+    store_options = {"request": request, "response": response}
+    user = await auth_client.client.get_user(store_options=store_options)
+
+    return {
+        "name": user.get("name"),
+        "email": user.get("email"),
+        "picture": user.get("picture"),
+        "sub": user.get("sub")
+    }
+```
+
+---
+
+## Session Management
+
+### Check Session Status
+
+```python
+async def get_session_status(request: Request, response: Response):
+    store_options = {"request": request, "response": response}
+    session = await auth_client.client.get_session(store_options=store_options)
+
+    return {"authenticated": session is not None}
+```
+
+---
+
+## Custom Login/Logout
+
+### Custom Login Redirect
+
+```python
+@app.get("/custom-login")
+async def custom_login():
+    return RedirectResponse(
+        url="/auth/login?returnTo=/dashboard"
+    )
+```
+
+---
+
+## Testing
+
+### Mock Authentication
+
+```python
+# test_app.py
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+def test_protected_route():
+    # Mock authenticated session
+    with client.websocket_connect("/") as session:
+        response = client.get("/protected")
+        assert response.status_code == 200
+```
+
+---
+
+## References
+
+- [FastAPI Documentation](https://fastapi.tiangolo.com/)
+- [Auth0 FastAPI SDK](https://github.com/auth0/auth0-fastapi)
+- Return to [main skill guide](../SKILL.md)

--- a/plugins/auth0-sdks/skills/auth0-fastapi/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-fastapi/references/setup.md
@@ -1,0 +1,151 @@
+# Auth0 FastAPI Setup Guide
+
+Complete setup instructions for Auth0 with FastAPI.
+
+---
+
+## Quick Setup (Automated)
+
+### Bash Script (macOS/Linux)
+
+```bash
+#!/bin/bash
+
+# Create and activate virtual environment
+python -m venv venv
+source venv/bin/activate
+
+# Install dependencies
+pip install auth0-fastapi "uvicorn[standard]" python-dotenv itsdangerous
+
+# Install Auth0 CLI if needed
+if ! command -v auth0 &> /dev/null; then
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    brew install auth0/auth0-cli/auth0
+  else
+    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh
+  fi
+fi
+
+# Login to Auth0
+auth0 login
+
+# Create app or select existing
+read -p "Enter Auth0 app ID (or press Enter to create new): " APP_ID
+
+if [ -z "$APP_ID" ]; then
+  APP_ID=$(auth0 apps create \
+    --name "fastapi-app" \
+    --type regular \
+    --callbacks "http://localhost:3000/auth/callback" \
+    --logout-urls "http://localhost:3000" \
+    --origins "http://localhost:3000" \
+    --reveal-secrets \
+    --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
+fi
+
+# Get credentials
+AUTH0_DOMAIN=$(auth0 apps show "$APP_ID" --json | grep -o '"domain":"[^"]*' | cut -d'"' -f4)
+AUTH0_CLIENT_ID=$(auth0 apps show "$APP_ID" --reveal-secrets --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
+AUTH0_CLIENT_SECRET=$(auth0 apps show "$APP_ID" --reveal-secrets --json | grep -o '"client_secret":"[^"]*' | cut -d'"' -f4)
+SESSION_SECRET=$(openssl rand -hex 64)
+
+# Create .env file
+cat > .env << EOF
+AUTH0_DOMAIN=$AUTH0_DOMAIN
+AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID
+AUTH0_CLIENT_SECRET=$AUTH0_CLIENT_SECRET
+SESSION_SECRET=$SESSION_SECRET
+APP_BASE_URL=http://localhost:3000
+EOF
+
+echo "✅ Setup complete! Credentials saved to .env"
+```
+
+---
+
+## Manual Setup
+
+### Step 1: Create Virtual Environment
+
+```bash
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+```
+
+### Step 2: Install Dependencies
+
+```bash
+pip install auth0-fastapi "uvicorn[standard]" python-dotenv itsdangerous
+```
+
+### Step 3: Create Auth0 Application
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **Applications**
+3. Click **Create Application**
+4. Choose:
+   - Name: Your app name
+   - Type: **Regular Web Applications** (NOT Single Page)
+5. Configure:
+   - **Allowed Callback URLs**: `http://localhost:3000/auth/callback`
+   - **Allowed Logout URLs**: `http://localhost:3000`
+   - **Allowed Web Origins**: `http://localhost:3000`
+
+### Step 4: Create .env File
+
+```bash
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_CLIENT_ID=your-client-id
+AUTH0_CLIENT_SECRET=your-client-secret
+SESSION_SECRET=$(openssl rand -hex 64)
+APP_BASE_URL=http://localhost:3000
+```
+
+**Important:** Replace placeholders with actual values from Auth0 Dashboard → Application Settings.
+
+---
+
+## Troubleshooting
+
+### Virtual Environment Issues
+
+**Command not found after activation:**
+```bash
+# Ensure you're in the virtual environment
+which python  # Should show venv/bin/python
+
+# Reinstall if needed
+deactivate
+rm -rf venv
+python -m venv venv
+source venv/bin/activate
+```
+
+### Package Installation Errors
+
+**uvicorn[standard] glob expansion error:**
+```bash
+# Always quote the brackets
+pip install "uvicorn[standard]"
+```
+
+**Missing itsdangerous:**
+```bash
+pip install itsdangerous
+```
+
+### Auth0 CLI Issues
+
+**Not logged in:**
+```bash
+auth0 login --force
+```
+
+---
+
+## Next Steps
+
+1. Return to [main skill guide](../SKILL.md)
+2. See [Integration Guide](integration.md) for protected routes
+3. Check [API Reference](api.md) for full SDK documentation

--- a/plugins/auth0-sdks/skills/auth0-svelte/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-svelte/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: auth0-svelte
+description: Use when adding authentication to Svelte applications (login, logout, user sessions, protected routes) - integrates @auth0/auth0-spa-js SDK for SPAs with SvelteKit or Vite
+---
+
+# Auth0 Svelte Integration
+
+Add authentication to Svelte single-page applications using @auth0/auth0-spa-js.
+
+---
+
+## Prerequisites
+
+- Svelte 5.x+ application (SvelteKit or Vite)
+- Auth0 account and application configured
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **Server-side rendered Svelte with authentication middleware** - Consider custom server-side implementation
+- **Embedded login** - This SDK uses Auth0 Universal Login (redirect-based)
+- **Backend API authentication** - Use JWT validation instead
+- **Mobile apps** - Use native SDKs for iOS/Android
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+npm install @auth0/auth0-spa-js
+```
+
+### 2. Configure Environment
+
+**For automated setup with Auth0 CLI**, see [Setup Guide](references/setup.md) for complete scripts.
+
+**For manual setup:**
+
+Create `.env` file:
+
+```bash
+VITE_AUTH0_DOMAIN=your-tenant.auth0.com
+VITE_AUTH0_CLIENT_ID=your-client-id
+```
+
+### 3. Create Auth0 Service
+
+Create `src/lib/auth0.js`:
+
+```javascript
+import { Auth0Client } from '@auth0/auth0-spa-js';
+import { writable, derived } from 'svelte/store';
+
+const domain = import.meta.env.VITE_AUTH0_DOMAIN;
+const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
+
+// Initialize Auth0 client
+const auth0Client = new Auth0Client({
+  domain,
+  clientId,
+  authorizationParams: {
+    redirect_uri: window.location.origin
+  }
+});
+
+// Create reactive stores
+export const isLoading = writable(true);
+export const isAuthenticated = writable(false);
+export const user = writable(null);
+export const error = writable(null);
+
+// Initialize authentication state
+async function initAuth() {
+  try {
+    // Check if returning from Auth0 redirect
+    const query = window.location.search;
+    if (query.includes('code=') && query.includes('state=')) {
+      await auth0Client.handleRedirectCallback();
+      window.history.replaceState({}, document.title, window.location.pathname);
+    }
+
+    // Check if user is authenticated
+    const authenticated = await auth0Client.isAuthenticated();
+    isAuthenticated.set(authenticated);
+
+    if (authenticated) {
+      const userProfile = await auth0Client.getUser();
+      user.set(userProfile);
+    }
+  } catch (err) {
+    error.set(err.message);
+  } finally {
+    isLoading.set(false);
+  }
+}
+
+// Auth actions
+export const login = () => auth0Client.loginWithRedirect();
+
+export const logout = () => {
+  auth0Client.logout({
+    logoutParams: {
+      returnTo: window.location.origin
+    }
+  });
+};
+
+export const getAccessToken = async () => {
+  try {
+    return await auth0Client.getTokenSilently();
+  } catch (err) {
+    error.set(err.message);
+    throw err;
+  }
+};
+
+// Initialize on module load
+initAuth();
+```
+
+### 4. Add Authentication UI
+
+Create a login component `src/lib/LoginButton.svelte`:
+
+```svelte
+<script>
+  import { isLoading, isAuthenticated, user, login, logout } from './auth0';
+</script>
+
+{#if $isLoading}
+  <div>Loading...</div>
+{:else if $isAuthenticated}
+  <div class="user-profile">
+    <span>Welcome, {$user?.name}</span>
+    <button on:click={logout}>Logout</button>
+  </div>
+{:else}
+  <button on:click={login}>Login</button>
+{/if}
+
+<style>
+  .user-profile {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+</style>
+```
+
+### 5. Test Authentication
+
+Start your dev server and test the login flow:
+
+```bash
+npm run dev
+```
+
+---
+
+## Detailed Documentation
+
+- **[Setup Guide](references/setup.md)** - Automated setup scripts (Bash/PowerShell), CLI commands, manual configuration
+- **[Integration Guide](references/integration.md)** - Protected routes, API calls, error handling, advanced patterns
+- **[API Reference](references/api.md)** - Complete SDK API, configuration options, testing strategies
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgot to add redirect URI in Auth0 Dashboard | Add your application URL (e.g., `http://localhost:5173`, `https://app.example.com`) to Allowed Callback URLs in Auth0 Dashboard |
+| Using wrong env var prefix | Vite uses `VITE_` prefix for environment variables |
+| Not handling loading state | Always check `$isLoading` before rendering auth-dependent UI |
+| Storing tokens in localStorage | Never manually store tokens - SDK handles secure storage automatically |
+| Not handling redirect callback | Must call `handleRedirectCallback()` when URL contains code/state parameters |
+| Missing await on auth methods | Auth0 methods are async - always use `await` |
+| Forgetting $ prefix for stores | Svelte stores must be accessed with `$` prefix in templates |
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` - Basic Auth0 setup
+- `auth0-migration` - Migrate from another auth provider
+- `auth0-mfa` - Add Multi-Factor Authentication
+
+---
+
+## Quick Reference
+
+**Core Functions:**
+- `login()` - Initiate login
+- `logout()` - Log out user
+- `getAccessToken()` - Get access token for API calls
+
+**Stores:**
+- `$isAuthenticated` - Check if user is logged in
+- `$user` - User profile information
+- `$isLoading` - Loading state
+- `$error` - Error messages
+
+**Common Use Cases:**
+- Login/Logout buttons → See Step 4 above
+- Protected routes → [Integration Guide](references/integration.md#protected-routes)
+- API calls with tokens → [Integration Guide](references/integration.md#calling-apis)
+- Error handling → [Integration Guide](references/integration.md#error-handling)
+
+---
+
+## References
+
+- [Auth0 SPA JS SDK Documentation](https://auth0.com/docs/libraries/auth0-spa-js)
+- [Auth0 Svelte Quickstart](https://auth0.com/docs/quickstart/spa/svelte)
+- [SDK GitHub Repository](https://github.com/auth0/auth0-spa-js)

--- a/plugins/auth0-sdks/skills/auth0-svelte/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-svelte/references/api.md
@@ -1,0 +1,351 @@
+# Auth0 Svelte API Reference
+
+Complete reference for the Auth0 SPA JS SDK integration in Svelte.
+
+---
+
+## Auth0Client Configuration
+
+### Constructor Options
+
+```javascript
+import { Auth0Client } from '@auth0/auth0-spa-js';
+
+const auth0Client = new Auth0Client({
+  domain: 'your-tenant.auth0.com',        // Required
+  clientId: 'your-client-id',              // Required
+  authorizationParams: {
+    redirect_uri: window.location.origin, // Required
+    audience: 'https://your-api',         // Optional
+    scope: 'openid profile email',         // Optional (default)
+    responseType: 'code',                  // Optional (default)
+  },
+  cacheLocation: 'memory',                 // Optional: 'memory' or 'localstorage'
+  useRefreshTokens: true,                  // Optional: enable refresh tokens
+  useRefreshTokensFallback: false,         // Optional: fallback if RT not available
+});
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `domain` | string | Required | Your Auth0 tenant domain |
+| `clientId` | string | Required | Your Auth0 application client ID |
+| `authorizationParams.redirect_uri` | string | Required | Where Auth0 redirects after auth |
+| `authorizationParams.audience` | string | undefined | API identifier for access tokens |
+| `authorizationParams.scope` | string | `'openid profile email'` | OAuth scopes to request |
+| `cacheLocation` | string | `'memory'` | Where to store tokens (`'memory'` or `'localstorage'`) |
+| `useRefreshTokens` | boolean | false | Enable refresh token rotation |
+
+---
+
+## Core Methods
+
+### loginWithRedirect()
+
+Redirect to Auth0 Universal Login:
+
+```javascript
+await auth0Client.loginWithRedirect({
+  authorizationParams: {
+    redirect_uri: window.location.origin,
+    // Optional: pass additional parameters
+    screen_hint: 'signup', // Show signup page
+    prompt: 'login'        // Force re-authentication
+  }
+});
+```
+
+### handleRedirectCallback()
+
+Handle the redirect back from Auth0:
+
+```javascript
+const result = await auth0Client.handleRedirectCallback();
+// result contains: appState, user info
+console.log(result.appState); // Custom state passed to login
+```
+
+### isAuthenticated()
+
+Check if user is authenticated:
+
+```javascript
+const authenticated = await auth0Client.isAuthenticated();
+console.log(authenticated); // true or false
+```
+
+### getUser()
+
+Get the current user's profile:
+
+```javascript
+const user = await auth0Client.getUser();
+console.log(user);
+// {
+//   sub: 'auth0|123456',
+//   name: 'John Doe',
+//   email: 'john@example.com',
+//   picture: 'https://...',
+//   ...
+// }
+```
+
+### getTokenSilently()
+
+Get an access token silently (without redirect):
+
+```javascript
+try {
+  const token = await auth0Client.getTokenSilently({
+    authorizationParams: {
+      audience: 'https://your-api',
+      scope: 'read:data'
+    }
+  });
+  console.log(token); // JWT access token
+} catch (err) {
+  if (err.error === 'login_required') {
+    // User needs to log in
+    await auth0Client.loginWithRedirect();
+  } else if (err.error === 'consent_required') {
+    // User needs to grant permissions
+    await auth0Client.loginWithRedirect({
+      authorizationParams: {
+        prompt: 'consent'
+      }
+    });
+  }
+}
+```
+
+### logout()
+
+Log out the user:
+
+```javascript
+auth0Client.logout({
+  logoutParams: {
+    returnTo: window.location.origin // Where to redirect after logout
+  }
+});
+```
+
+---
+
+## Svelte Store Integration
+
+### Reactive Stores
+
+```javascript
+import { writable, derived } from 'svelte/store';
+
+// Basic stores
+export const isLoading = writable(true);
+export const isAuthenticated = writable(false);
+export const user = writable(null);
+export const error = writable(null);
+
+// Derived stores
+export const userName = derived(user, ($user) => $user?.name || 'Guest');
+export const isEmailVerified = derived(user, ($user) => $user?.email_verified || false);
+```
+
+### Using Stores in Components
+
+```svelte
+<script>
+  import { isAuthenticated, user, userName } from '$lib/auth0';
+
+  // Access store values with $ prefix
+  console.log($isAuthenticated);
+  console.log($user);
+  console.log($userName);
+</script>
+
+<div>
+  {#if $isAuthenticated}
+    <p>Hello, {$userName}!</p>
+  {/if}
+</div>
+```
+
+---
+
+## Error Handling
+
+### Common Errors
+
+| Error Code | Description | Solution |
+|------------|-------------|----------|
+| `login_required` | User needs to authenticate | Call `loginWithRedirect()` |
+| `consent_required` | User needs to grant permissions | Call `loginWithRedirect({ prompt: 'consent' })` |
+| `invalid_token` | Token is invalid or expired | Refresh token or re-authenticate |
+| `access_denied` | User denied authorization | Show error message, allow retry |
+
+### Error Handling Pattern
+
+```javascript
+export const getAccessToken = async () => {
+  try {
+    return await auth0Client.getTokenSilently();
+  } catch (err) {
+    switch (err.error) {
+      case 'login_required':
+        error.set('Please log in to continue');
+        await login();
+        break;
+      case 'consent_required':
+        error.set('Additional permissions required');
+        await auth0Client.loginWithRedirect({
+          authorizationParams: { prompt: 'consent' }
+        });
+        break;
+      case 'invalid_token':
+        error.set('Session expired, please log in again');
+        await login();
+        break;
+      default:
+        error.set(err.message || 'Authentication error');
+    }
+    throw err;
+  }
+};
+```
+
+---
+
+## Advanced Patterns
+
+### Custom State with Login
+
+Pass custom state through the authentication flow:
+
+```javascript
+export const login = (customState = {}) => {
+  auth0Client.loginWithRedirect({
+    authorizationParams: {
+      redirect_uri: window.location.origin
+    },
+    appState: customState // Will be returned after authentication
+  });
+};
+
+// In handleRedirectCallback
+const { appState } = await auth0Client.handleRedirectCallback();
+if (appState?.returnTo) {
+  window.location.href = appState.returnTo;
+}
+```
+
+### Token Caching
+
+Control token caching behavior:
+
+```javascript
+// Use localStorage for persistent tokens
+const auth0Client = new Auth0Client({
+  domain,
+  clientId,
+  cacheLocation: 'localstorage',
+  useRefreshTokens: true // Enable refresh tokens
+});
+
+// Clear cached tokens
+await auth0Client.logout({ localOnly: true });
+```
+
+### Organizations
+
+Support Auth0 Organizations:
+
+```javascript
+// Login to specific organization
+export const loginToOrg = (orgId) => {
+  auth0Client.loginWithRedirect({
+    authorizationParams: {
+      redirect_uri: window.location.origin,
+      organization: orgId // Organization ID or slug
+    }
+  });
+};
+
+// Validate user belongs to organization
+const user = await auth0Client.getUser();
+if (user?.org_id !== expectedOrgId) {
+  error.set('Unauthorized organization');
+}
+```
+
+---
+
+## Testing
+
+### Mock SDK for Tests
+
+```javascript
+// test/mocks/auth0.js
+export const mockAuth0Client = {
+  loginWithRedirect: vi.fn(),
+  handleRedirectCallback: vi.fn().mockResolvedValue({
+    appState: {}
+  }),
+  isAuthenticated: vi.fn().mockResolvedValue(true),
+  getUser: vi.fn().mockResolvedValue({
+    sub: 'auth0|123',
+    name: 'Test User',
+    email: 'test@example.com'
+  }),
+  getTokenSilently: vi.fn().mockResolvedValue('mock-token'),
+  logout: vi.fn()
+};
+```
+
+### Component Testing
+
+```javascript
+// Component.test.js
+import { render } from '@testing-library/svelte';
+import Component from './Component.svelte';
+import { mockAuth0 } from './test/mocks/auth0';
+
+// Mock the auth0 module
+vi.mock('$lib/auth0', () => mockAuth0);
+
+test('renders user when authenticated', () => {
+  const { getByText } = render(Component);
+  expect(getByText('Test User')).toBeInTheDocument();
+});
+```
+
+---
+
+## Security Best Practices
+
+1. **Never hardcode credentials** - Always use environment variables
+2. **Use HTTPS in production** - Required for secure token handling
+3. **Set appropriate scopes** - Request only needed permissions
+4. **Validate tokens server-side** - Don't trust client-side validation alone
+5. **Use refresh tokens carefully** - Enable only if needed, understand security implications
+6. **Clear tokens on logout** - Use `logout()` method, not manual clearing
+7. **Handle errors gracefully** - Don't expose sensitive error details to users
+
+---
+
+## Performance Tips
+
+1. **Use memory cache** - Faster than localStorage for most use cases
+2. **Minimize token refreshes** - Cache tokens appropriately
+3. **Lazy load user data** - Only fetch when needed
+4. **Debounce authentication checks** - Don't check on every route change
+5. **Use derived stores** - Compute values reactively instead of repeatedly
+
+---
+
+## References
+
+- [Auth0 SPA JS SDK Documentation](https://auth0.com/docs/libraries/auth0-spa-js)
+- [Svelte Store Documentation](https://svelte.dev/docs#run-time-svelte-store)
+- [Auth0 Authentication API](https://auth0.com/docs/api/authentication)
+- [OAuth 2.0 Specification](https://oauth.net/2/)

--- a/plugins/auth0-sdks/skills/auth0-svelte/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-svelte/references/integration.md
@@ -1,0 +1,339 @@
+# Auth0 Svelte Integration Guide
+
+Advanced patterns for integrating Auth0 into Svelte applications.
+
+---
+
+## Protected Routes
+
+Protect routes by checking authentication status before rendering:
+
+```svelte
+<!-- src/routes/protected/+page.svelte -->
+<script>
+  import { isAuthenticated, isLoading, user, login } from '$lib/auth0';
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    // Redirect to login if not authenticated
+    if (!$isLoading && !$isAuthenticated) {
+      login();
+    }
+  });
+</script>
+
+{#if $isLoading}
+  <div>Loading...</div>
+{:else if $isAuthenticated}
+  <div>
+    <h1>Protected Content</h1>
+    <p>Welcome, {$user?.name}!</p>
+  </div>
+{:else}
+  <div>Redirecting to login...</div>
+{/if}
+```
+
+### Route Guard Component
+
+Create a reusable route guard component:
+
+```svelte
+<!-- src/lib/ProtectedRoute.svelte -->
+<script>
+  import { isAuthenticated, isLoading, login } from './auth0';
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    if (!$isLoading && !$isAuthenticated) {
+      login();
+    }
+  });
+</script>
+
+{#if $isLoading}
+  <div class="loading">Loading...</div>
+{:else if $isAuthenticated}
+  <slot />
+{:else}
+  <div>Redirecting...</div>
+{/if}
+```
+
+Use it like this:
+
+```svelte
+<!-- src/routes/dashboard/+page.svelte -->
+<script>
+  import ProtectedRoute from '$lib/ProtectedRoute.svelte';
+</script>
+
+<ProtectedRoute>
+  <h1>Dashboard</h1>
+  <p>This content is protected</p>
+</ProtectedRoute>
+```
+
+---
+
+## Calling APIs
+
+Get an access token to call your API:
+
+```svelte
+<script>
+  import { getAccessToken } from '$lib/auth0';
+
+  async function callApi() {
+    try {
+      const token = await getAccessToken();
+
+      const response = await fetch('https://your-api.com/endpoint', {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+
+      const data = await response.json();
+      console.log(data);
+    } catch (err) {
+      console.error('API call failed:', err);
+    }
+  }
+</script>
+
+<button on:click={callApi}>Call API</button>
+```
+
+### API with Audience
+
+If your API requires an audience parameter:
+
+Update `src/lib/auth0.js`:
+
+```javascript
+// Add audience to Auth0Client configuration
+const auth0Client = new Auth0Client({
+  domain,
+  clientId,
+  authorizationParams: {
+    redirect_uri: window.location.origin,
+    audience: 'https://your-api-identifier' // Add this
+  }
+});
+
+// Update getAccessToken to request specific audience
+export const getAccessToken = async (options = {}) => {
+  try {
+    return await auth0Client.getTokenSilently({
+      authorizationParams: {
+        audience: 'https://your-api-identifier',
+        ...options
+      }
+    });
+  } catch (err) {
+    error.set(err.message);
+    throw err;
+  }
+};
+```
+
+---
+
+## Error Handling
+
+Handle authentication errors gracefully:
+
+```svelte
+<script>
+  import { error, isLoading, isAuthenticated, login } from '$lib/auth0';
+</script>
+
+{#if $error}
+  <div class="error">
+    <p>Authentication error: {$error}</p>
+    <button on:click={() => { $error = null; login(); }}>
+      Try Again
+    </button>
+  </div>
+{:else if $isLoading}
+  <div>Loading...</div>
+{:else if $isAuthenticated}
+  <div>Authenticated content</div>
+{:else}
+  <button on:click={login}>Login</button>
+{/if}
+
+<style>
+  .error {
+    background: #fee;
+    border: 1px solid #c00;
+    padding: 1rem;
+    border-radius: 4px;
+  }
+</style>
+```
+
+### Login Error Recovery
+
+Handle specific login errors:
+
+Update `src/lib/auth0.js`:
+
+```javascript
+export const login = async (options = {}) => {
+  try {
+    await auth0Client.loginWithRedirect(options);
+  } catch (err) {
+    if (err.error === 'login_required') {
+      error.set('Please log in to continue');
+    } else if (err.error === 'consent_required') {
+      error.set('Please grant the required permissions');
+    } else {
+      error.set(err.message || 'Login failed');
+    }
+    throw err;
+  }
+};
+```
+
+---
+
+## User Profile Management
+
+Display and update user information:
+
+```svelte
+<script>
+  import { user, isAuthenticated } from '$lib/auth0';
+</script>
+
+{#if $isAuthenticated && $user}
+  <div class="profile">
+    {#if $user.picture}
+      <img src={$user.picture} alt={$user.name} />
+    {/if}
+    <div class="info">
+      <h2>{$user.name}</h2>
+      <p>{$user.email}</p>
+      {#if $user.email_verified}
+        <span class="verified">✓ Verified</span>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .profile {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  img {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+  }
+
+  .verified {
+    color: green;
+    font-size: 0.875rem;
+  }
+</style>
+```
+
+---
+
+## Silent Authentication
+
+Automatically refresh authentication state:
+
+```javascript
+// src/lib/auth0.js
+import { onMount } from 'svelte';
+
+// Add this function to your auth0.js
+export function setupSilentAuth() {
+  // Check authentication status every 5 minutes
+  setInterval(async () => {
+    try {
+      const authenticated = await auth0Client.isAuthenticated();
+      isAuthenticated.set(authenticated);
+
+      if (authenticated) {
+        const userProfile = await auth0Client.getUser();
+        user.set(userProfile);
+      }
+    } catch (err) {
+      console.error('Silent auth check failed:', err);
+    }
+  }, 5 * 60 * 1000); // 5 minutes
+}
+```
+
+Call it from your root layout:
+
+```svelte
+<!-- src/routes/+layout.svelte -->
+<script>
+  import { setupSilentAuth } from '$lib/auth0';
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    setupSilentAuth();
+  });
+</script>
+
+<slot />
+```
+
+---
+
+## Testing
+
+### Mock Auth0 for Testing
+
+```javascript
+// src/lib/auth0.test.js
+import { writable } from 'svelte/store';
+
+export const mockAuth0 = {
+  isLoading: writable(false),
+  isAuthenticated: writable(true),
+  user: writable({
+    name: 'Test User',
+    email: 'test@example.com',
+    picture: 'https://example.com/avatar.jpg'
+  }),
+  error: writable(null),
+  login: vi.fn(),
+  logout: vi.fn(),
+  getAccessToken: vi.fn().mockResolvedValue('mock-token')
+};
+```
+
+---
+
+## SvelteKit Server-Side Considerations
+
+If using SvelteKit with server-side rendering:
+
+```javascript
+// src/hooks.server.js - Optional server-side auth handling
+export async function handle({ event, resolve }) {
+  // Auth0 authentication is client-side only with this setup
+  // For server-side auth, consider using a different approach
+  return resolve(event);
+}
+```
+
+**Note:** The @auth0/auth0-spa-js SDK is designed for client-side authentication. For full SSR with server-side authentication in SvelteKit, you may need to implement a custom server-side flow using Auth0's OAuth2/OIDC endpoints directly.
+
+---
+
+## Next Steps
+
+- Check [API Reference](api.md) for complete SDK documentation
+- See [Setup Guide](setup.md) for configuration options
+- Return to [main skill guide](../SKILL.md) for overview

--- a/plugins/auth0-sdks/skills/auth0-svelte/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-svelte/references/setup.md
@@ -1,0 +1,299 @@
+# Auth0 Svelte Setup Guide
+
+Complete setup instructions with automated scripts and manual configuration options.
+
+---
+
+## Quick Setup (Automated)
+
+### Bash Script (macOS/Linux)
+
+Run this script to automatically set up everything:
+
+```bash
+#!/bin/bash
+
+# Detect OS and install Auth0 CLI if needed
+if ! command -v auth0 &> /dev/null; then
+  echo "Installing Auth0 CLI..."
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    brew install auth0/auth0-cli/auth0
+  elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
+  elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+    echo "Please install Auth0 CLI: https://github.com/auth0/auth0-cli#installation"
+    exit 1
+  fi
+fi
+
+# Check if logged in to Auth0
+if ! auth0 tenants list &> /dev/null; then
+  echo ""
+  echo "======================================"
+  echo "Auth0 Login Required"
+  echo "======================================"
+  echo ""
+  read -p "Do you have an Auth0 account? (y/n): " HAS_ACCOUNT
+
+  if [[ "$HAS_ACCOUNT" != "y" ]]; then
+    echo ""
+    echo "Let's create your free Auth0 account!"
+    echo ""
+    echo "1. Visit: https://auth0.com/signup"
+    echo "2. Sign up with your email or GitHub"
+    echo "3. Choose a tenant domain (e.g., 'mycompany')"
+    echo "4. Complete the onboarding"
+    echo ""
+    read -p "Press Enter when you've created your account..."
+  fi
+
+  echo ""
+  echo "Logging in to Auth0..."
+  echo "A browser will open for authentication."
+  echo ""
+  auth0 login
+
+  if ! auth0 tenants list &> /dev/null; then
+    echo "❌ Login failed. Please try again or visit https://auth0.com/docs"
+    exit 1
+  fi
+
+  echo "✅ Successfully logged in to Auth0!"
+fi
+
+# List apps and prompt for selection
+echo "Your Auth0 applications:"
+auth0 apps list
+
+read -p "Enter your Auth0 app ID (or press Enter to create a new one): " APP_ID
+
+if [ -z "$APP_ID" ]; then
+  echo "Creating new Auth0 SPA application..."
+  APP_NAME="${PWD##*/}-svelte-app"
+  APP_ID=$(auth0 apps create \
+    --name "$APP_NAME" \
+    --type spa \
+    --callbacks "http://localhost:5173,http://localhost:3000" \
+    --logout-urls "http://localhost:5173,http://localhost:3000" \
+    --origins "http://localhost:5173,http://localhost:3000" \
+    --web-origins "http://localhost:5173,http://localhost:3000" \
+    --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
+  echo "Created app with ID: $APP_ID"
+fi
+
+# Get app details and create .env file
+echo "Fetching Auth0 credentials..."
+AUTH0_DOMAIN=$(auth0 apps show "$APP_ID" --json | grep -o '"domain":"[^"]*' | cut -d'"' -f4)
+AUTH0_CLIENT_ID=$(auth0 apps show "$APP_ID" --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
+
+# Create .env file
+cat > .env << EOF
+VITE_AUTH0_DOMAIN=$AUTH0_DOMAIN
+VITE_AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID
+EOF
+
+echo "✅ Auth0 configuration complete!"
+echo "Created .env file with:"
+echo "  VITE_AUTH0_DOMAIN=$AUTH0_DOMAIN"
+echo "  VITE_AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID"
+```
+
+### PowerShell Script (Windows)
+
+```powershell
+# Install Auth0 CLI if not present
+if (!(Get-Command auth0 -ErrorAction SilentlyContinue)) {
+  Write-Host "Installing Auth0 CLI..."
+  scoop install auth0
+}
+
+# Check if logged in
+try {
+  auth0 tenants list | Out-Null
+} catch {
+  Write-Host ""
+  Write-Host "======================================"
+  Write-Host "Auth0 Login Required"
+  Write-Host "======================================"
+  Write-Host ""
+
+  $hasAccount = Read-Host "Do you have an Auth0 account? (y/n)"
+
+  if ($hasAccount -ne "y") {
+    Write-Host ""
+    Write-Host "Let's create your free Auth0 account!"
+    Write-Host ""
+    Write-Host "1. Visit: https://auth0.com/signup"
+    Write-Host "2. Sign up with your email or GitHub"
+    Write-Host "3. Choose a tenant domain (e.g., 'mycompany')"
+    Write-Host "4. Complete the onboarding"
+    Write-Host ""
+    Read-Host "Press Enter when you've created your account"
+  }
+
+  Write-Host ""
+  Write-Host "Logging in to Auth0..."
+  Write-Host "A browser will open for authentication."
+  Write-Host ""
+  auth0 login
+
+  try {
+    auth0 tenants list | Out-Null
+    Write-Host "✅ Successfully logged in to Auth0!"
+  } catch {
+    Write-Host "❌ Login failed. Please try again or visit https://auth0.com/docs"
+    exit 1
+  }
+}
+
+# List and select app
+Write-Host "Your Auth0 applications:"
+auth0 apps list
+
+$appId = Read-Host "Enter your Auth0 app ID (or press Enter to create new)"
+
+if ([string]::IsNullOrEmpty($appId)) {
+  $appName = Split-Path -Leaf (Get-Location)
+  Write-Host "Creating new Auth0 SPA application..."
+  $appJson = auth0 apps create --name "$appName-svelte-app" --type spa `
+    --callbacks "http://localhost:5173,http://localhost:3000" `
+    --logout-urls "http://localhost:5173,http://localhost:3000" `
+    --origins "http://localhost:5173,http://localhost:3000" `
+    --web-origins "http://localhost:5173,http://localhost:3000" --json
+
+  $appId = ($appJson | ConvertFrom-Json).client_id
+  Write-Host "Created app with ID: $appId"
+}
+
+# Get credentials and create .env
+Write-Host "Fetching Auth0 credentials..."
+$appDetails = auth0 apps show $appId --json | ConvertFrom-Json
+
+@"
+VITE_AUTH0_DOMAIN=$($appDetails.domain)
+VITE_AUTH0_CLIENT_ID=$($appDetails.client_id)
+"@ | Out-File -FilePath .env -Encoding UTF8
+
+Write-Host "✅ Auth0 configuration complete!"
+Write-Host "Created .env file with:"
+Write-Host "  VITE_AUTH0_DOMAIN=$($appDetails.domain)"
+Write-Host "  VITE_AUTH0_CLIENT_ID=$($appDetails.client_id)"
+```
+
+---
+
+## Manual Setup
+
+If you prefer manual setup or the scripts don't work:
+
+### Step 1: Install SDK
+
+```bash
+npm install @auth0/auth0-spa-js
+```
+
+### Step 2: Install Auth0 CLI
+
+**macOS:**
+```bash
+brew install auth0/auth0-cli/auth0
+```
+
+**Linux:**
+```bash
+curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh
+```
+
+**Windows:**
+```powershell
+scoop install auth0
+# Or: choco install auth0-cli
+```
+
+### Step 3: Get Credentials
+
+```bash
+# Login to Auth0
+auth0 login
+
+# List your apps
+auth0 apps list
+
+# Get app details (replace <app-id>)
+auth0 apps show <app-id>
+```
+
+### Step 4: Create .env File
+
+```bash
+VITE_AUTH0_DOMAIN=<your-tenant>.auth0.com
+VITE_AUTH0_CLIENT_ID=<your-client-id>
+```
+
+---
+
+## Creating an Auth0 Application via Dashboard
+
+If you prefer using the Auth0 Dashboard instead of the CLI:
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **Applications**
+3. Click **Create Application**
+4. Choose:
+   - Name: Your app name
+   - Type: **Single Page Web Applications**
+5. Configure:
+   - **Allowed Callback URLs**: `http://localhost:5173, http://localhost:3000`
+   - **Allowed Logout URLs**: `http://localhost:5173, http://localhost:3000`
+   - **Allowed Web Origins**: `http://localhost:5173, http://localhost:3000`
+   - **Allowed Origins (CORS)**: `http://localhost:5173, http://localhost:3000`
+6. Copy your **Domain** and **Client ID**
+7. Create `.env` file as shown in Step 4 above
+
+---
+
+## Troubleshooting Setup
+
+### CLI Installation Issues
+
+**macOS - Homebrew not found:**
+```bash
+# Install Homebrew first
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+**Windows - Scoop not found:**
+```powershell
+# Install Scoop first
+iwr -useb get.scoop.sh | iex
+```
+
+### Login Issues
+
+**Browser doesn't open:**
+```bash
+# Use device code flow
+auth0 login --no-browser
+```
+
+**"Not logged in" error:**
+```bash
+# Force new login
+auth0 login --force
+```
+
+### Environment Variable Issues
+
+**Variables not loading:**
+- Ensure variables start with `VITE_`
+- Restart dev server after creating `.env`
+- Check file is named exactly `.env` (not `.env.local`)
+
+---
+
+## Next Steps
+
+After setup is complete:
+1. Return to [main skill guide](../SKILL.md) for integration steps
+2. See [Integration Guide](integration.md) for advanced patterns
+3. Check [API Reference](api.md) for complete SDK documentation

--- a/plugins/auth0-sdks/skills/auth0-vanilla-js/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-vanilla-js/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: auth0-vanilla-js
+description: Use when adding authentication to vanilla JavaScript applications (login, logout, user sessions) - integrates @auth0/auth0-spa-js SDK for SPAs without frameworks
+---
+
+# Auth0 Vanilla JavaScript Integration
+
+Add authentication to vanilla JavaScript single-page applications using @auth0/auth0-spa-js.
+
+---
+
+## Prerequisites
+
+- Modern JavaScript (ES6+) knowledge
+- Build tool like Vite (optional but recommended)
+- Auth0 account and application configured
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **Framework-based apps** - Use framework-specific skills (React, Vue, Angular, Svelte)
+- **Server-side rendered apps** - Consider using a backend framework
+- **Embedded login** - This SDK uses Auth0 Universal Login (redirect-based)
+- **Backend API authentication** - Use JWT validation instead
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+npm install @auth0/auth0-spa-js
+```
+
+### 2. Configure Environment
+
+**For automated setup with Auth0 CLI**, see [Setup Guide](references/setup.md) for complete scripts.
+
+**For manual setup with Vite:**
+
+Create `.env` file:
+
+```bash
+VITE_AUTH0_DOMAIN=your-tenant.auth0.com
+VITE_AUTH0_CLIENT_ID=your-client-id
+```
+
+### 3. Create Auth Module
+
+Create `auth.js`:
+
+```javascript
+import { Auth0Client } from '@auth0/auth0-spa-js';
+
+let auth0Client;
+let isAuthenticated = false;
+let user = null;
+
+// Initialize Auth0
+export async function initAuth0() {
+  auth0Client = new Auth0Client({
+    domain: import.meta.env.VITE_AUTH0_DOMAIN,
+    clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
+    authorizationParams: {
+      redirect_uri: window.location.origin
+    }
+  });
+
+  // Check if returning from Auth0 redirect
+  const query = window.location.search;
+  if (query.includes('code=') && query.includes('state=')) {
+    await auth0Client.handleRedirectCallback();
+    window.history.replaceState({}, document.title, window.location.pathname);
+  }
+
+  // Update authentication state
+  isAuthenticated = await auth0Client.isAuthenticated();
+  if (isAuthenticated) {
+    user = await auth0Client.getUser();
+  }
+
+  return { isAuthenticated, user };
+}
+
+// Login
+export function login() {
+  return auth0Client.loginWithRedirect();
+}
+
+// Logout
+export function logout() {
+  return auth0Client.logout({
+    logoutParams: {
+      returnTo: window.location.origin
+    }
+  });
+}
+
+// Get access token
+export async function getAccessToken() {
+  return await auth0Client.getTokenSilently();
+}
+
+// Get current auth state
+export function getAuthState() {
+  return { isAuthenticated, user };
+}
+```
+
+### 4. Create UI
+
+Create `index.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Auth0 Vanilla JS</title>
+</head>
+<body>
+  <div id="app">
+    <div id="loading">Loading...</div>
+    <div id="authenticated" style="display: none;">
+      <div id="user-info"></div>
+      <button id="logout-btn">Logout</button>
+    </div>
+    <div id="unauthenticated" style="display: none;">
+      <button id="login-btn">Login</button>
+    </div>
+  </div>
+  <script type="module" src="/app.js"></script>
+</body>
+</html>
+```
+
+Create `app.js`:
+
+```javascript
+import { initAuth0, login, logout, getAuthState } from './auth.js';
+
+async function updateUI() {
+  const { isAuthenticated, user } = getAuthState();
+
+  const loading = document.getElementById('loading');
+  const authenticated = document.getElementById('authenticated');
+  const unauthenticated = document.getElementById('unauthenticated');
+  const userInfo = document.getElementById('user-info');
+
+  loading.style.display = 'none';
+
+  if (isAuthenticated) {
+    authenticated.style.display = 'block';
+    unauthenticated.style.display = 'none';
+    userInfo.innerHTML = `
+      <img src="${user.picture}" alt="${user.name}" width="48" />
+      <h2>Welcome, ${user.name}!</h2>
+      <p>${user.email}</p>
+    `;
+  } else {
+    authenticated.style.display = 'none';
+    unauthenticated.style.display = 'block';
+  }
+}
+
+// Initialize app
+(async () => {
+  await initAuth0();
+  updateUI();
+
+  // Attach event listeners
+  document.getElementById('login-btn')?.addEventListener('click', login);
+  document.getElementById('logout-btn')?.addEventListener('click', logout);
+})();
+```
+
+### 5. Test Authentication
+
+Start your dev server:
+
+```bash
+npm run dev  # If using Vite
+# or
+npx vite     # Direct Vite command
+```
+
+---
+
+## Detailed Documentation
+
+- **[Setup Guide](references/setup.md)** - Automated setup scripts (Bash/PowerShell), CLI commands, manual configuration
+- **[Integration Guide](references/integration.md)** - Protected routes, API calls, error handling, advanced patterns
+- **[API Reference](references/api.md)** - Complete SDK API, configuration options, testing strategies
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgot to add redirect URI in Auth0 Dashboard | Add your application URL (e.g., `http://localhost:5173`, `https://app.example.com`) to Allowed Callback URLs in Auth0 Dashboard |
+| Using wrong env var prefix | Vite uses `VITE_` prefix for environment variables |
+| Not handling redirect callback | Must call `handleRedirectCallback()` when URL contains code/state parameters |
+| Missing await on async functions | All Auth0 methods are async - always use `await` |
+| Accessing env vars in browser | Use `import.meta.env.VITE_*` with Vite, not `process.env` |
+| Not initializing before use | Call `initAuth0()` before using any auth functions |
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` - Basic Auth0 setup
+- `auth0-migration` - Migrate from another auth provider
+- `auth0-mfa` - Add Multi-Factor Authentication
+
+---
+
+## Quick Reference
+
+**Core Functions:**
+- `initAuth0()` - Initialize Auth0 client (call first)
+- `login()` - Initiate login
+- `logout()` - Log out user
+- `getAccessToken()` - Get access token for API calls
+- `getAuthState()` - Get current auth state
+
+**Common Use Cases:**
+- Login/Logout buttons → See Step 4 above
+- Protected pages → [Integration Guide](references/integration.md#protected-pages)
+- API calls with tokens → [Integration Guide](references/integration.md#calling-apis)
+- Error handling → [Integration Guide](references/integration.md#error-handling)
+
+---
+
+## References
+
+- [Auth0 SPA JS SDK Documentation](https://auth0.com/docs/libraries/auth0-spa-js)
+- [Auth0 Vanilla JS Quickstart](https://auth0.com/docs/quickstart/spa/vanillajs)
+- [SDK GitHub Repository](https://github.com/auth0/auth0-spa-js)

--- a/plugins/auth0-sdks/skills/auth0-vanilla-js/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-vanilla-js/references/api.md
@@ -1,0 +1,358 @@
+# Auth0 Vanilla JavaScript API Reference
+
+Complete reference for the Auth0 SPA JS SDK in vanilla JavaScript applications.
+
+---
+
+## Auth0Client Configuration
+
+### Initialization
+
+```javascript
+import { Auth0Client } from '@auth0/auth0-spa-js';
+
+const auth0Client = new Auth0Client({
+  domain: 'your-tenant.auth0.com',        // Required
+  clientId: 'your-client-id',              // Required
+  authorizationParams: {
+    redirect_uri: window.location.origin, // Required
+    audience: 'https://your-api',         // Optional
+    scope: 'openid profile email',         // Optional
+  },
+  cacheLocation: 'memory',                 // Optional
+  useRefreshTokens: false,                 // Optional
+});
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `domain` | string | Required | Your Auth0 tenant domain |
+| `clientId` | string | Required | Your application client ID |
+| `authorizationParams.redirect_uri` | string | Required | Callback URL after authentication |
+| `authorizationParams.audience` | string | undefined | API identifier for access tokens |
+| `authorizationParams.scope` | string | `'openid profile email'` | OAuth scopes |
+| `cacheLocation` | string | `'memory'` | Token cache location |
+| `useRefreshTokens` | boolean | false | Enable refresh tokens |
+
+---
+
+## Core Methods
+
+### loginWithRedirect()
+
+Redirect user to Auth0 login:
+
+```javascript
+await auth0Client.loginWithRedirect({
+  authorizationParams: {
+    redirect_uri: window.location.origin,
+    screen_hint: 'signup', // Optional: show signup
+    prompt: 'login'        // Optional: force re-auth
+  }
+});
+```
+
+### handleRedirectCallback()
+
+Handle return from Auth0:
+
+```javascript
+const { appState } = await auth0Client.handleRedirectCallback();
+console.log(appState); // Custom state passed to login
+
+// Clean up URL
+window.history.replaceState({}, document.title, window.location.pathname);
+```
+
+### isAuthenticated()
+
+Check authentication status:
+
+```javascript
+const authenticated = await auth0Client.isAuthenticated();
+console.log(authenticated); // true or false
+```
+
+### getUser()
+
+Get user profile:
+
+```javascript
+const user = await auth0Client.getUser();
+console.log(user);
+// {
+//   sub: 'auth0|123456',
+//   name: 'John Doe',
+//   email: 'john@example.com',
+//   picture: 'https://...',
+//   email_verified: true
+// }
+```
+
+### getTokenSilently()
+
+Get access token:
+
+```javascript
+try {
+  const token = await auth0Client.getTokenSilently({
+    authorizationParams: {
+      audience: 'https://your-api',
+      scope: 'read:data'
+    }
+  });
+  console.log(token); // JWT token
+} catch (err) {
+  if (err.error === 'login_required') {
+    await auth0Client.loginWithRedirect();
+  }
+}
+```
+
+### logout()
+
+Log out user:
+
+```javascript
+auth0Client.logout({
+  logoutParams: {
+    returnTo: window.location.origin
+  }
+});
+```
+
+---
+
+## Common Patterns
+
+### Complete Initialization
+
+```javascript
+async function initAuth0() {
+  const auth0Client = new Auth0Client({
+    domain: import.meta.env.VITE_AUTH0_DOMAIN,
+    clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
+    authorizationParams: {
+      redirect_uri: window.location.origin
+    }
+  });
+
+  // Handle redirect callback
+  const query = window.location.search;
+  if (query.includes('code=') && query.includes('state=')) {
+    try {
+      await auth0Client.handleRedirectCallback();
+      window.history.replaceState({}, document.title, window.location.pathname);
+    } catch (err) {
+      console.error('Callback error:', err);
+    }
+  }
+
+  // Check authentication
+  const isAuthenticated = await auth0Client.isAuthenticated();
+  let user = null;
+
+  if (isAuthenticated) {
+    user = await auth0Client.getUser();
+  }
+
+  return { auth0Client, isAuthenticated, user };
+}
+```
+
+### API Call Pattern
+
+```javascript
+async function callProtectedAPI(endpoint) {
+  try {
+    const token = await auth0Client.getTokenSilently();
+
+    const response = await fetch(`https://api.example.com${endpoint}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (err) {
+    console.error('API call failed:', err);
+    throw err;
+  }
+}
+```
+
+---
+
+## Error Handling
+
+### Common Errors
+
+| Error Code | Description | Solution |
+|------------|-------------|----------|
+| `login_required` | User not authenticated | Call `loginWithRedirect()` |
+| `consent_required` | Missing permissions | Redirect with `prompt: 'consent'` |
+| `invalid_token` | Token invalid/expired | Re-authenticate |
+| `access_denied` | User denied access | Show error, allow retry |
+
+### Error Handler Pattern
+
+```javascript
+async function handleAuthError(err) {
+  switch (err.error) {
+    case 'login_required':
+      await auth0Client.loginWithRedirect();
+      break;
+    case 'consent_required':
+      await auth0Client.loginWithRedirect({
+        authorizationParams: { prompt: 'consent' }
+      });
+      break;
+    case 'invalid_token':
+      alert('Your session has expired. Please log in again.');
+      await auth0Client.loginWithRedirect();
+      break;
+    default:
+      console.error('Auth error:', err);
+      alert('Authentication failed. Please try again.');
+  }
+}
+```
+
+---
+
+## Advanced Features
+
+### Custom App State
+
+Pass custom state through authentication:
+
+```javascript
+// Login with custom state
+await auth0Client.loginWithRedirect({
+  appState: {
+    returnTo: '/dashboard',
+    customData: { foo: 'bar' }
+  }
+});
+
+// Retrieve after callback
+const { appState } = await auth0Client.handleRedirectCallback();
+if (appState?.returnTo) {
+  window.location.href = appState.returnTo;
+}
+```
+
+### Organizations
+
+Support Auth0 Organizations:
+
+```javascript
+// Login to organization
+await auth0Client.loginWithRedirect({
+  authorizationParams: {
+    organization: 'org_abc123'
+  }
+});
+
+// Verify organization
+const user = await auth0Client.getUser();
+if (user.org_id !== 'org_abc123') {
+  throw new Error('Unauthorized organization');
+}
+```
+
+### Token Caching
+
+```javascript
+// Use localStorage for persistent cache
+const auth0Client = new Auth0Client({
+  domain: '...',
+  clientId: '...',
+  cacheLocation: 'localstorage', // Persist across page reloads
+  useRefreshTokens: true         // Enable refresh tokens
+});
+
+// Clear cache on logout
+await auth0Client.logout({ localOnly: true });
+```
+
+---
+
+## Environment Variables
+
+### Vite
+
+```javascript
+const config = {
+  domain: import.meta.env.VITE_AUTH0_DOMAIN,
+  clientId: import.meta.env.VITE_AUTH0_CLIENT_ID
+};
+```
+
+### Plain JavaScript (no build tool)
+
+If not using a build tool, create a config file:
+
+```javascript
+// config.js
+export const auth0Config = {
+  domain: 'your-tenant.auth0.com',
+  clientId: 'your-client-id'
+};
+```
+
+**Never commit credentials to source control!**
+
+---
+
+## Security Best Practices
+
+1. **Use HTTPS** - Required in production
+2. **Never expose tokens** - Don't log or display tokens
+3. **Validate on server** - Client-side checks aren't sufficient
+4. **Use appropriate scopes** - Request minimum required permissions
+5. **Clear tokens on logout** - Use SDK's logout method
+6. **Handle errors gracefully** - Don't expose sensitive details
+7. **Use refresh tokens carefully** - Understand security implications
+
+---
+
+## Performance Tips
+
+1. **Initialize once** - Create client instance only once
+2. **Cache user data** - Don't fetch repeatedly
+3. **Use memory cache** - Faster than localStorage for most cases
+4. **Minimize token refreshes** - Let SDK handle automatically
+5. **Lazy load auth** - Only initialize when needed
+
+---
+
+## Browser Compatibility
+
+The SDK supports modern browsers with:
+- ES6+ support
+- Promise support
+- Fetch API support
+- localStorage/sessionStorage (for caching)
+
+For older browsers, use polyfills:
+```javascript
+// Add to your HTML
+<script src="https://polyfill.io/v3/polyfill.min.js?features=Promise,fetch"></script>
+```
+
+---
+
+## References
+
+- [Auth0 SPA JS SDK Documentation](https://auth0.com/docs/libraries/auth0-spa-js)
+- [SDK GitHub Repository](https://github.com/auth0/auth0-spa-js)
+- [Auth0 Authentication API](https://auth0.com/docs/api/authentication)
+- [OAuth 2.0 Specification](https://oauth.net/2/)

--- a/plugins/auth0-sdks/skills/auth0-vanilla-js/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-vanilla-js/references/integration.md
@@ -1,0 +1,427 @@
+# Auth0 Vanilla JavaScript Integration Guide
+
+Advanced patterns for integrating Auth0 into vanilla JavaScript applications.
+
+---
+
+## Protected Pages
+
+Create pages that require authentication:
+
+```javascript
+// protected.js
+import { getAuthState, login } from './auth.js';
+
+export async function renderProtectedPage() {
+  const { isAuthenticated, user } = getAuthState();
+
+  if (!isAuthenticated) {
+    // Redirect to login
+    await login();
+    return;
+  }
+
+  // Render protected content
+  document.getElementById('app').innerHTML = `
+    <h1>Protected Page</h1>
+    <p>Welcome, ${user.name}!</p>
+    <p>This content is only visible to authenticated users.</p>
+  `;
+}
+```
+
+### Simple Router with Protected Routes
+
+```javascript
+// router.js
+import { getAuthState, login } from './auth.js';
+
+const routes = {
+  '/': renderHome,
+  '/dashboard': renderDashboard,
+  '/profile': renderProfile
+};
+
+const protectedRoutes = ['/dashboard', '/profile'];
+
+export function navigate(path) {
+  const { isAuthenticated } = getAuthState();
+
+  // Check if route requires authentication
+  if (protectedRoutes.includes(path) && !isAuthenticated) {
+    login();
+    return;
+  }
+
+  // Render route
+  const renderFn = routes[path] || render404;
+  renderFn();
+
+  // Update URL
+  window.history.pushState({}, '', path);
+}
+
+// Handle browser back/forward
+window.addEventListener('popstate', () => {
+  navigate(window.location.pathname);
+});
+```
+
+---
+
+## Calling APIs
+
+Make authenticated API calls:
+
+```javascript
+// api.js
+import { getAccessToken } from './auth.js';
+
+export async function callApi(endpoint, options = {}) {
+  try {
+    const token = await getAccessToken();
+
+    const response = await fetch(`https://your-api.com${endpoint}`, {
+      ...options,
+      headers: {
+        ...options.headers,
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (err) {
+    console.error('API call failed:', err);
+    throw err;
+  }
+}
+
+// Usage
+async function getUserData() {
+  try {
+    const data = await callApi('/user/profile');
+    console.log(data);
+  } catch (err) {
+    alert('Failed to load user data');
+  }
+}
+```
+
+### With Audience Parameter
+
+Update `auth.js` to include API audience:
+
+```javascript
+export async function initAuth0() {
+  auth0Client = new Auth0Client({
+    domain: import.meta.env.VITE_AUTH0_DOMAIN,
+    clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
+    authorizationParams: {
+      redirect_uri: window.location.origin,
+      audience: 'https://your-api-identifier' // Add this
+    }
+  });
+  // ... rest of initialization
+}
+```
+
+---
+
+## Error Handling
+
+Handle errors gracefully throughout your app:
+
+```javascript
+// error.js
+export function showError(message) {
+  const errorDiv = document.createElement('div');
+  errorDiv.className = 'error-notification';
+  errorDiv.textContent = message;
+  errorDiv.style.cssText = `
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    background: #fee;
+    border: 1px solid #c00;
+    padding: 1rem;
+    border-radius: 4px;
+    z-index: 1000;
+  `;
+
+  document.body.appendChild(errorDiv);
+
+  // Auto-dismiss after 5 seconds
+  setTimeout(() => errorDiv.remove(), 5000);
+}
+
+// Usage in auth.js
+export async function initAuth0() {
+  try {
+    auth0Client = new Auth0Client({...});
+    // ... initialization
+  } catch (err) {
+    showError(`Authentication error: ${err.message}`);
+    throw err;
+  }
+}
+```
+
+---
+
+## State Management
+
+Simple state management for authentication:
+
+```javascript
+// state.js
+let state = {
+  isAuthenticated: false,
+  user: null,
+  loading: true,
+  error: null
+};
+
+const listeners = new Set();
+
+export function getState() {
+  return { ...state };
+}
+
+export function setState(updates) {
+  state = { ...state, ...updates };
+  listeners.forEach(listener => listener(state));
+}
+
+export function subscribe(listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+// Usage
+subscribe((state) => {
+  if (state.isAuthenticated) {
+    renderAuthenticatedUI();
+  } else {
+    renderUnauthenticatedUI();
+  }
+});
+```
+
+---
+
+## User Profile Display
+
+Create a reusable profile component:
+
+```javascript
+// profile.js
+export function renderUserProfile(user) {
+  return `
+    <div class="user-profile">
+      <img src="${user.picture}" alt="${user.name}" width="48" height="48" />
+      <div class="user-info">
+        <h3>${user.name}</h3>
+        <p>${user.email}</p>
+        ${user.email_verified ? '<span class="verified">✓ Verified</span>' : ''}
+      </div>
+    </div>
+  `;
+}
+
+// Usage in app.js
+import { renderUserProfile } from './profile.js';
+
+function updateUI() {
+  const { user } = getAuthState();
+  document.getElementById('profile').innerHTML = renderUserProfile(user);
+}
+```
+
+---
+
+## Loading States
+
+Show loading indicators during authentication:
+
+```javascript
+// Loading component
+function showLoading() {
+  document.getElementById('app').innerHTML = `
+    <div class="loading-spinner">
+      <div class="spinner"></div>
+      <p>Loading...</p>
+    </div>
+  `;
+}
+
+function hideLoading() {
+  const loading = document.querySelector('.loading-spinner');
+  if (loading) loading.remove();
+}
+
+// In app.js initialization
+(async () => {
+  showLoading();
+  try {
+    await initAuth0();
+    updateUI();
+  } finally {
+    hideLoading();
+  }
+})();
+```
+
+---
+
+## Session Management
+
+Periodically check authentication status:
+
+```javascript
+// session.js
+let sessionCheckInterval;
+
+export function startSessionMonitoring(intervalMs = 5 * 60 * 1000) {
+  sessionCheckInterval = setInterval(async () => {
+    try {
+      const authenticated = await auth0Client.isAuthenticated();
+      if (!authenticated && getState().isAuthenticated) {
+        // Session expired
+        setState({ isAuthenticated: false, user: null });
+        alert('Your session has expired. Please log in again.');
+        await login();
+      }
+    } catch (err) {
+      console.error('Session check failed:', err);
+    }
+  }, intervalMs);
+}
+
+export function stopSessionMonitoring() {
+  if (sessionCheckInterval) {
+    clearInterval(sessionCheckInterval);
+  }
+}
+
+// Start monitoring after initialization
+initAuth0().then(() => {
+  if (getState().isAuthenticated) {
+    startSessionMonitoring();
+  }
+});
+```
+
+---
+
+## Form Integration
+
+Handle forms with authentication:
+
+```javascript
+// form-handler.js
+import { getAccessToken } from './auth.js';
+
+export async function handleFormSubmit(event, endpoint) {
+  event.preventDefault();
+
+  const formData = new FormData(event.target);
+  const data = Object.fromEntries(formData);
+
+  try {
+    const token = await getAccessToken();
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify(data)
+    });
+
+    if (!response.ok) throw new Error('Form submission failed');
+
+    return await response.json();
+  } catch (err) {
+    showError(err.message);
+    throw err;
+  }
+}
+
+// Usage
+document.getElementById('myForm').addEventListener('submit', async (e) => {
+  const result = await handleFormSubmit(e, '/api/submit');
+  console.log('Form submitted:', result);
+});
+```
+
+---
+
+## Local Storage Caching
+
+Cache user preferences (not tokens - SDK handles that):
+
+```javascript
+// cache.js
+export function cacheUserPreferences(user) {
+  const prefs = {
+    userId: user.sub,
+    theme: 'light',
+    language: 'en'
+  };
+  localStorage.setItem('userPrefs', JSON.stringify(prefs));
+}
+
+export function getUserPreferences() {
+  const prefs = localStorage.getItem('userPrefs');
+  return prefs ? JSON.parse(prefs) : null;
+}
+
+export function clearUserPreferences() {
+  localStorage.removeItem('userPrefs');
+}
+```
+
+---
+
+## Testing
+
+### Mock Auth for Testing
+
+```javascript
+// test/auth.mock.js
+export const mockAuth = {
+  initAuth0: () => Promise.resolve({
+    isAuthenticated: true,
+    user: {
+      sub: 'auth0|123',
+      name: 'Test User',
+      email: 'test@example.com',
+      picture: 'https://example.com/avatar.jpg'
+    }
+  }),
+  login: () => Promise.resolve(),
+  logout: () => Promise.resolve(),
+  getAccessToken: () => Promise.resolve('mock-token'),
+  getAuthState: () => ({
+    isAuthenticated: true,
+    user: {
+      sub: 'auth0|123',
+      name: 'Test User',
+      email: 'test@example.com'
+    }
+  })
+};
+```
+
+---
+
+## Next Steps
+
+- Check [API Reference](api.md) for complete SDK documentation
+- See [Setup Guide](setup.md) for configuration options
+- Return to [main skill guide](../SKILL.md) for overview

--- a/plugins/auth0-sdks/skills/auth0-vanilla-js/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-vanilla-js/references/setup.md
@@ -1,0 +1,240 @@
+# Auth0 Vanilla JavaScript Setup Guide
+
+Complete setup instructions with automated scripts and manual configuration options.
+
+---
+
+## Quick Setup (Automated)
+
+### Bash Script (macOS/Linux)
+
+Run this script to automatically set up everything:
+
+```bash
+#!/bin/bash
+
+# Detect OS and install Auth0 CLI if needed
+if ! command -v auth0 &> /dev/null; then
+  echo "Installing Auth0 CLI..."
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    brew install auth0/auth0-cli/auth0
+  elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
+  fi
+fi
+
+# Check if logged in to Auth0
+if ! auth0 tenants list &> /dev/null; then
+  echo "Logging in to Auth0..."
+  auth0 login
+fi
+
+# List apps and prompt for selection
+echo "Your Auth0 applications:"
+auth0 apps list
+
+read -p "Enter your Auth0 app ID (or press Enter to create a new one): " APP_ID
+
+if [ -z "$APP_ID" ]; then
+  echo "Creating new Auth0 SPA application..."
+  APP_NAME="vanilla-js-app"
+  APP_ID=$(auth0 apps create \
+    --name "$APP_NAME" \
+    --type spa \
+    --callbacks "http://localhost:5173,http://localhost:3000" \
+    --logout-urls "http://localhost:5173,http://localhost:3000" \
+    --origins "http://localhost:5173,http://localhost:3000" \
+    --web-origins "http://localhost:5173,http://localhost:3000" \
+    --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
+  echo "Created app with ID: $APP_ID"
+fi
+
+# Get app details and create .env file
+echo "Fetching Auth0 credentials..."
+AUTH0_DOMAIN=$(auth0 apps show "$APP_ID" --json | grep -o '"domain":"[^"]*' | cut -d'"' -f4)
+AUTH0_CLIENT_ID=$(auth0 apps show "$APP_ID" --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
+
+# Create .env file
+cat > .env << EOF
+VITE_AUTH0_DOMAIN=$AUTH0_DOMAIN
+VITE_AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID
+EOF
+
+echo "✅ Auth0 configuration complete!"
+echo "Created .env file with:"
+echo "  VITE_AUTH0_DOMAIN=$AUTH0_DOMAIN"
+echo "  VITE_AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID"
+```
+
+### PowerShell Script (Windows)
+
+```powershell
+# Install Auth0 CLI if not present
+if (!(Get-Command auth0 -ErrorAction SilentlyContinue)) {
+  Write-Host "Installing Auth0 CLI..."
+  scoop install auth0
+}
+
+# Check if logged in
+try {
+  auth0 tenants list | Out-Null
+} catch {
+  Write-Host "Logging in to Auth0..."
+  auth0 login
+}
+
+# List and select app
+Write-Host "Your Auth0 applications:"
+auth0 apps list
+
+$appId = Read-Host "Enter your Auth0 app ID (or press Enter to create new)"
+
+if ([string]::IsNullOrEmpty($appId)) {
+  Write-Host "Creating new Auth0 SPA application..."
+  $appJson = auth0 apps create --name "vanilla-js-app" --type spa `
+    --callbacks "http://localhost:5173,http://localhost:3000" `
+    --logout-urls "http://localhost:5173,http://localhost:3000" `
+    --origins "http://localhost:5173,http://localhost:3000" `
+    --web-origins "http://localhost:5173,http://localhost:3000" --json
+
+  $appId = ($appJson | ConvertFrom-Json).client_id
+  Write-Host "Created app with ID: $appId"
+}
+
+# Get credentials and create .env
+Write-Host "Fetching Auth0 credentials..."
+$appDetails = auth0 apps show $appId --json | ConvertFrom-Json
+
+@"
+VITE_AUTH0_DOMAIN=$($appDetails.domain)
+VITE_AUTH0_CLIENT_ID=$($appDetails.client_id)
+"@ | Out-File -FilePath .env -Encoding UTF8
+
+Write-Host "✅ Auth0 configuration complete!"
+```
+
+---
+
+## Manual Setup
+
+### Step 1: Install SDK
+
+```bash
+npm install @auth0/auth0-spa-js
+```
+
+### Step 2: Install Build Tool (Optional)
+
+While not required, using Vite makes development easier:
+
+```bash
+npm install --save-dev vite
+```
+
+Add to `package.json`:
+
+```json
+{
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}
+```
+
+### Step 3: Install Auth0 CLI
+
+**macOS:**
+```bash
+brew install auth0/auth0-cli/auth0
+```
+
+**Linux:**
+```bash
+curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh
+```
+
+**Windows:**
+```powershell
+scoop install auth0
+```
+
+### Step 4: Get Credentials
+
+```bash
+auth0 login
+auth0 apps list
+auth0 apps show <app-id>
+```
+
+### Step 5: Create .env File
+
+```bash
+VITE_AUTH0_DOMAIN=<your-tenant>.auth0.com
+VITE_AUTH0_CLIENT_ID=<your-client-id>
+```
+
+---
+
+## Project Structure
+
+Recommended file structure:
+
+```
+my-app/
+├── index.html       # Main HTML file
+├── app.js           # Main application logic
+├── auth.js          # Auth0 integration
+├── style.css        # Styles (optional)
+├── .env             # Environment variables
+├── package.json     # Dependencies
+└── vite.config.js   # Vite config (optional)
+```
+
+---
+
+## Troubleshooting Setup
+
+### Environment Variables Not Loading
+
+**Problem:** `import.meta.env.VITE_AUTH0_DOMAIN` is undefined
+
+**Solutions:**
+- Ensure variable names start with `VITE_`
+- Restart dev server after creating `.env`
+- Check file is named exactly `.env`
+- Verify `.env` is in project root
+
+### CORS Errors
+
+**Problem:** Browser shows CORS policy errors
+
+**Solution:** Add your development URL to Auth0 Dashboard:
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to Applications → Your App → Settings
+3. Add to **Allowed Web Origins**: `http://localhost:5173`
+4. Add to **Allowed Origins (CORS)**: `http://localhost:5173`
+
+### Module Not Found
+
+**Problem:** Can't find `@auth0/auth0-spa-js`
+
+**Solution:**
+```bash
+# Reinstall dependencies
+npm install
+
+# Verify installation
+npm list @auth0/auth0-spa-js
+```
+
+---
+
+## Next Steps
+
+After setup is complete:
+1. Return to [main skill guide](../SKILL.md) for integration steps
+2. See [Integration Guide](integration.md) for advanced patterns
+3. Check [API Reference](api.md) for complete SDK documentation


### PR DESCRIPTION
### Description
Adds 8 new framework integration skills to enable AI-assisted Auth0 setup for Svelte, Vanilla JS, FastAPI, ASP.NET Core, Blazor Server, and Cap'n Web applications.

New Skills 

  SPA Frameworks:
  - auth0-svelte - Svelte 5+ with @auth0/auth0-spa-js
  - auth0-vanilla-js - Vanilla JavaScript with Vite

  Web Applications:
  - auth0-fastapi - FastAPI with auth0-fastapi SDK (session-based)
  - auth0-aspnet-core - ASP.NET Core MVC with Auth0.AspNetCore.Authentication
  - auth0-blazor-server - Blazor Server with Auth0.AspNetCore.Authentication

  Backend APIs:
  - auth0-aspnet-webapi - ASP.NET Core Web API with JWT validation
  - auth0-fastapi-backend - FastAPI with python-jose JWT validation

  RPC:
  - auth0-capnweb - Cap'n Web RPC with WebSocket authentication


### References


### Testing

Manually tested

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
