### PR TITLE
fix: update auth0-nextjs skill for src/ convention, v4 env vars, and import paths

### DIFF
--- a/plugins/auth0-sdks/skills/auth0-nextjs/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-nextjs/SKILL.md
@@ -54,7 +54,11 @@ Generate secret: `openssl rand -hex 32`
 
 ### 3. Create Auth0 Client and Middleware
 
-Create `lib/auth0.ts`:
+**Detect project structure first:** Check whether the project uses a `src/` directory (i.e. `src/app/` or `src/pages/` exists). This determines where to place files:
+- **With `src/`:** `src/lib/auth0.ts`, `src/middleware.ts` (or `src/proxy.ts` for Next.js 16)
+- **Without `src/`:** `lib/auth0.ts`, `middleware.ts` (or `proxy.ts` for Next.js 16)
+
+Create `lib/auth0.ts` (or `src/lib/auth0.ts` if using the `src/` convention):
 
 ```typescript
 import { Auth0Client } from '@auth0/nextjs-auth0/server';
@@ -70,11 +74,11 @@ export const auth0 = new Auth0Client({
 
 **Middleware Configuration (Next.js 15 vs 16):**
 
-**Next.js 15** - Create `middleware.ts` at project root:
+**Next.js 15** - Create `middleware.ts` (at project root, or `src/middleware.ts` if using `src/`):
 
 ```typescript
 import { NextRequest } from 'next/server';
-import { auth0 } from './lib/auth0';
+import { auth0 } from '@/lib/auth0';
 
 export async function middleware(request: NextRequest) {
   return await auth0.middleware(request);
@@ -89,11 +93,11 @@ export const config = {
 
 **Next.js 16** - You have two options:
 
-**Option 1:** Use `middleware.ts` (same as Next.js 15):
+**Option 1:** Use `middleware.ts` (same as Next.js 15, same `src/` placement rules):
 
 ```typescript
 import { NextRequest } from 'next/server';
-import { auth0 } from './lib/auth0';
+import { auth0 } from '@/lib/auth0';
 
 export async function middleware(request: NextRequest) {
   return await auth0.middleware(request);
@@ -106,11 +110,11 @@ export const config = {
 };
 ```
 
-**Option 2:** Use `proxy.ts` at project root:
+**Option 2:** Use `proxy.ts` (at project root, or `src/proxy.ts` if using `src/`):
 
 ```typescript
 import { NextRequest } from 'next/server';
-import { auth0 } from './lib/auth0';
+import { auth0 } from '@/lib/auth0';
 
 export async function proxy(request: NextRequest) {
   return await auth0.middleware(request);
@@ -137,7 +141,7 @@ This automatically creates endpoints:
 
 ```typescript
 import { Auth0Provider } from '@auth0/nextjs-auth0/client';
-import { auth0 } from './lib/auth0';
+import { auth0 } from '@/lib/auth0';
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const session = await auth0.getSession();
@@ -243,10 +247,11 @@ Visit `http://localhost:3000` and test the login flow.
 ## Quick Reference
 
 **V4 Setup:**
-- Create `lib/auth0.ts` with `Auth0Client` instance
+- Detect `src/` convention: check if `src/app/` or `src/pages/` exists — place all files inside `src/` if so
+- Create `lib/auth0.ts` (or `src/lib/auth0.ts`) with `Auth0Client` instance
 - Create middleware configuration (required):
-  - Next.js 15: `middleware.ts` with `middleware()` function
-  - Next.js 16: `middleware.ts` with `middleware()` OR `proxy.ts` with `proxy()` function
+  - Next.js 15: `middleware.ts` (or `src/middleware.ts`) with `middleware()` function
+  - Next.js 16: `middleware.ts` with `middleware()` OR `proxy.ts` with `proxy()` function (same `src/` rules)
 - Optional: Wrap with `<Auth0Provider>` for SSR user
 
 **Client-Side Hooks:**

--- a/plugins/auth0-sdks/skills/auth0-nextjs/references/integration.md
+++ b/plugins/auth0-sdks/skills/auth0-nextjs/references/integration.md
@@ -106,12 +106,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 Protect multiple routes with middleware.
 
-**Next.js 15** - Use `middleware.ts`:
+**File placement:** If the project uses a `src/` directory (i.e. `src/app/` exists), place `middleware.ts` or `proxy.ts` inside `src/`. Otherwise, place at the project root.
+
+**Next.js 15** - Use `middleware.ts` (or `src/middleware.ts`):
 
 ```typescript
 // middleware.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { auth0 } from './lib/auth0';
+import { auth0 } from '@/lib/auth0';
 
 export async function middleware(request: NextRequest) {
   const authRes = await auth0.middleware(request);
@@ -144,12 +146,12 @@ export const config = {
 };
 ```
 
-**Next.js 16** - Use either `middleware.ts` (same as above) or `proxy.ts`:
+**Next.js 16** - Use either `middleware.ts` (same as above) or `proxy.ts` (same `src/` placement rules):
 
 ```typescript
 // proxy.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { auth0 } from './lib/auth0';
+import { auth0 } from '@/lib/auth0';
 
 export async function proxy(request: NextRequest) {
   const authRes = await auth0.middleware(request);

--- a/plugins/auth0-sdks/skills/auth0-nextjs/references/setup.md
+++ b/plugins/auth0-sdks/skills/auth0-nextjs/references/setup.md
@@ -30,7 +30,7 @@ Then ask the user for explicit confirmation before proceeding — do not continu
   - Options: "Yes, append to existing .env" / "No, I'll update it manually"
 
 - If neither exists, ask:
-  - Question: "This setup will create a `.env.local` file containing Auth0 credentials (AUTH0_CLIENT_ID, AUTH0_ISSUER_BASE_URL, AUTH0_SECRET) and a placeholder for AUTH0_CLIENT_SECRET that you will need to fill in manually. Do you want to proceed?"
+  - Question: "This setup will create a `.env.local` file containing Auth0 credentials (AUTH0_CLIENT_ID, AUTH0_DOMAIN, AUTH0_SECRET) and a placeholder for AUTH0_CLIENT_SECRET that you will need to fill in manually. Do you want to proceed?"
   - Options: "Yes, create .env.local" / "No, I'll configure it manually"
 
 **Do not proceed with writing to any env file unless the user selects the confirmation option.**
@@ -60,7 +60,7 @@ if [ -z "$APP_ID" ]; then
   APP_ID=$(auth0 apps create \
     --name "${PWD##*/}-nextjs" \
     --type regular \
-    --callbacks "http://localhost:3000/api/auth/callback" \
+    --callbacks "http://localhost:3000/auth/callback" \
     --logout-urls "http://localhost:3000" \
     --metadata "created_by=agent_skills" \
     --json | grep -o '"client_id":"[^"]*' | cut -d'"' -f4)
@@ -85,8 +85,8 @@ fi
 # Append Auth0 credentials
 cat >> "$TARGET_FILE" << ENVEOF
 AUTH0_SECRET=$AUTH0_SECRET
-AUTH0_BASE_URL=http://localhost:3000
-AUTH0_ISSUER_BASE_URL=https://$AUTH0_DOMAIN
+APP_BASE_URL=http://localhost:3000
+AUTH0_DOMAIN=$AUTH0_DOMAIN
 AUTH0_CLIENT_ID=$AUTH0_CLIENT_ID
 AUTH0_CLIENT_SECRET='YOUR_CLIENT_SECRET'
 ENVEOF
@@ -112,8 +112,8 @@ npm install @auth0/nextjs-auth0
 
 ```bash
 AUTH0_SECRET=<openssl-rand-hex-32>
-AUTH0_BASE_URL=http://localhost:3000
-AUTH0_ISSUER_BASE_URL=https://your-tenant.auth0.com
+APP_BASE_URL=http://localhost:3000
+AUTH0_DOMAIN=your-tenant.auth0.com
 AUTH0_CLIENT_ID=your-client-id
 AUTH0_CLIENT_SECRET=your-client-secret
 ```
@@ -129,14 +129,14 @@ Via CLI:
 ```bash
 auth0 login
 auth0 apps create --name "My Next.js App" --type regular \
-  --callbacks "http://localhost:3000/api/auth/callback" \
+  --callbacks "http://localhost:3000/auth/callback" \
   --logout-urls "http://localhost:3000"
 ```
 
 Via Dashboard:
 1. Create **Regular Web Application**
 2. Configure:
-   - Allowed Callback URLs: `http://localhost:3000/api/auth/callback`
+   - Allowed Callback URLs: `http://localhost:3000/auth/callback`
    - Allowed Logout URLs: `http://localhost:3000`
 3. Copy credentials to `.env.local`
 
@@ -153,8 +153,8 @@ Via Dashboard:
 - Verify client secret copied correctly
 
 **Callback URL mismatch:**
-- Ensure `/api/auth/callback` is in Allowed Callback URLs
-- Check `AUTH0_BASE_URL` matches your domain
+- Ensure `/auth/callback` is in Allowed Callback URLs
+- Check `APP_BASE_URL` matches your domain
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix middleware/proxy file placement to account for `src/` directory convention in Next.js projects
- Fix import paths in middleware examples from relative (`'./lib/auth0'`) to alias (`'@/lib/auth0'`)
- Update setup.md from stale v3 env vars (`AUTH0_BASE_URL`, `AUTH0_ISSUER_BASE_URL`) to v4 equivalents (`APP_BASE_URL`, `AUTH0_DOMAIN`)
- Update setup.md callback URLs from v3 `/api/auth/callback` to v4 `/auth/callback`