### PR TITLE
Added stricter instructions for instruction following

### DIFF
--- a/plugins/auth0-sdks/skills/auth0-express/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-express/references/setup.md
@@ -1,133 +1,220 @@
 # Auth0 Express Setup Guide
 
-Setup instructions for Express.js applications.
+---
+
+## LLM Execution Instructions
+
+**You MUST follow these steps in order to set up Auth0. Execute each command and proceed to the next step.**
+
+1. Install the Auth0 CLI if not present
+2. Ensure user is logged in to Auth0
+3. Create a new Auth0 Regular Web Application automatically
+4. Extract credentials from the CLI output
+5. Write credentials to env file (after user confirmation)
+
+**Note:** The CLIENT_SECRET cannot be automatically written to the env file for security reasons. After setup, inform the user they need to manually add the CLIENT_SECRET value.
+
+**Do NOT show users manual Dashboard instructions unless the CLI approach completely fails after multiple attempts.**
 
 ---
 
-## Quick Setup (Automated)
+## Step 1: Check for existing env file and get user confirmation
 
-Below automates the setup, except for the CLIENT_SECRET. Inform the user that they have to fill in the value for the CLIENT_SECRET themselves.
-
-**Never read the contents of `.env.local` or `.env` at any point during setup.** The file may contain sensitive secrets that should not be exposed in the LLM context. If you determine you need to read the file for any reason, ask the user for explicit permission before doing so — do not proceed until the user confirms.
-
-**Before running any part of this setup that writes to an env file, you MUST ask the user for explicit confirmation.** Follow the steps below precisely.
-
-### Step 1: Check for existing env files and confirm with user
-
-Before writing credentials, check which env files exist:
+Before doing anything, check if env files exist and ask user for permission:
 
 ```bash
 test -f .env.local && echo "ENV_LOCAL_EXISTS" || echo "ENV_LOCAL_NOT_FOUND"
 test -f .env && echo "ENV_EXISTS" || echo "ENV_NOT_FOUND"
 ```
 
-Then ask the user for explicit confirmation before proceeding — do not continue until the user confirms:
+**Then ask the user:**
+- If no env file exists: "This setup will create a `.env` file with Auth0 credentials. You'll need to manually add the CLIENT_SECRET afterward. Proceed?"
+- If env file exists: "An env file exists. This will append Auth0 credentials without modifying existing content. Proceed?"
 
-- If `.env.local` exists, ask:
-  - Question: "A `.env.local` file already exists and may contain secrets unrelated to Auth0. This setup will append Auth0 credentials to it without modifying existing content. Do you want to proceed?"
-  - Options: "Yes, append to existing .env.local" / "No, I'll update it manually"
-
-- If `.env.local` does **not** exist but `.env` exists, ask:
-  - Question: "A `.env` file already exists and may contain secrets unrelated to Auth0. This setup will append Auth0 credentials to it without modifying existing content. Do you want to proceed?"
-  - Options: "Yes, append to existing .env" / "No, I'll update it manually"
-
-- If neither exists, ask:
-  - Question: "This setup will create a `.env.local` file containing Auth0 credentials (CLIENT_ID, ISSUER_BASE_URL, SECRET) and a placeholder for CLIENT_SECRET. Do you want to proceed?"
-  - Options: "Yes, create .env.local" / "No, I'll configure it manually"
-
-**Do not proceed with writing to any env file unless the user selects the confirmation option.**
-
-### Step 2: Run automated setup (only after confirmation)
-
-```bash
-#!/bin/bash
-
-# Install Auth0 CLI
-if ! command -v auth0 &> /dev/null; then
-  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0/auth0-cli/auth0 || \
-  curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
-fi
-
-# Login
-auth0 login 2>/dev/null || auth0 login
-
-# Create/select app
-auth0 apps list
-read -p "Enter app ID (or Enter to create): " APP_ID
-
-if [ -z "$APP_ID" ]; then
-  APP_ID=$(auth0 apps create --name "${PWD##*/}-express" --type regular \
-    --callbacks "http://localhost:3000/callback" \
-    --logout-urls "http://localhost:3000" \
-    --metadata "created_by=agent_skills" \
-    --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
-fi
-
-# Get credentials
-DOMAIN=$(auth0 apps show "$APP_ID" --json | grep -o '"domain":"[^"]*' | cut -d'"' -f4)
-CLIENT_ID=$(auth0 apps show "$APP_ID" --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
-SECRET=$(openssl rand -hex 32)
-
-# Determine target env file
-if [ -f .env.local ]; then
-  TARGET_FILE=".env.local"
-elif [ -f .env ]; then
-  TARGET_FILE=".env"
-else
-  TARGET_FILE=".env.local"
-fi
-
-# Append Auth0 credentials
-cat >> "$TARGET_FILE" << ENVEOF
-SECRET=$SECRET
-BASE_URL=http://localhost:3000
-CLIENT_ID=$CLIENT_ID
-CLIENT_SECRET='YOUR_CLIENT_SECRET'
-ISSUER_BASE_URL=https://$DOMAIN
-ENVEOF
-
-echo "✅ Auth0 credentials written to $TARGET_FILE"
-```
-
-After the script runs, remind the user to:
-1. Open the env file that was written and replace `YOUR_CLIENT_SECRET` with the actual client secret from Auth0.
-2. Ensure the env file is listed in `.gitignore` to avoid accidentally committing secrets.
+**Do not continue unless user confirms.**
 
 ---
 
-## Manual Setup
+## Step 2: Install Auth0 CLI
 
-### Install Packages
+Check if Auth0 CLI is installed, install if needed:
+
+```bash
+command -v auth0 &> /dev/null && echo "AUTH0_CLI_INSTALLED" || echo "AUTH0_CLI_NOT_FOUND"
+```
+
+**If not installed, run the appropriate command for the user's OS:**
+
+**macOS:**
+```bash
+brew install auth0/auth0-cli/auth0
+```
+
+**Linux:**
+```bash
+curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
+```
+
+**Windows (PowerShell):**
+```powershell
+scoop install auth0
+```
+
+---
+
+## Step 3: Ensure user is logged in to Auth0
+
+Check login status:
+
+```bash
+auth0 tenants list 2>&1
+```
+
+**If the command fails or shows an error**, the user needs to log in:
+
+```bash
+auth0 login
+```
+
+Tell the user: "A browser window will open. Please log in to your Auth0 account (or create one at https://auth0.com/signup if needed)."
+
+**Wait for user to complete login, then verify:**
+
+```bash
+auth0 tenants list
+```
+
+---
+
+## Step 4: Create Auth0 Application
+
+**Create a new Regular Web Application - run this single command:**
+
+```bash
+auth0 apps create \
+  --name "$(basename "$PWD")-express" \
+  --type regular \
+  --callbacks "http://localhost:3000/callback" \
+  --logout-urls "http://localhost:3000" \
+  --metadata "created_by=agent_skills" \
+  --json
+```
+
+**This outputs JSON. Extract these values from the response:**
+- `client_id` - This is your Auth0 Client ID
+- `client_secret` - This is your Auth0 Client Secret (tell user to save this)
+- `domain` - This is your Auth0 Domain (in the format `xxx.auth0.com` or `xxx.us.auth0.com`)
+
+**Example output parsing:**
+```bash
+# The command above outputs JSON like:
+# {"client_id":"abc123","client_secret":"xyz789","domain":"dev-example.us.auth0.com",...}
+# Extract client_id, client_secret, and domain from this output
+```
+
+---
+
+## Step 5: Generate SECRET
+
+Generate a random secret for session encryption:
+
+```bash
+openssl rand -hex 32
+```
+
+Save this output - you'll need it for the env file.
+
+---
+
+## Step 6: Write credentials to env file
+
+**Write the following to `.env`:**
+
+```bash
+cat >> .env << 'EOF'
+SECRET=<generated-secret-from-step-5>
+BASE_URL=http://localhost:3000
+CLIENT_ID=<client_id-from-step-4>
+CLIENT_SECRET=<client_secret-from-step-4>
+ISSUER_BASE_URL=https://<domain-from-step-4>
+EOF
+```
+
+**Replace placeholders with actual values from previous steps.**
+
+**Important:** Tell the user to verify the CLIENT_SECRET was written correctly, as this is a sensitive value.
+
+---
+
+## Step 7: Install SDK
 
 ```bash
 npm install express-openid-connect dotenv
 ```
 
-### Create .env
+---
 
-```bash
-SECRET=<openssl-rand-hex-32>
-BASE_URL=http://localhost:3000
-CLIENT_ID=your-client-id
-CLIENT_SECRET=your-client-secret
-ISSUER_BASE_URL=https://your-tenant.auth0.com
-```
+## Verification
 
-### Get Auth0 Credentials
+After setup, confirm to the user:
+- Auth0 application created successfully
+- Credentials written to `.env`
+- SDK installed
 
-CLI: `auth0 apps show <app-id> --reveal-secrets`
-
-Dashboard: Create Regular Web Application, copy credentials
+Tell them to:
+1. Verify CLIENT_SECRET is correct in the env file
+2. Ensure the env file is in `.gitignore`
+3. Restart the server to load environment variables
 
 ---
 
 ## Troubleshooting
 
-**"Invalid state" error:** Regenerate `SECRET`
+### CLI Installation Issues
 
-**Client secret required:** Express uses Regular Web Application type
+**macOS - Homebrew not found:**
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
 
-**Callback URL mismatch:** Add `/callback` to Allowed Callback URLs
+### Login Issues
+
+**Browser doesn't open:**
+```bash
+auth0 login --no-browser
+```
+
+**"Not logged in" error:**
+```bash
+auth0 login --force
+```
+
+### Common Errors
+
+**"Invalid state" error:** Regenerate `SECRET` with `openssl rand -hex 32`
+
+**Client secret required:** Express uses Regular Web Application type (not SPA)
+
+**Callback URL mismatch:** Add `/callback` to Allowed Callback URLs via CLI:
+
+```bash
+auth0 apps update <app-id> --callbacks "http://localhost:3000/callback"
+```
+
+---
+
+## Fallback: Manual Dashboard Setup
+
+**Only use this if the CLI approach fails completely after troubleshooting.**
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **Applications**
+3. Click **Create Application**
+4. Choose **Regular Web Applications**
+5. Configure:
+   - **Allowed Callback URLs**: `http://localhost:3000/callback`
+   - **Allowed Logout URLs**: `http://localhost:3000`
+6. Copy **Domain**, **Client ID**, and **Client Secret** to `.env` file
 
 ---
 

--- a/plugins/auth0-sdks/skills/auth0-react-native/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-react-native/references/setup.md
@@ -1,69 +1,132 @@
 # Auth0 React Native Setup Guide
 
-Setup instructions for React Native and Expo mobile applications.
+---
+
+## LLM Execution Instructions
+
+**You MUST follow these steps in order to set up Auth0. Execute each command and proceed to the next step.**
+
+1. Install the Auth0 CLI if not present
+2. Ensure user is logged in to Auth0
+3. Create a new Auth0 Native Application automatically
+4. Extract credentials from the CLI output
+5. Configure iOS and Android with the credentials
+
+**Do NOT show users manual Dashboard instructions unless the CLI approach completely fails after multiple attempts.**
 
 ---
 
-## Quick Setup
+## Step 1: Install Auth0 CLI
 
-### For Expo
+Check if Auth0 CLI is installed, install if needed:
 
 ```bash
-# Install SDK
-npx expo install react-native-auth0
-
-# Configure app.json
-# Add scheme, bundleIdentifier, and package
+command -v auth0 &> /dev/null && echo "AUTH0_CLI_INSTALLED" || echo "AUTH0_CLI_NOT_FOUND"
 ```
 
-### For React Native CLI
+**If not installed, run the appropriate command for the user's OS:**
 
+**macOS:**
 ```bash
-# Install SDK
-npm install react-native-auth0
+brew install auth0/auth0-cli/auth0
+```
 
-# iOS: Install pods
-cd ios && pod install && cd ..
-
-# Configure iOS Info.plist and Android AndroidManifest.xml
+**Linux:**
+```bash
+curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
 ```
 
 ---
 
-## Manual Setup
+## Step 2: Ensure user is logged in to Auth0
 
-### 1. Install SDK
+Check login status:
 
-**Expo:**
 ```bash
-npx expo install react-native-auth0
+auth0 tenants list 2>&1
 ```
 
-**React Native CLI:**
-```bash
-npm install react-native-auth0
-npx pod-install  # iOS only
-```
+**If the command fails or shows an error**, the user needs to log in:
 
-### 2. Create Auth0 Native Application
-
-Via CLI:
 ```bash
 auth0 login
-auth0 apps create --name "My Mobile App" --type native \
-  --callbacks "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback" \
-  --logout-urls "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback" \
-  --metadata "created_by=agent_skills"
 ```
 
-Via Dashboard:
-1. Create **Native** application type
-2. Configure callback URLs with your app scheme
-3. Copy domain and client ID
+Tell the user: "A browser window will open. Please log in to your Auth0 account (or create one at https://auth0.com/signup if needed)."
 
-### 3. Configure iOS
+**Wait for user to complete login, then verify:**
 
-Update `ios/{YourApp}/Info.plist`:
+```bash
+auth0 tenants list
+```
+
+---
+
+## Step 3: Get App Bundle Identifier
+
+Before creating the Auth0 app, determine the bundle identifier:
+
+**For Expo projects**, check `app.json`:
+```bash
+grep -o '"bundleIdentifier"[[:space:]]*:[[:space:]]*"[^"]*"' app.json 2>/dev/null || echo "NOT_FOUND"
+grep -o '"package"[[:space:]]*:[[:space:]]*"[^"]*"' app.json 2>/dev/null || echo "NOT_FOUND"
+```
+
+**For React Native CLI projects**, check iOS and Android configs:
+```bash
+# iOS bundle ID
+grep -o 'PRODUCT_BUNDLE_IDENTIFIER = [^;]*' ios/*.xcodeproj/project.pbxproj 2>/dev/null | head -1 || echo "NOT_FOUND"
+# Android package
+grep -o 'applicationId "[^"]*"' android/app/build.gradle 2>/dev/null || echo "NOT_FOUND"
+```
+
+If not found, ask the user for their bundle identifier (e.g., `com.mycompany.myapp`).
+
+---
+
+## Step 4: Create Auth0 Application
+
+**Get the Auth0 domain first:**
+```bash
+auth0 tenants list --json | grep -o '"name":"[^"]*"' | head -1 | cut -d'"' -f4
+```
+
+**Create a new Native Application - replace `{BUNDLE_ID}` with actual bundle ID and `{DOMAIN}` with Auth0 domain:**
+
+```bash
+auth0 apps create \
+  --name "$(basename "$PWD")-mobile" \
+  --type native \
+  --callbacks "{BUNDLE_ID}.auth0://{DOMAIN}/ios/{BUNDLE_ID}/callback,{BUNDLE_ID}.auth0://{DOMAIN}/android/{BUNDLE_ID}/callback" \
+  --logout-urls "{BUNDLE_ID}.auth0://{DOMAIN}/ios/{BUNDLE_ID}/callback,{BUNDLE_ID}.auth0://{DOMAIN}/android/{BUNDLE_ID}/callback" \
+  --metadata "created_by=agent_skills" \
+  --json
+```
+
+**This outputs JSON. Extract these values from the response:**
+- `client_id` - This is your Auth0 Client ID
+- `domain` - This is your Auth0 Domain
+
+---
+
+## Step 5: Install SDK
+
+**For Expo:**
+```bash
+npx expo install react-native-auth0
+```
+
+**For React Native CLI:**
+```bash
+npm install react-native-auth0
+cd ios && pod install && cd ..
+```
+
+---
+
+## Step 6: Configure iOS
+
+Update `ios/{YourApp}/Info.plist` - add inside the `<dict>` tag:
 
 ```xml
 <key>CFBundleURLTypes</key>
@@ -81,9 +144,11 @@ Update `ios/{YourApp}/Info.plist`:
 </array>
 ```
 
-### 4. Configure Android
+---
 
-Update `android/app/src/main/AndroidManifest.xml`:
+## Step 7: Configure Android
+
+Update `android/app/src/main/AndroidManifest.xml` - add inside `<application>`:
 
 ```xml
 <activity android:name="com.auth0.android.provider.RedirectActivity" android:exported="true">
@@ -92,26 +157,30 @@ Update `android/app/src/main/AndroidManifest.xml`:
     <category android:name="android.intent.category.DEFAULT" />
     <category android:name="android.intent.category.BROWSABLE" />
     <data
-      android:host="YOUR_DOMAIN"
+      android:host="<domain-from-step-4>"
       android:pathPrefix="/android/${applicationId}/callback"
-      android:scheme="${applicationId}" />
+      android:scheme="${applicationId}.auth0" />
   </intent-filter>
 </activity>
 ```
 
-### 5. Configure Expo
+**Replace `<domain-from-step-4>` with the actual Auth0 domain.**
+
+---
+
+## Step 8: Configure Expo (if applicable)
 
 Update `app.json`:
 
 ```json
 {
   "expo": {
-    "scheme": "myappscheme",
+    "scheme": "<bundle-id>.auth0",
     "ios": {
-      "bundleIdentifier": "com.mycompany.myapp"
+      "bundleIdentifier": "<bundle-id>"
     },
     "android": {
-      "package": "com.mycompany.myapp"
+      "package": "<bundle-id>"
     }
   }
 }
@@ -119,19 +188,67 @@ Update `app.json`:
 
 ---
 
+## Verification
+
+After setup, confirm to the user:
+- Auth0 Native application created successfully
+- SDK installed
+- iOS Info.plist configured
+- Android AndroidManifest.xml configured
+- Expo app.json configured (if applicable)
+
+Tell them to rebuild the app:
+- **Expo:** `npx expo prebuild` then `npx expo run:ios` or `npx expo run:android`
+- **React Native CLI:** `npx react-native run-ios` or `npx react-native run-android`
+
+---
+
 ## Troubleshooting
+
+### CLI Installation Issues
+
+**macOS - Homebrew not found:**
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### Login Issues
+
+**Browser doesn't open:**
+```bash
+auth0 login --no-browser
+```
+
+### Common Errors
 
 **Callback not working:**
 - Verify scheme matches bundle ID/package name
 - Check Auth0 allowed callbacks include your scheme
 
 **Build errors on iOS:**
-- Run `pod install` in ios/ directory
-- Clean build folder in Xcode
+```bash
+cd ios && pod install && cd ..
+# Clean build in Xcode: Product → Clean Build Folder
+```
 
 **Android redirect issues:**
 - Ensure RedirectActivity is exported
 - Check scheme matches package name
+
+---
+
+## Fallback: Manual Dashboard Setup
+
+**Only use this if the CLI approach fails completely after troubleshooting.**
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **Applications**
+3. Click **Create Application**
+4. Choose **Native**
+5. Configure callback URLs with your app scheme:
+   - `{bundle-id}.auth0://{domain}/ios/{bundle-id}/callback`
+   - `{bundle-id}.auth0://{domain}/android/{bundle-id}/callback`
+6. Copy **Domain** and **Client ID** for use in your app
 
 ---
 

--- a/plugins/auth0-sdks/skills/auth0-react/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-react/references/setup.md
@@ -1,241 +1,46 @@
 # Auth0 React Setup Guide
 
-Complete setup instructions with automated scripts and manual configuration options.
+---
+
+## LLM Execution Instructions
+
+**You MUST follow these steps in order to set up Auth0. Execute each command and proceed to the next step.**
+
+1. Install the Auth0 CLI if not present
+2. Ensure user is logged in to Auth0
+3. Create a new Auth0 SPA application automatically
+4. Extract credentials from the CLI output
+5. Write credentials to `.env` file (after user confirmation)
+
+**Do NOT show users manual Dashboard instructions unless the CLI approach completely fails after multiple attempts.**
 
 ---
 
-## Quick Setup (Automated)
+## Step 1: Check for existing .env and get user confirmation
 
-**Never read the contents of `.env` at any point during setup.** The file may contain sensitive secrets that should not be exposed in the LLM context. If you determine you need to read the file for any reason, ask the user for explicit permission before doing so — do not proceed until the user confirms.
-
-**Before running any part of this setup that writes to `.env`, you MUST ask the user for explicit confirmation.** Follow the steps below precisely.
-
-### Step 1: Check for existing .env and confirm with user
-
-Before writing to `.env`, check whether the file already exists:
+Before doing anything, check if `.env` exists and ask user for permission:
 
 ```bash
 test -f .env && echo "EXISTS" || echo "NOT_FOUND"
 ```
 
-Then ask the user for explicit confirmation before proceeding — do not continue until the user confirms:
+**Then ask the user:**
+- If `.env` does **not** exist: "This setup will create a `.env` file with Auth0 credentials (domain and client ID). Proceed?"
+- If `.env` **exists**: "A `.env` file exists. This will append Auth0 credentials without modifying existing content. Proceed?"
 
-- If `.env` does **not** exist, ask:
-  - Question: "This setup will create a `.env` file containing Auth0 credentials (domain and client ID). Do you want to proceed?"
-  - Options: "Yes, create .env" / "No, I'll configure it manually"
-
-- If `.env` **already exists**, ask:
-  - Question: "A `.env` file already exists and may contain secrets unrelated to Auth0. This setup will append Auth0 credentials to it without modifying existing content. Do you want to proceed?"
-  - Options: "Yes, append to existing .env" / "No, I'll update it manually"
-
-**Do not proceed with writing to `.env` unless the user selects the confirmation option.**
-
-### Step 2: Run automated setup (only after confirmation)
-
-#### Bash Script (macOS/Linux)
-
-Run this script to automatically set up everything:
-
-```bash
-#!/bin/bash
-
-# Detect OS and install Auth0 CLI if needed
-if ! command -v auth0 &> /dev/null; then
-  echo "Installing Auth0 CLI..."
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
-  elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
-  elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
-    echo "Please install Auth0 CLI: https://github.com/auth0/auth0-cli#installation"
-    exit 1
-  fi
-fi
-
-# Check if logged in to Auth0
-if ! auth0 tenants list &> /dev/null; then
-  echo ""
-  echo "======================================"
-  echo "Auth0 Login Required"
-  echo "======================================"
-  echo ""
-  read -p "Do you have an Auth0 account? (y/n): " HAS_ACCOUNT
-
-  if [[ "$HAS_ACCOUNT" != "y" ]]; then
-    echo ""
-    echo "Let's create your free Auth0 account!"
-    echo ""
-    echo "1. Visit: https://auth0.com/signup"
-    echo "2. Sign up with your email or GitHub"
-    echo "3. Choose a tenant domain (e.g., 'mycompany')"
-    echo "4. Complete the onboarding"
-    echo ""
-    read -p "Press Enter when you've created your account..."
-  fi
-
-  echo ""
-  echo "Logging in to Auth0..."
-  echo "A browser will open for authentication."
-  echo ""
-  auth0 login
-
-  if ! auth0 tenants list &> /dev/null; then
-    echo "❌ Login failed. Please try again or visit https://auth0.com/docs"
-    exit 1
-  fi
-
-  echo "✅ Successfully logged in to Auth0!"
-fi
-
-# Detect if Vite or CRA
-if grep -q '"vite"' package.json 2>/dev/null; then
-  PREFIX="VITE_AUTH0"
-elif grep -q '"react-scripts"' package.json 2>/dev/null; then
-  PREFIX="REACT_APP_AUTH0"
-else
-  echo "Detecting React project type..."
-  PREFIX="VITE_AUTH0"  # Default to Vite
-fi
-
-# List apps and prompt for selection
-echo "Your Auth0 applications:"
-auth0 apps list
-
-read -p "Enter your Auth0 app ID (or press Enter to create a new one): " APP_ID
-
-if [ -z "$APP_ID" ]; then
-  echo "Creating new Auth0 SPA application..."
-  APP_NAME="${PWD##*/}-react-app"
-  APP_ID=$(auth0 apps create \
-    --name "$APP_NAME" \
-    --type spa \
-    --callbacks "http://localhost:3000,http://localhost:5173" \
-    --logout-urls "http://localhost:3000,http://localhost:5173" \
-    --origins "http://localhost:3000,http://localhost:5173" \
-    --web-origins "http://localhost:3000,http://localhost:5173" \
-    --metadata "created_by=agent_skills" \
-    --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
-  echo "Created app with ID: $APP_ID"
-fi
-
-# Get app details and create .env file
-echo "Fetching Auth0 credentials..."
-AUTH0_DOMAIN=$(auth0 apps show "$APP_ID" --json | grep -o '"domain":"[^"]*' | cut -d'"' -f4)
-AUTH0_CLIENT_ID=$(auth0 apps show "$APP_ID" --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
-
-# Append Auth0 credentials to .env
-cat >> .env << EOF
-${PREFIX}_DOMAIN=$AUTH0_DOMAIN
-${PREFIX}_CLIENT_ID=$AUTH0_CLIENT_ID
-EOF
-
-echo "✅ Auth0 configuration complete!"
-echo "Appended to .env:"
-echo "  ${PREFIX}_DOMAIN=$AUTH0_DOMAIN"
-echo "  ${PREFIX}_CLIENT_ID=$AUTH0_CLIENT_ID"
-```
-
-#### PowerShell Script (Windows)
-
-```powershell
-# Install Auth0 CLI if not present
-if (!(Get-Command auth0 -ErrorAction SilentlyContinue)) {
-  Write-Host "Installing Auth0 CLI..."
-  scoop install auth0
-}
-
-# Check if logged in
-try {
-  auth0 tenants list | Out-Null
-} catch {
-  Write-Host ""
-  Write-Host "======================================"
-  Write-Host "Auth0 Login Required"
-  Write-Host "======================================"
-  Write-Host ""
-
-  $hasAccount = Read-Host "Do you have an Auth0 account? (y/n)"
-
-  if ($hasAccount -ne "y") {
-    Write-Host ""
-    Write-Host "Let's create your free Auth0 account!"
-    Write-Host ""
-    Write-Host "1. Visit: https://auth0.com/signup"
-    Write-Host "2. Sign up with your email or GitHub"
-    Write-Host "3. Choose a tenant domain (e.g., 'mycompany')"
-    Write-Host "4. Complete the onboarding"
-    Write-Host ""
-    Read-Host "Press Enter when you've created your account"
-  }
-
-  Write-Host ""
-  Write-Host "Logging in to Auth0..."
-  Write-Host "A browser will open for authentication."
-  Write-Host ""
-  auth0 login
-
-  try {
-    auth0 tenants list | Out-Null
-    Write-Host "✅ Successfully logged in to Auth0!"
-  } catch {
-    Write-Host "❌ Login failed. Please try again or visit https://auth0.com/docs"
-    exit 1
-  }
-}
-
-# Detect project type
-$prefix = if (Select-String -Path "package.json" -Pattern '"vite"' -Quiet) { "VITE_AUTH0" }
-          elseif (Select-String -Path "package.json" -Pattern '"react-scripts"' -Quiet) { "REACT_APP_AUTH0" }
-          else { "VITE_AUTH0" }
-
-# List and select app
-Write-Host "Your Auth0 applications:"
-auth0 apps list
-
-$appId = Read-Host "Enter your Auth0 app ID (or press Enter to create new)"
-
-if ([string]::IsNullOrEmpty($appId)) {
-  $appName = Split-Path -Leaf (Get-Location)
-  Write-Host "Creating new Auth0 SPA application..."
-  $appJson = auth0 apps create --name "$appName-react-app" --type spa `
-    --callbacks "http://localhost:3000,http://localhost:5173" `
-    --logout-urls "http://localhost:3000,http://localhost:5173" `
-    --origins "http://localhost:3000,http://localhost:5173" `
-    --web-origins "http://localhost:3000,http://localhost:5173" `
-    --metadata "created_by=agent_skills" --json
-
-  $appId = ($appJson | ConvertFrom-Json).client_id
-  Write-Host "Created app with ID: $appId"
-}
-
-# Get credentials and create .env
-Write-Host "Fetching Auth0 credentials..."
-$appDetails = auth0 apps show $appId --json | ConvertFrom-Json
-
-@"
-${prefix}_DOMAIN=$($appDetails.domain)
-${prefix}_CLIENT_ID=$($appDetails.client_id)
-"@ | Out-File -FilePath .env -Encoding UTF8 -Append
-
-Write-Host "✅ Auth0 configuration complete!"
-Write-Host "Appended to .env:"
-Write-Host "  ${prefix}_DOMAIN=$($appDetails.domain)"
-Write-Host "  ${prefix}_CLIENT_ID=$($appDetails.client_id)"
-```
+**Do not continue unless user confirms.**
 
 ---
 
-## Manual Setup
+## Step 2: Install Auth0 CLI
 
-If you prefer manual setup or the scripts don't work:
-
-### Step 1: Install SDK
+Check if Auth0 CLI is installed, install if needed:
 
 ```bash
-npm install @auth0/auth0-react
+command -v auth0 &> /dev/null && echo "AUTH0_CLI_INSTALLED" || echo "AUTH0_CLI_NOT_FOUND"
 ```
 
-### Step 2: Install Auth0 CLI
+**If not installed, run the appropriate command for the user's OS:**
 
 **macOS:**
 ```bash
@@ -244,77 +49,129 @@ brew install auth0/auth0-cli/auth0
 
 **Linux:**
 ```bash
-curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
 ```
 
-**Windows:**
+**Windows (PowerShell):**
 ```powershell
 scoop install auth0
-# Or: choco install auth0-cli
 ```
 
-### Step 3: Get Credentials
+---
+
+## Step 3: Ensure user is logged in to Auth0
+
+Check login status:
 
 ```bash
-# Login to Auth0
+auth0 tenants list 2>&1
+```
+
+**If the command fails or shows an error**, the user needs to log in:
+
+```bash
 auth0 login
-
-# List your apps
-auth0 apps list
-
-# Get app details (replace <app-id>)
-auth0 apps show <app-id>
 ```
 
-### Step 4: Create .env File
+Tell the user: "A browser window will open. Please log in to your Auth0 account (or create one at https://auth0.com/signup if needed)."
 
-**For Vite:**
-```bash
-VITE_AUTH0_DOMAIN=<your-tenant>.auth0.com
-VITE_AUTH0_CLIENT_ID=<your-client-id>
-```
+**Wait for user to complete login, then verify:**
 
-**For Create React App:**
 ```bash
-REACT_APP_AUTH0_DOMAIN=<your-tenant>.auth0.com
-REACT_APP_AUTH0_CLIENT_ID=<your-client-id>
+auth0 tenants list
 ```
 
 ---
 
-## Creating an Auth0 Application via Dashboard
+## Step 4: Create Auth0 Application
 
-If you prefer using the Auth0 Dashboard instead of the CLI:
+**Detect the project type first:**
 
-1. Go to [Auth0 Dashboard](https://manage.auth0.com)
-2. Navigate to **Applications** → **Applications**
-3. Click **Create Application**
-4. Choose:
-   - Name: Your app name
-   - Type: **Single Page Web Applications**
-5. Configure:
-   - **Allowed Callback URLs**: `http://localhost:3000, http://localhost:5173`
-   - **Allowed Logout URLs**: `http://localhost:3000, http://localhost:5173`
-   - **Allowed Web Origins**: `http://localhost:3000, http://localhost:5173`
-   - **Allowed Origins (CORS)**: `http://localhost:3000, http://localhost:5173`
-6. Copy your **Domain** and **Client ID**
-7. Create `.env` file as shown in Step 4 above
+```bash
+grep -q '"vite"' package.json 2>/dev/null && echo "VITE" || (grep -q '"react-scripts"' package.json 2>/dev/null && echo "CRA" || echo "VITE")
+```
+
+**Create a new SPA application - run this single command:**
+
+```bash
+auth0 apps create \
+  --name "$(basename "$PWD")-react-app" \
+  --type spa \
+  --callbacks "http://localhost:3000,http://localhost:5173" \
+  --logout-urls "http://localhost:3000,http://localhost:5173" \
+  --origins "http://localhost:3000,http://localhost:5173" \
+  --web-origins "http://localhost:3000,http://localhost:5173" \
+  --metadata "created_by=agent_skills" \
+  --json
+```
+
+**This outputs JSON. Extract these values from the response:**
+- `client_id` - This is your Auth0 Client ID
+- `domain` - This is your Auth0 Domain (in the format `xxx.auth0.com` or `xxx.us.auth0.com`)
+
+**Example output parsing (save the JSON output to extract values):**
+```bash
+# The command above outputs JSON like:
+# {"client_id":"abc123","domain":"dev-example.us.auth0.com",...}
+# Extract client_id and domain from this output
+```
 
 ---
 
-## Troubleshooting Setup
+## Step 5: Write credentials to .env
+
+**Based on project type detected in Step 4:**
+
+**For Vite projects**, append to `.env`:
+```bash
+cat >> .env << 'EOF'
+VITE_AUTH0_DOMAIN=<domain-from-step-4>
+VITE_AUTH0_CLIENT_ID=<client_id-from-step-4>
+EOF
+```
+
+**For Create React App projects**, append to `.env`:
+```bash
+cat >> .env << 'EOF'
+REACT_APP_AUTH0_DOMAIN=<domain-from-step-4>
+REACT_APP_AUTH0_CLIENT_ID=<client_id-from-step-4>
+EOF
+```
+
+**Replace `<domain-from-step-4>` and `<client_id-from-step-4>` with the actual values from the JSON output.**
+
+---
+
+## Step 6: Install SDK
+
+```bash
+npm install @auth0/auth0-react
+```
+
+---
+
+## Verification
+
+After setup, confirm to the user:
+- Auth0 application created successfully
+- Credentials written to `.env`
+- SDK installed
+
+Tell them to restart their dev server to load the new environment variables.
+
+---
+
+## Troubleshooting
 
 ### CLI Installation Issues
 
 **macOS - Homebrew not found:**
 ```bash
-# Install Homebrew first
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 **Windows - Scoop not found:**
 ```powershell
-# Install Scoop first
 iwr -useb get.scoop.sh | iex
 ```
 
@@ -322,27 +179,35 @@ iwr -useb get.scoop.sh | iex
 
 **Browser doesn't open:**
 ```bash
-# Use device code flow
 auth0 login --no-browser
 ```
 
 **"Not logged in" error:**
 ```bash
-# Force new login
 auth0 login --force
 ```
 
 ### Environment Variable Issues
 
-**Variables not loading (Vite):**
-- Ensure variables start with `VITE_`
-- Restart dev server after creating `.env`
-- Check file is named exactly `.env` (not `.env.local`)
+- **Vite**: Variables must start with `VITE_` prefix
+- **CRA**: Variables must start with `REACT_APP_` prefix
+- Always restart dev server after modifying `.env`
 
-**Variables not loading (CRA):**
-- Ensure variables start with `REACT_APP_`
-- Restart dev server after creating `.env`
-- CRA doesn't support `.env` hot reload
+---
+
+## Fallback: Manual Dashboard Setup
+
+**Only use this if the CLI approach fails completely after troubleshooting.**
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **Applications**
+3. Click **Create Application**
+4. Choose **Single Page Web Applications**
+5. Configure:
+   - **Allowed Callback URLs**: `http://localhost:3000, http://localhost:5173`
+   - **Allowed Logout URLs**: `http://localhost:3000, http://localhost:5173`
+   - **Allowed Web Origins**: `http://localhost:3000, http://localhost:5173`
+6. Copy **Domain** and **Client ID** to `.env` file
 
 ---
 

--- a/plugins/auth0-sdks/skills/auth0-vue/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-vue/references/setup.md
@@ -1,185 +1,46 @@
 # Auth0 Vue Setup Guide
 
-Complete setup instructions with automated scripts and manual configuration options.
+---
+
+## LLM Execution Instructions
+
+**You MUST follow these steps in order to set up Auth0. Execute each command and proceed to the next step.**
+
+1. Install the Auth0 CLI if not present
+2. Ensure user is logged in to Auth0
+3. Create a new Auth0 SPA application automatically
+4. Extract credentials from the CLI output
+5. Write credentials to `.env` file (after user confirmation)
+
+**Do NOT show users manual Dashboard instructions unless the CLI approach completely fails after multiple attempts.**
 
 ---
 
-## Quick Setup (Automated)
+## Step 1: Check for existing .env and get user confirmation
 
-**Never read the contents of `.env` at any point during setup.** The file may contain sensitive secrets that should not be exposed in the LLM context. If you determine you need to read the file for any reason, ask the user for explicit permission before doing so — do not proceed until the user confirms.
-
-**Before running any part of this setup that writes to `.env`, you MUST ask the user for explicit confirmation.** Follow the steps below precisely.
-
-### Step 1: Check for existing .env and confirm with user
-
-Before writing to `.env`, check whether the file already exists:
+Before doing anything, check if `.env` exists and ask user for permission:
 
 ```bash
 test -f .env && echo "EXISTS" || echo "NOT_FOUND"
 ```
 
-Then ask the user for explicit confirmation before proceeding — do not continue until the user confirms:
+**Then ask the user:**
+- If `.env` does **not** exist: "This setup will create a `.env` file with Auth0 credentials (domain and client ID). Proceed?"
+- If `.env` **exists**: "A `.env` file exists. This will append Auth0 credentials without modifying existing content. Proceed?"
 
-- If `.env` does **not** exist, ask:
-  - Question: "This setup will create a `.env` file containing Auth0 credentials (domain and client ID). Do you want to proceed?"
-  - Options: "Yes, create .env" / "No, I'll configure it manually"
-
-- If `.env` **already exists**, ask:
-  - Question: "A `.env` file already exists and may contain secrets unrelated to Auth0. This setup will append Auth0 credentials to it without modifying existing content. Do you want to proceed?"
-  - Options: "Yes, append to existing .env" / "No, I'll update it manually"
-
-**Do not proceed with writing to `.env` unless the user selects the confirmation option.**
-
-### Step 2: Run automated setup (only after confirmation)
-
-#### Bash Script (macOS/Linux)
-
-Run this script to automatically set up everything:
-
-```bash
-#!/bin/bash
-
-# Detect OS and install Auth0 CLI if needed
-if ! command -v auth0 &> /dev/null; then
-  echo "Installing Auth0 CLI..."
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
-  elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
-  fi
-fi
-
-# Check if logged in to Auth0
-if ! auth0 tenants list &> /dev/null; then
-  echo "======================================"
-  echo "Auth0 Login Required"
-  echo "======================================"
-  read -p "Do you have an Auth0 account? (y/n): " HAS_ACCOUNT
-
-  if [[ "$HAS_ACCOUNT" != "y" ]]; then
-    echo "Let's create your free Auth0 account!"
-    echo "1. Visit: https://auth0.com/signup"
-    echo "2. Sign up with your email or GitHub"
-    echo "3. Choose a tenant domain"
-    read -p "Press Enter when you've created your account..."
-  fi
-
-  auth0 login
-fi
-
-# List apps and prompt for selection
-echo "Your Auth0 applications:"
-auth0 apps list
-
-read -p "Enter your Auth0 app ID (or press Enter to create new): " APP_ID
-
-if [ -z "$APP_ID" ]; then
-  echo "Creating new Auth0 SPA application..."
-  APP_NAME="${PWD##*/}-vue-app"
-  APP_ID=$(auth0 apps create \
-    --name "$APP_NAME" \
-    --type spa \
-    --callbacks "http://localhost:5173,http://localhost:3000" \
-    --logout-urls "http://localhost:5173,http://localhost:3000" \
-    --origins "http://localhost:5173,http://localhost:3000" \
-    --web-origins "http://localhost:5173,http://localhost:3000" \
-    --metadata "created_by=agent_skills" \
-    --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
-  echo "Created app with ID: $APP_ID"
-fi
-
-# Get app details and create .env file
-echo "Fetching Auth0 credentials..."
-AUTH0_DOMAIN=$(auth0 apps show "$APP_ID" --json | grep -o '"domain":"[^"]*' | cut -d'"' -f4)
-AUTH0_CLIENT_ID=$(auth0 apps show "$APP_ID" --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
-
-# Append Auth0 credentials to .env
-cat >> .env << EOF
-VITE_AUTH0_DOMAIN=$AUTH0_DOMAIN
-VITE_AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID
-EOF
-
-echo "✅ Auth0 configuration complete!"
-echo "Appended to .env:"
-echo "  VITE_AUTH0_DOMAIN=$AUTH0_DOMAIN"
-echo "  VITE_AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID"
-```
-
-#### PowerShell Script (Windows)
-
-```powershell
-# Install Auth0 CLI if not present
-if (!(Get-Command auth0 -ErrorAction SilentlyContinue)) {
-  Write-Host "Installing Auth0 CLI..."
-  scoop install auth0
-}
-
-# Check if logged in
-try {
-  auth0 tenants list | Out-Null
-} catch {
-  Write-Host "======================================"
-  Write-Host "Auth0 Login Required"
-  Write-Host "======================================"
-
-  $hasAccount = Read-Host "Do you have an Auth0 account? (y/n)"
-
-  if ($hasAccount -ne "y") {
-    Write-Host "Let's create your free Auth0 account!"
-    Write-Host "1. Visit: https://auth0.com/signup"
-    Write-Host "2. Sign up with your email or GitHub"
-    Read-Host "Press Enter when you've created your account"
-  }
-
-  auth0 login
-}
-
-# List and select app
-Write-Host "Your Auth0 applications:"
-auth0 apps list
-
-$appId = Read-Host "Enter your Auth0 app ID (or press Enter to create new)"
-
-if ([string]::IsNullOrEmpty($appId)) {
-  $appName = Split-Path -Leaf (Get-Location)
-  Write-Host "Creating new Auth0 SPA application..."
-  $appJson = auth0 apps create --name "$appName-vue-app" --type spa `
-    --callbacks "http://localhost:5173,http://localhost:3000" `
-    --logout-urls "http://localhost:5173,http://localhost:3000" `
-    --origins "http://localhost:5173,http://localhost:3000" `
-    --web-origins "http://localhost:5173,http://localhost:3000" `
-    --metadata "created_by=agent_skills" --json
-
-  $appId = ($appJson | ConvertFrom-Json).client_id
-  Write-Host "Created app with ID: $appId"
-}
-
-# Get credentials and create .env
-Write-Host "Fetching Auth0 credentials..."
-$appDetails = auth0 apps show $appId --json | ConvertFrom-Json
-
-@"
-VITE_AUTH0_DOMAIN=$($appDetails.domain)
-VITE_AUTH0_CLIENT_ID=$($appDetails.client_id)
-"@ | Out-File -FilePath .env -Encoding UTF8 -Append
-
-Write-Host "✅ Auth0 configuration complete!"
-Write-Host "Appended to .env:"
-Write-Host "  VITE_AUTH0_DOMAIN=$($appDetails.domain)"
-Write-Host "  VITE_AUTH0_CLIENT_ID=$($appDetails.client_id)"
-```
+**Do not continue unless user confirms.**
 
 ---
 
-## Manual Setup
+## Step 2: Install Auth0 CLI
 
-### Step 1: Install SDK
+Check if Auth0 CLI is installed, install if needed:
 
 ```bash
-npm install @auth0/auth0-vue
+command -v auth0 &> /dev/null && echo "AUTH0_CLI_INSTALLED" || echo "AUTH0_CLI_NOT_FOUND"
 ```
 
-### Step 2: Install Auth0 CLI
+**If not installed, run the appropriate command for the user's OS:**
 
 **macOS:**
 ```bash
@@ -188,65 +49,118 @@ brew install auth0/auth0-cli/auth0
 
 **Linux:**
 ```bash
-curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
 ```
 
-**Windows:**
+**Windows (PowerShell):**
 ```powershell
 scoop install auth0
 ```
 
-### Step 3: Get Credentials
+---
+
+## Step 3: Ensure user is logged in to Auth0
+
+Check login status:
 
 ```bash
-# Login to Auth0
-auth0 login
-
-# List your apps
-auth0 apps list
-
-# Get app details
-auth0 apps show <app-id>
+auth0 tenants list 2>&1
 ```
 
-### Step 4: Create .env File
+**If the command fails or shows an error**, the user needs to log in:
 
 ```bash
-VITE_AUTH0_DOMAIN=<your-tenant>.auth0.com
-VITE_AUTH0_CLIENT_ID=<your-client-id>
+auth0 login
+```
+
+Tell the user: "A browser window will open. Please log in to your Auth0 account (or create one at https://auth0.com/signup if needed)."
+
+**Wait for user to complete login, then verify:**
+
+```bash
+auth0 tenants list
 ```
 
 ---
 
-## Creating Auth0 Application via Dashboard
+## Step 4: Create Auth0 Application
 
-1. Go to [Auth0 Dashboard](https://manage.auth0.com)
-2. Navigate to **Applications** → **Applications**
-3. Click **Create Application**
-4. Choose **Single Page Web Applications**
-5. Configure:
-   - **Allowed Callback URLs**: `http://localhost:5173, http://localhost:3000`
-   - **Allowed Logout URLs**: `http://localhost:5173, http://localhost:3000`
-   - **Allowed Web Origins**: `http://localhost:5173, http://localhost:3000`
-   - **Allowed Origins (CORS)**: `http://localhost:5173, http://localhost:3000`
-6. Copy your **Domain** and **Client ID**
-7. Create `.env` file as shown above
+**Create a new SPA application - run this single command:**
+
+```bash
+auth0 apps create \
+  --name "$(basename "$PWD")-vue-app" \
+  --type spa \
+  --callbacks "http://localhost:5173,http://localhost:3000" \
+  --logout-urls "http://localhost:5173,http://localhost:3000" \
+  --origins "http://localhost:5173,http://localhost:3000" \
+  --web-origins "http://localhost:5173,http://localhost:3000" \
+  --metadata "created_by=agent_skills" \
+  --json
+```
+
+**This outputs JSON. Extract these values from the response:**
+- `client_id` - This is your Auth0 Client ID
+- `domain` - This is your Auth0 Domain (in the format `xxx.auth0.com` or `xxx.us.auth0.com`)
+
+**Example output parsing:**
+```bash
+# The command above outputs JSON like:
+# {"client_id":"abc123","domain":"dev-example.us.auth0.com",...}
+# Extract client_id and domain from this output
+```
+
+---
+
+## Step 5: Write credentials to .env
+
+**Write the following to `.env`:**
+
+```bash
+cat >> .env << 'EOF'
+VITE_AUTH0_DOMAIN=<domain-from-step-4>
+VITE_AUTH0_CLIENT_ID=<client_id-from-step-4>
+EOF
+```
+
+**Replace `<domain-from-step-4>` and `<client_id-from-step-4>` with actual values from the JSON output.**
+
+---
+
+## Step 6: Install SDK
+
+```bash
+npm install @auth0/auth0-vue
+```
+
+---
+
+## Verification
+
+After setup, confirm to the user:
+- Auth0 application created successfully
+- Credentials written to `.env`
+- SDK installed
+
+Tell them to restart their dev server to load the new environment variables.
 
 ---
 
 ## Troubleshooting
 
-### Environment Variables Not Loading
+### CLI Installation Issues
 
-**Issue**: Variables not available in app
+**macOS - Homebrew not found:**
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
 
-**Solution:**
-- Ensure variables start with `VITE_` prefix
-- Restart dev server after creating `.env`
-- Check file is named exactly `.env` (not `.env.local`)
-- Vite only loads variables at build time, not runtime
+**Windows - Scoop not found:**
+```powershell
+iwr -useb get.scoop.sh | iex
+```
 
-### Auth0 CLI Issues
+### Login Issues
 
 **Browser doesn't open:**
 ```bash
@@ -258,14 +172,35 @@ auth0 login --no-browser
 auth0 login --force
 ```
 
+### Environment Variable Issues
+
+- Variables must start with `VITE_` prefix for Vite projects
+- Restart dev server after modifying `.env`
+- Vite only loads variables at build time, not runtime
+
 ### CORS Errors
 
-**Issue**: CORS errors when logging in
+Add your app URL to "Allowed Web Origins" in Auth0 Dashboard or update via CLI:
 
-**Solution:**
-- Add your app URL to "Allowed Web Origins" in Auth0 Dashboard
-- Ensure callback URLs include protocol (`http://` or `https://`)
-- For local dev, use `http://localhost:5173` (Vite default)
+```bash
+auth0 apps update <app-id> --web-origins "http://localhost:5173,http://localhost:3000"
+```
+
+---
+
+## Fallback: Manual Dashboard Setup
+
+**Only use this if the CLI approach fails completely after troubleshooting.**
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com)
+2. Navigate to **Applications** → **Applications**
+3. Click **Create Application**
+4. Choose **Single Page Web Applications**
+5. Configure:
+   - **Allowed Callback URLs**: `http://localhost:5173, http://localhost:3000`
+   - **Allowed Logout URLs**: `http://localhost:5173, http://localhost:3000`
+   - **Allowed Web Origins**: `http://localhost:5173, http://localhost:3000`
+6. Copy **Domain** and **Client ID** to `.env` file
 
 ---
 

--- a/plugins/auth0/skills/auth0-mfa/SKILL.md
+++ b/plugins/auth0/skills/auth0-mfa/SKILL.md
@@ -47,16 +47,9 @@ Multi-Factor Authentication (MFA) requires users to provide two or more verifica
 
 ## Step 1: Enable MFA in Tenant
 
-### Via Auth0 Dashboard
+**You MUST use the Auth0 CLI to configure MFA.** Do NOT instruct users to manually configure MFA via the Auth0 Dashboard.
 
-1. Go to **Security → Multi-factor Auth**
-2. Enable desired factors (TOTP, SMS, etc.)
-3. Configure **Policies**:
-   - **Always** - Require MFA for all logins
-   - **Adaptive** - Risk-based MFA
-   - **Never** - Disable MFA (use step-up instead)
-
-### Via Auth0 CLI
+### Using Auth0 CLI (Required)
 
 ```bash
 # View current MFA configuration

--- a/plugins/auth0/skills/auth0-migration/references/user-import.md
+++ b/plugins/auth0/skills/auth0-migration/references/user-import.md
@@ -305,23 +305,9 @@ Auth0 supports these password hashing algorithms:
 
 ## Importing to Auth0
 
-### Method 1: Auth0 Dashboard
+**You MUST use the Auth0 CLI or Management API to import users.** Do NOT instruct users to manually import via the Auth0 Dashboard.
 
-**Steps:**
-1. Go to Auth0 Dashboard
-2. Navigate to **Authentication → Database → [Your Connection]**
-3. Click **Users** tab
-4. Click **Import Users** button
-5. Upload your JSON file
-6. Review and confirm
-
-**Limitations:**
-- File size: Max 500KB per upload
-- Users per file: Recommended max 10,000
-
----
-
-### Method 2: Auth0 CLI
+### Method 1: Auth0 CLI (Recommended)
 
 **Prerequisites:**
 ```bash
@@ -350,7 +336,7 @@ auth0 api get "jobs/{job-id}"
 
 ---
 
-### Method 3: Management API
+### Method 2: Management API
 
 **Using curl:**
 ```bash

--- a/plugins/auth0/skills/auth0-quickstart/SKILL.md
+++ b/plugins/auth0/skills/auth0-quickstart/SKILL.md
@@ -9,6 +9,19 @@ Detect your framework and get started with Auth0 authentication.
 
 ---
 
+## IMPORTANT: CLI-First Requirement
+
+**You MUST use the Auth0 CLI to create applications and configure credentials.** Do NOT instruct users to manually create applications via the Auth0 Dashboard. The Auth0 CLI:
+
+- Automatically installs on macOS, Linux, and Windows
+- Handles authentication and account creation
+- Creates applications with correct settings for each framework type
+- Fetches credentials and can write them directly to environment files
+
+**Always use the CLI commands below.** Only fall back to manual CLI commands if the automated scripts in the framework-specific skills fail. Never fall back to Dashboard instructions.
+
+---
+
 ## Step 1: Detect Your Framework
 
 **Run this command to identify your framework:**
@@ -36,27 +49,42 @@ ls -la | grep -E "angular.json|vue.config.js|next.config"
 
 ---
 
-## Step 2: Auth0 Account Setup
+## Step 2: Auth0 Account Setup (REQUIRED)
+
+**You MUST install and use the Auth0 CLI.** Run this automated installation:
 
 ### Install Auth0 CLI
 
-**macOS/Linux:**
 ```bash
-brew install auth0/auth0-cli/auth0
+#!/bin/bash
+# Detect OS and install Auth0 CLI
+if ! command -v auth0 &> /dev/null; then
+  echo "Installing Auth0 CLI..."
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    brew install auth0/auth0-cli/auth0
+  elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
+  elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+    scoop install auth0
+  fi
+fi
 ```
 
-**Windows:**
-```bash
-scoop install auth0
-# Or: choco install auth0-cli
+**For Windows PowerShell:**
+```powershell
+if (!(Get-Command auth0 -ErrorAction SilentlyContinue)) {
+  scoop install auth0
+}
 ```
-
-**Full installation guide:** See [CLI Reference](references/cli.md#installation)
 
 ### Login to Auth0
 
 ```bash
-auth0 login
+# Check if logged in, login if needed
+if ! auth0 tenants list &> /dev/null; then
+  echo "Visit https://auth0.com/signup if you need an account"
+  auth0 login
+fi
 ```
 
 This opens your browser to authenticate with Auth0.


### PR DESCRIPTION
### Description
 When Auth0 skills (quickstart, migration, SDK-specific) are invoked, LLMs rarely use the Auth0 CLI to automatically create applications and configure credentials. Instead, they default to showing manual Dashboard instructions, requiring users to manually create apps, copy values, and paste them into .env files.
 
 Restructured all Auth0 skill setup files to be LLM-optimized for oneshot execution:
  1. Added "LLM Execution Instructions" at the top of each setup file with explicit directives to use CLI
  2. Replaced interactive bash scripts with sequential, non-interactive commands that LLMs can execute step-by-step
  3. Moved Dashboard instructions to "Fallback Only" sections, clearly marked as last resort
  4. Added clear JSON output parsing instructions so LLMs know exactly what credentials to extract
  5. Standardized the pattern across all SDK setup files (React, Next.js, Vue, Angular, Express, React Native, Nuxt)

### References


### Testing
Manually tested


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
