### PR TITLE
feat: add instrumentation metadata to Auth0 CLI app creation

### DIFF
--- a/plugins/auth0-sdks/skills/auth0-angular/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-angular/references/setup.md
@@ -44,6 +44,7 @@ if [ -z "$APP_ID" ]; then
     --logout-urls "http://localhost:4200" \
     --origins "http://localhost:4200" \
     --web-origins "http://localhost:4200" \
+    --metadata "created_by=agent_skills" \
     --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
 fi
 

--- a/plugins/auth0-sdks/skills/auth0-express/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-express/references/setup.md
@@ -26,6 +26,7 @@ if [ -z "$APP_ID" ]; then
   APP_ID=$(auth0 apps create --name "${PWD##*/}-express" --type regular \
     --callbacks "http://localhost:3000/callback" \
     --logout-urls "http://localhost:3000" \
+    --metadata "created_by=agent_skills" \
     --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
 fi
 

--- a/plugins/auth0-sdks/skills/auth0-nextjs/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-nextjs/references/setup.md
@@ -33,6 +33,7 @@ if [ -z "$APP_ID" ]; then
     --type regular \
     --callbacks "http://localhost:3000/api/auth/callback" \
     --logout-urls "http://localhost:3000" \
+    --metadata "created_by=agent_skills" \
     --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
 fi
 

--- a/plugins/auth0-sdks/skills/auth0-react-native/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-react-native/references/setup.md
@@ -52,7 +52,8 @@ Via CLI:
 auth0 login
 auth0 apps create --name "My Mobile App" --type native \
   --callbacks "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback" \
-  --logout-urls "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback"
+  --logout-urls "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback" \
+  --metadata "created_by=agent_skills"
 ```
 
 Via Dashboard:

--- a/plugins/auth0-sdks/skills/auth0-react/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-react/references/setup.md
@@ -87,6 +87,7 @@ if [ -z "$APP_ID" ]; then
     --logout-urls "http://localhost:3000,http://localhost:5173" \
     --origins "http://localhost:3000,http://localhost:5173" \
     --web-origins "http://localhost:3000,http://localhost:5173" \
+    --metadata "created_by=agent_skills" \
     --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
   echo "Created app with ID: $APP_ID"
 fi
@@ -174,7 +175,8 @@ if ([string]::IsNullOrEmpty($appId)) {
     --callbacks "http://localhost:3000,http://localhost:5173" `
     --logout-urls "http://localhost:3000,http://localhost:5173" `
     --origins "http://localhost:3000,http://localhost:5173" `
-    --web-origins "http://localhost:3000,http://localhost:5173" --json
+    --web-origins "http://localhost:3000,http://localhost:5173" `
+    --metadata "created_by=agent_skills" --json
 
   $appId = ($appJson | ConvertFrom-Json).client_id
   Write-Host "Created app with ID: $appId"

--- a/plugins/auth0-sdks/skills/auth0-vue/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-vue/references/setup.md
@@ -57,6 +57,7 @@ if [ -z "$APP_ID" ]; then
     --logout-urls "http://localhost:5173,http://localhost:3000" \
     --origins "http://localhost:5173,http://localhost:3000" \
     --web-origins "http://localhost:5173,http://localhost:3000" \
+    --metadata "created_by=agent_skills" \
     --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
   echo "Created app with ID: $APP_ID"
 fi
@@ -120,7 +121,8 @@ if ([string]::IsNullOrEmpty($appId)) {
     --callbacks "http://localhost:5173,http://localhost:3000" `
     --logout-urls "http://localhost:5173,http://localhost:3000" `
     --origins "http://localhost:5173,http://localhost:3000" `
-    --web-origins "http://localhost:5173,http://localhost:3000" --json
+    --web-origins "http://localhost:5173,http://localhost:3000" `
+    --metadata "created_by=agent_skills" --json
 
   $appId = ($appJson | ConvertFrom-Json).client_id
   Write-Host "Created app with ID: $appId"

--- a/plugins/auth0/skills/auth0-quickstart/SKILL.md
+++ b/plugins/auth0/skills/auth0-quickstart/SKILL.md
@@ -71,21 +71,24 @@ Choose application type based on your framework:
 ```bash
 auth0 apps create --name "My App" --type spa \
   --callbacks "http://localhost:3000" \
-  --logout-urls "http://localhost:3000"
+  --logout-urls "http://localhost:3000" \
+  --metadata "created_by=agent_skills"
 ```
 
 **Regular Web Apps (Next.js, Express):**
 ```bash
 auth0 apps create --name "My App" --type regular \
   --callbacks "http://localhost:3000/api/auth/callback" \
-  --logout-urls "http://localhost:3000"
+  --logout-urls "http://localhost:3000" \
+  --metadata "created_by=agent_skills"
 ```
 
 **Native Apps (React Native):**
 ```bash
 auth0 apps create --name "My App" --type native \
   --callbacks "myapp://callback" \
-  --logout-urls "myapp://logout"
+  --logout-urls "myapp://logout" \
+  --metadata "created_by=agent_skills"
 ```
 
 **Get your credentials:**

--- a/plugins/auth0/skills/auth0-quickstart/references/cli.md
+++ b/plugins/auth0/skills/auth0-quickstart/references/cli.md
@@ -74,7 +74,8 @@ auth0 apps create \
   --callbacks "http://localhost:3000" \
   --logout-urls "http://localhost:3000" \
   --origins "http://localhost:3000" \
-  --web-origins "http://localhost:3000"
+  --web-origins "http://localhost:3000" \
+  --metadata "created_by=agent_skills"
 ```
 
 ### Regular Web Application
@@ -86,7 +87,8 @@ auth0 apps create \
   --name "My Next.js App" \
   --type regular \
   --callbacks "http://localhost:3000/api/auth/callback" \
-  --logout-urls "http://localhost:3000"
+  --logout-urls "http://localhost:3000" \
+  --metadata "created_by=agent_skills"
 ```
 
 ### Native Application
@@ -98,7 +100,8 @@ auth0 apps create \
   --name "My Mobile App" \
   --type native \
   --callbacks "myapp://callback" \
-  --logout-urls "myapp://logout"
+  --logout-urls "myapp://logout" \
+  --metadata "created_by=agent_skills"
 ```
 
 ### Machine-to-Machine (M2M)
@@ -108,7 +111,8 @@ For backend APIs, cron jobs, server-to-server:
 ```bash
 auth0 apps create \
   --name "My API Service" \
-  --type m2m
+  --type m2m \
+  --metadata "created_by=agent_skills"
 ```
 
 ---


### PR DESCRIPTION
## Summary
Add `created_by=agent_skills` metadata to all `auth0 apps create` commands across all quickstart skills to enable tracking and instrumentation of apps created via agent skills.

## Changes
- Updated all setup scripts (Bash and PowerShell) to include `--metadata "created_by=agent_skills"` flag
- Applied to all SDK skills:
  - auth0-express
  - auth0-nextjs
  - auth0-vue
  - auth0-react
  - auth0-angular
  - auth0-react-native
- Updated auth0-quickstart documentation with metadata examples in both CLI reference and main SKILL.md

## Testing
- Verified syntax with Auth0 CLI v1.27.0
- Successfully created test app with metadata flag
- Confirmed metadata appears in application's `client_metadata` field

## Example
```bash
auth0 apps create --name "My App" --type spa \
  --callbacks "http://localhost:3000" \
  --logout-urls "http://localhost:3000" \
  --metadata "created_by=agent_skills"
```

Results in:
```json
"client_metadata": {
    "created_by": "agent_skills"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)