### PR TITLE
chore: use encodeURIComponent

### DIFF
--- a/plugins/auth0-sdks/skills/auth0-nuxt/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-nuxt/SKILL.md
@@ -116,7 +116,7 @@ const user = useUser();
 ```typescript
 // middleware/auth.ts - Client navigation
 export default defineNuxtRouteMiddleware((to) => {
-  if (!useUser().value) return navigateTo(`/auth/login?returnTo=${to.path}`);
+  if (!useUser().value) return navigateTo(`/auth/login?returnTo=${encodeURIComponent(to.path)}`);
 });
 ```
 
@@ -127,7 +127,7 @@ export default defineEventHandler(async (event) => {
   const auth0Client = useAuth0(event);
   const session = await auth0Client.getSession();
   if (!session)  {
-    return sendRedirect(event, `/auth/login?returnTo=${url.pathname}`);
+    return sendRedirect(event, `/auth/login?returnTo=${encodeURIComponent(url.pathname)}`);
   }
 });
 ```

--- a/plugins/auth0-sdks/skills/auth0-nuxt/references/examples.md
+++ b/plugins/auth0-sdks/skills/auth0-nuxt/references/examples.md
@@ -24,7 +24,7 @@ const route = useRoute();
         <a v-if="user" :href="`/auth/logout`">
           Logout ({{ user.name }})
         </a>
-        <a v-else :href="`/auth/login?returnTo=${route.path}`">
+        <a v-else :href="`/auth/login?returnTo=${encodeURIComponent(route.path)}`">
           Login
         </a>
       </div>
@@ -423,7 +423,7 @@ export default defineEventHandler(async (event) => {
 const handleLogin = async () => {
   // Enhanced behavior with JavaScript
   const returnTo = useRoute().fullPath;
-  await navigateTo(`/auth/login?returnTo=${returnTo}`);
+  await navigateTo(`/auth/login?returnTo=${encodeURIComponent(returnTo)}`);
 };
 </script>
 ```

--- a/plugins/auth0-sdks/skills/auth0-nuxt/references/route-protection.md
+++ b/plugins/auth0-sdks/skills/auth0-nuxt/references/route-protection.md
@@ -21,7 +21,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const user = useUser();
 
   if (!user.value) {
-    return navigateTo(`/auth/login?returnTo=${to.path}`);
+    return navigateTo(`/auth/login?returnTo=${encodeURIComponent(to.path)}`);
   }
 });
 ```
@@ -49,7 +49,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const user = useUser();
 
   if (!user.value) {
-    return navigateTo(`/auth/login?returnTo=${to.path}`);
+    return navigateTo(`/auth/login?returnTo=${encodeURIComponent(to.path)}`);
   }
 
   // Check for admin role
@@ -77,7 +77,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const user = useUser();
 
   if (!user.value) {
-    return navigateTo(`/auth/login?returnTo=${to.path}`);
+    return navigateTo(`/auth/login?returnTo=${encodeURIComponent(to.path)}`);
   }
 
   // Check for specific permission
@@ -130,7 +130,7 @@ export default defineEventHandler(async (event) => {
     const session = await auth0Client.getSession();
 
     if (!session) {
-      return sendRedirect(event, `/auth/login?returnTo=${url.pathname}`);
+      return sendRedirect(event, `/auth/login?returnTo=${encodeURIComponent(url.pathname)}`);
     }
   }
 });
@@ -154,7 +154,7 @@ export default defineEventHandler(async (event) => {
     const session = await auth0Client.getSession();
 
     if (!session) {
-      return sendRedirect(event, `/auth/login?returnTo=${url.pathname}`);
+      return sendRedirect(event, `/auth/login?returnTo=${encodeURIComponent(url.pathname)}`);
     }
   }
 });
@@ -172,7 +172,7 @@ export default defineEventHandler(async (event) => {
     const session = await auth0Client.getSession();
 
     if (!session) {
-      return sendRedirect(event, `/auth/login?returnTo=${url.pathname}`);
+      return sendRedirect(event, `/auth/login?returnTo=${encodeURIComponent(url.pathname)}`);
     }
 
     const user = await auth0Client.getUser();
@@ -322,7 +322,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
 
   const user = useUser();
   if (!user.value) {
-    return navigateTo(`/auth/login?returnTo=${to.path}`);
+    return navigateTo(`/auth/login?returnTo=${encodeURIComponent(to.path)}`);
   }
 });
 ```
@@ -335,7 +335,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const user = useUser();
 
   if (!user.value) {
-    return navigateTo(`/auth/login?returnTo=${to.path}`);
+    return navigateTo(`/auth/login?returnTo=${encodeURIComponent(to.path)}`);
   }
 
   const subscription = user.value['https://my-app.com/subscription'];
@@ -390,7 +390,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const user = useUser();
 
   if (!user.value) {
-    return navigateTo(`/auth/login?returnTo=${to.path}`);
+    return navigateTo(`/auth/login?returnTo=${encodeURIComponent(to.path)}`);
   }
 
   if (!user.value.email_verified) {
@@ -409,7 +409,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   <div>
     <h1>Unauthorized</h1>
     <p>You need to log in to access this page.</p>
-    <a :href="`/auth/login?returnTo=${$route.query.returnTo || '/'}`">
+    <a :href="`/auth/login?returnTo=${encodeURIComponent($route.query.returnTo || '/')}`">
       Log In
     </a>
   </div>


### PR DESCRIPTION
### Description

Passing `pathname` to a query parameter typically does not contain special characters or query parameters. However, as users may change the code at a later point to use something else, it's a good practise to always use `encodeURIComponent`.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
