### PR TITLE
fix(auth0-express): use correct environment variables

### DIFF
--- a/plugins/auth0-sdks/skills/auth0-express/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-express/SKILL.md
@@ -42,11 +42,11 @@ npm install express-openid-connect dotenv
 Create `.env`:
 
 ```bash
-AUTH0_SECRET=<openssl-rand-hex-32>
-AUTH0_BASE_URL=http://localhost:3000
-AUTH0_CLIENT_ID=your-client-id
-AUTH0_CLIENT_SECRET=your-client-secret
-AUTH0_ISSUER_BASE_URL=https://your-tenant.auth0.com
+SECRET=<openssl-rand-hex-32>
+BASE_URL=http://localhost:3000
+CLIENT_ID=your-client-id
+CLIENT_SECRET=your-client-secret
+ISSUER_BASE_URL=https://your-tenant.auth0.com
 ```
 
 Generate secret: `openssl rand -hex 32`
@@ -66,11 +66,11 @@ const app = express();
 app.use(auth({
   authRequired: false,  // Don't require auth for all routes
   auth0Logout: true,    // Enable logout endpoint
-  secret: process.env.AUTH0_SECRET,
-  baseURL: process.env.AUTH0_BASE_URL,
-  clientID: process.env.AUTH0_CLIENT_ID,
-  issuerBaseURL: process.env.AUTH0_ISSUER_BASE_URL,
-  clientSecret: process.env.AUTH0_CLIENT_SECRET
+  secret: process.env.SECRET,
+  baseURL: process.env.BASE_URL,
+  clientID: process.env.CLIENT_ID,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  clientSecret: process.env.CLIENT_SECRET
 }));
 
 app.listen(3000, () => {
@@ -141,11 +141,11 @@ Visit `http://localhost:3000` and test the login flow.
 | Mistake | Fix |
 |---------|-----|
 | Forgot to add callback URL in Auth0 Dashboard | Add `/callback` path to Allowed Callback URLs (e.g., `http://localhost:3000/callback`) |
-| Missing or weak SECRET | Generate secure secret with `openssl rand -hex 32` and store in .env |
+| Missing or weak SECRET | Generate secure secret with `openssl rand -hex 32` and store in .env as `SECRET` |
 | Setting authRequired: true globally | Set to false and use `requiresAuth()` middleware on specific routes |
 | App created as SPA type in Auth0 | Must be Regular Web Application type for server-side auth |
 | Session secret exposed in code | Always use environment variables, never hardcode secrets |
-| Wrong baseURL for production | Update AUTH0_BASE_URL to match your production domain |
+| Wrong baseURL for production | Update BASE_URL to match your production domain |
 | Not handling logout returnTo | Add your domain to Allowed Logout URLs in Auth0 Dashboard |
 
 ---

--- a/plugins/auth0-sdks/skills/auth0-express/references/api.md
+++ b/plugins/auth0-sdks/skills/auth0-express/references/api.md
@@ -116,11 +116,11 @@ app.get('/call-api', requiresAuth(), async (req, res) => {
 app.use(auth({
   authRequired: false,
   auth0Logout: true,
-  secret: process.env.AUTH0_SECRET,
-  baseURL: process.env.AUTH0_BASE_URL,
-  clientID: process.env.AUTH0_CLIENT_ID,
-  issuerBaseURL: process.env.AUTH0_ISSUER_BASE_URL,
-  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  secret: process.env.SECRET,
+  baseURL: process.env.BASE_URL,
+  clientID: process.env.CLIENT_ID,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  clientSecret: process.env.CLIENT_SECRET,
   authorizationParams: {
     response_type: 'code',
     audience: 'https://your-api-identifier',  // Add this
@@ -172,11 +172,11 @@ app.get('/home', (req, res) => {
 app.use(auth({
   authRequired: false,          // Don't require auth globally
   auth0Logout: true,            // Enable logout route
-  secret: process.env.AUTH0_SECRET,
-  baseURL: process.env.AUTH0_BASE_URL,
-  clientID: process.env.AUTH0_CLIENT_ID,
-  issuerBaseURL: process.env.AUTH0_ISSUER_BASE_URL,
-  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  secret: process.env.SECRET,
+  baseURL: process.env.BASE_URL,
+  clientID: process.env.CLIENT_ID,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  clientSecret: process.env.CLIENT_SECRET,
 
   // Authorization parameters
   authorizationParams: {
@@ -220,11 +220,11 @@ app.use(auth({
 
 | Issue | Solution |
 |-------|----------|
-| "Missing required parameter: state" | Ensure `AUTH0_SECRET` is set and at least 32 characters |
-| Session not persisting | Check cookies are enabled and `AUTH0_BASE_URL` is correct |
+| "Missing required parameter: state" | Ensure `SECRET` is set and at least 32 characters |
+| Session not persisting | Check cookies are enabled and `BASE_URL` is correct |
 | Infinite redirect loop | Check `authRequired: false` for middleware config |
-| Callback URL mismatch | Verify `AUTH0_BASE_URL/callback` is in Auth0 allowed callback URLs |
-| "Invalid redirect URI" | Ensure callback URL in Auth0 matches `AUTH0_BASE_URL` exactly |
+| Callback URL mismatch | Verify `BASE_URL/callback` is in Auth0 allowed callback URLs |
+| "Invalid redirect URI" | Ensure callback URL in Auth0 matches `BASE_URL` exactly |
 
 ---
 
@@ -301,7 +301,7 @@ app.use(auth({
 
 - **Keep secrets secure** - Never commit `.env` to version control
 - **Use HTTPS in production** - Auth0 requires secure callback URLs
-- **Rotate secrets regularly** - Update `AUTH0_SECRET` periodically
+- **Rotate secrets regularly** - Update `SECRET` periodically
 - **Validate on server** - Authentication is server-side, tokens are secure
 - **Configure session properly** - Set appropriate session durations
 - **Use helmet** - Add security headers with `npm install helmet`

--- a/plugins/auth0-sdks/skills/auth0-express/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-express/references/integration.md
@@ -193,7 +193,7 @@ app.use((err, req, res, next) => {
 
 | Issue | Solution |
 |-------|----------|
-| "Invalid state" | Regenerate AUTH0_SECRET |
+| "Invalid state" | Regenerate SECRET |
 | Session not persisting | Check cookie settings, use HTTPS in production |
 | Redirect loop | Verify callback URL matches Auth0 config |
 

--- a/plugins/auth0-sdks/skills/auth0-express/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-express/references/setup.md
@@ -37,11 +37,11 @@ SECRET=$(openssl rand -hex 32)
 
 # Create .env
 cat > .env << ENVEOF
-AUTH0_SECRET=$SECRET
-AUTH0_BASE_URL=http://localhost:3000
-AUTH0_CLIENT_ID=$CLIENT_ID
-AUTH0_CLIENT_SECRET=$CLIENT_SECRET
-AUTH0_ISSUER_BASE_URL=https://$DOMAIN
+SECRET=$SECRET
+BASE_URL=http://localhost:3000
+CLIENT_ID=$CLIENT_ID
+CLIENT_SECRET=$CLIENT_SECRET
+ISSUER_BASE_URL=https://$DOMAIN
 ENVEOF
 
 echo "✅ Created .env file"
@@ -60,11 +60,11 @@ npm install express-openid-connect dotenv
 ### Create .env
 
 ```bash
-AUTH0_SECRET=<openssl-rand-hex-32>
-AUTH0_BASE_URL=http://localhost:3000
-AUTH0_CLIENT_ID=your-client-id
-AUTH0_CLIENT_SECRET=your-client-secret
-AUTH0_ISSUER_BASE_URL=https://your-tenant.auth0.com
+SECRET=<openssl-rand-hex-32>
+BASE_URL=http://localhost:3000
+CLIENT_ID=your-client-id
+CLIENT_SECRET=your-client-secret
+ISSUER_BASE_URL=https://your-tenant.auth0.com
 ```
 
 ### Get Auth0 Credentials
@@ -77,7 +77,7 @@ Dashboard: Create Regular Web Application, copy credentials
 
 ## Troubleshooting
 
-**"Invalid state" error:** Regenerate `AUTH0_SECRET`
+**"Invalid state" error:** Regenerate `SECRET`
 
 **Client secret required:** Express uses Regular Web Application type
 


### PR DESCRIPTION
### Description

express-openid-connect does not use the mentioned environment variables. Instead it uses those mentioned [here](https://github.com/auth0/express-openid-connect?tab=readme-ov-file#configuring-the-sdk).

```
ISSUER_BASE_URL=https://YOUR_DOMAIN
CLIENT_ID=YOUR_CLIENT_ID
CLIENT_SECRET=YOUR_CLIENT_SECRET // optional
BASE_URL=https://YOUR_APPLICATION_ROOT_URL
SECRET=LONG_RANDOM_VALUE
```

### References

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
