### PR TITLE
fix: include nuxt and fastify in plugin and marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
     {
       "name": "auth0-sdks",
       "source": "./plugins/auth0-sdks",
-      "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Angular, Express, and React Native with complete implementation guides.",
+      "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, and React Native with complete implementation guides.",
       "version": "1.0.0",
       "repository": "https://github.com/auth0/agent-skills.git",
       "license": "Apache-2.0",
@@ -36,8 +36,11 @@
         "react",
         "nextjs",
         "vue",
+        "nuxt",
         "angular",
         "express",
+        "fastify",
+        "fastify-api",
         "react-native"
       ],
       "category": "sdk"

--- a/plugins/auth0-sdks/.claude-plugin/plugin.json
+++ b/plugins/auth0-sdks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "auth0-sdks",
   "version": "1.0.0",
-  "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Angular, Express, Fastify, and React Native with complete implementation guides."
+  "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, and React Native with complete implementation guides."
 }


### PR DESCRIPTION
### Description

Include nuxt and fastify in both plugin and marketplace metadata.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
