### PR TITLE
fix: remove displayName from plugins

### DIFF
--- a/plugins/auth0-sdks/.claude-plugin/plugin.json
+++ b/plugins/auth0-sdks/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "auth0-sdks",
-  "displayName": "Auth0 SDK Skills",
   "version": "1.0.0",
   "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Angular, Express, Fastify, and React Native with complete implementation guides."
 }

--- a/plugins/auth0/.claude-plugin/plugin.json
+++ b/plugins/auth0/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "auth0",
-  "displayName": "Auth0 Skills",
   "version": "1.0.0",
   "description": "Essential Auth0 skills including quickstarts, migration from other providers, and Multi-Factor Authentication (MFA)."
 }


### PR DESCRIPTION
### Description

Removes displayName from the plugin's json files.


### References

Closes #15 

### Testing

- Have Claude Code version 2.1.62 installed
- Start Claude Code in CLI (on Mac Terminal)
- Run '/plugin marketplace add auth0/agent-skills'
- Run '/plugin'
- Navigate to "Marketplaces"
- Select "auth0-agent-skills"
- Select "Browse plugins (2)"
- Select one of the plugins
- Select "Install for you..." (all types fail)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
