### PR TITLE
fix: keep sensitive CLI commands out of the SKILL

### DIFF
--- a/plugins/auth0/skills/auth0-quickstart/references/cli.md
+++ b/plugins/auth0/skills/auth0-quickstart/references/cli.md
@@ -120,9 +120,6 @@ auth0 apps create \
 ```bash
 # List all applications
 auth0 apps list
-
-# List with more details
-auth0 apps list --reveal
 ```
 
 ### Show Application Details
@@ -130,9 +127,6 @@ auth0 apps list --reveal
 ```bash
 # Show app details (includes client ID and secret)
 auth0 apps show <app-id>
-
-# Show with secrets revealed
-auth0 apps show <app-id> --reveal
 ```
 
 ### Update Application


### PR DESCRIPTION
### Description

We do not want the SKILL to decide to reveal sensitive information in the response.

### References

N/A


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
