### PR TITLE
chore: add claudelint

### DIFF
--- a/.claudelint.yaml
+++ b/.claudelint.yaml
@@ -1,0 +1,109 @@
+# claudelint configuration
+# See https://github.com/stbenjam/claudelint for more information
+
+# Enable/disable rules with configurable severity levels
+rules:
+  # Plugin Structure
+  plugin-json-required:
+    enabled: true
+    severity: error
+
+  plugin-json-valid:
+    enabled: true
+    severity: error
+
+  plugin-naming:
+    enabled: true
+    severity: warning
+
+  # Disabled for skills-only marketplace
+  commands-dir-required:
+    enabled: false
+    severity: warning
+
+  # Require at least one command file; start as info locally
+  commands-exist:
+    enabled: true
+    severity: info
+
+  plugin-readme:
+    enabled: true
+    severity: warning
+
+  # Command Format
+  command-naming:
+    enabled: true
+    severity: warning
+
+  command-frontmatter:
+    enabled: true
+    severity: error
+
+  # Checks for Name, Synopsis, Description, Implementation sections
+  command-sections:
+    enabled: true
+    severity: warning
+
+  # Enforce "plugin:command" format
+  command-name-format:
+    enabled: true
+    severity: warning
+
+  # Marketplace (auto on marketplace repos)
+  marketplace-json-valid:
+    enabled: auto
+    severity: error
+
+  marketplace-registration:
+    enabled: auto
+    severity: error
+
+  # Skills
+  skill-frontmatter:
+    enabled: true
+    severity: warning
+
+  # Custom: Enforce Agent Skills specification directory structure
+  skill-directory-structure:
+    enabled: true
+    severity: error
+
+  # Custom: Enforce that all skills are documented in plugin README.md
+  skill-readme-documentation:
+    enabled: true
+    severity: error
+
+  # Custom: Enforce kebab-case naming for markdown files in skills/
+  skill-markdown-naming:
+    enabled: true
+    severity: error
+
+  # Custom: Enforce license and metadata.author in SKILL.md frontmatter
+  skill-required-metadata:
+    enabled: true
+    severity: error
+
+# Custom rules for marketplace-specific validation
+custom-rules:
+  - ./.claudelint/rules.py
+
+# Exclusions
+exclude:
+- "**/node_modules/**"
+- "**/.git/**"
+- "**/dist/**"
+- "**/build/**"
+- "**/.venv/**"
+- "**/__pycache__/**"
+- "**/*.min.*"
+- "**/*.lock"
+- "**/.DS_Store"
+- "**/.idea/**"
+- "**/.vscode/**"
+- "**/coverage/**"
+- "**/tmp/**"
+- "**/tests/fixtures/**"    # allow test data to be messy
+- "**/examples/**"          # sample code often incomplete
+
+# Strict mode
+strict: true

--- a/.claudelint/rules.py
+++ b/.claudelint/rules.py
@@ -1,0 +1,484 @@
+"""
+Custom claudelint rules for agent-skills repository, enforcing Agent Skills specification and marketplace conventions.
+"""
+
+import re
+import yaml
+from pathlib import Path
+from typing import List, Optional, Dict, Any
+
+try:
+    # Try importing from claudelint package (when installed via pip/uvx)
+    from claudelint.src.rule import Rule, RuleViolation, Severity
+    from claudelint.src.context import RepositoryContext
+except ImportError:
+    try:
+        # Fallback for development environment
+        from src.rule import Rule, RuleViolation, Severity
+        from src.context import RepositoryContext
+    except ImportError:
+        # Final fallback
+        from claudelint import Rule, RuleViolation, Severity, RepositoryContext
+
+
+class SkillDirectoryStructureRule(Rule):
+    """
+    Enforce Agent Skills specification directory structure.
+
+    Only SKILL.md should exist in the skill root directory.
+    All other content must be organized in optional directories:
+    - scripts/     - Executable code
+    - references/  - Additional documentation
+    - assets/      - Static resources (templates, images, data files)
+    - tests/       - Validation artifacts (TDD transcripts, test data)
+    """
+
+    # Allowed directories per Agent Skills spec (plus tests/ for validation artifacts)
+    ALLOWED_DIRS = {'scripts', 'references', 'assets', 'tests'}
+
+    # Files that are allowed in skill root
+    ALLOWED_ROOT_FILES = {'SKILL.md', '.gitignore', '.gitkeep'}
+
+    @property
+    def rule_id(self) -> str:
+        return "skill-directory-structure"
+
+    @property
+    def description(self) -> str:
+        return "Skills must follow Agent Skills specification: only SKILL.md in root, other content in scripts/, references/, assets/, or tests/"
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+
+        # Find all skill directories across all plugins
+        for plugin_path in context.plugins:
+            skills_dir = plugin_path / "skills"
+            if not skills_dir.exists():
+                continue
+
+            # Check each skill directory
+            for skill_dir in skills_dir.iterdir():
+                if not skill_dir.is_dir():
+                    continue
+
+                # Skip hidden directories
+                if skill_dir.name.startswith('.'):
+                    continue
+
+                violations.extend(self._check_skill_directory(skill_dir))
+
+        return violations
+
+    def _check_skill_directory(self, skill_dir: Path) -> List[RuleViolation]:
+        """Check a single skill directory for structure violations."""
+        violations = []
+
+        # Check if SKILL.md exists (should be enforced by another rule, but good to check)
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            # Skip checking structure if no SKILL.md (another rule should catch this)
+            return violations
+
+        # Check all items in skill root
+        for item in skill_dir.iterdir():
+            item_name = item.name
+
+            # Allow hidden files/dirs (e.g., .gitignore, .git)
+            if item_name.startswith('.'):
+                continue
+
+            if item.is_dir():
+                # Check if directory is allowed
+                if item_name not in self.ALLOWED_DIRS:
+                    violations.append(
+                        self.violation(
+                            f"Unexpected directory '{item_name}/' in skill root. "
+                            f"Only 'scripts/', 'references/', 'assets/', and 'tests/' "
+                            f"directories are allowed. Move content to an appropriate directory.",
+                            file_path=item
+                        )
+                    )
+            else:
+                # Check if file is allowed in root
+                if item_name not in self.ALLOWED_ROOT_FILES:
+                    # Determine appropriate directory based on file extension/type
+                    suggestion = self._suggest_directory(item)
+
+                    violations.append(
+                        self.violation(
+                            f"File '{item_name}' should not be in skill root. "
+                            f"Per Agent Skills spec, only SKILL.md should be in root. "
+                            f"{suggestion}",
+                            file_path=item
+                        )
+                    )
+
+        return violations
+
+    def _suggest_directory(self, file_path: Path) -> str:
+        """Suggest appropriate directory based on file type."""
+        suffix = file_path.suffix.lower()
+        name = file_path.name.lower()
+
+        # Config files belong in scripts/
+        config_files = {'package.json', 'package-lock.json', 'tsconfig.json', 'jest.config.json',
+                       'jest.config.js', 'babel.config.js', '.eslintrc.json', '.prettierrc.json'}
+        if name in config_files:
+            return "Move to 'scripts/' directory."
+
+        # Scripts
+        if suffix in {'.py', '.sh', '.js', '.ts', '.bash', '.zsh'} or not suffix:
+            try:
+                if file_path.stat().st_mode & 0o111:  # Check if executable
+                    return "Move to 'scripts/' directory."
+            except (OSError, PermissionError):
+                # If we can't check permissions, suggest scripts/ for script extensions
+                if suffix in {'.py', '.sh', '.js', '.ts', '.bash', '.zsh'}:
+                    return "Move to 'scripts/' directory."
+
+        # Documentation
+        if suffix in {'.md', '.txt', '.rst', '.adoc'}:
+            if name != 'skill.md':
+                return "Move to 'references/' directory."
+
+        # Assets (images, templates, data) - excluding config files handled above
+        if suffix in {'.png', '.jpg', '.jpeg', '.gif', '.svg', '.xml', '.csv', '.template', '.tmpl'}:
+            return "Move to 'assets/' directory."
+
+        # Generic JSON/YAML files (not config) go to assets
+        if suffix in {'.json', '.yaml', '.yml'} and name not in config_files:
+            return "Move to 'assets/' directory."
+
+        # Default suggestion
+        return "Move to 'scripts/', 'references/', or 'assets/' as appropriate."
+
+
+class SkillReadmeDocumentationRule(Rule):
+    """
+    Enforce that all skills are documented in plugin README.md.
+
+    Each skill in the skills/ directory must have a corresponding entry
+    in the plugin's README.md file to ensure discoverability.
+    """
+
+    @property
+    def rule_id(self) -> str:
+        return "skill-readme-documentation"
+
+    @property
+    def description(self) -> str:
+        return "All skills must be documented in plugin README.md"
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+
+        # Check each plugin
+        for plugin_path in context.plugins:
+            skills_dir = plugin_path / "skills"
+            readme_path = plugin_path / "README.md"
+
+            # Skip if no skills directory
+            if not skills_dir.exists():
+                continue
+
+            # Get all skill directories that have SKILL.md
+            skill_names = {
+                skill_dir.name
+                for skill_dir in skills_dir.iterdir()
+                if skill_dir.is_dir()
+                and not skill_dir.name.startswith(".")
+                and (skill_dir / "SKILL.md").exists()
+            }
+
+            # Skip if no skills found
+            if not skill_names:
+                continue
+
+            # Check if README exists
+            if not readme_path.exists():
+                violations.append(
+                    self.violation(
+                        f"Plugin has {len(skill_names)} skill(s) but no README.md to document them",
+                        file_path=plugin_path
+                    )
+                )
+                continue
+
+            # Read README content
+            try:
+                readme_content = readme_path.read_text()
+            except Exception as e:
+                violations.append(
+                    self.violation(
+                        f"Could not read README.md: {e}",
+                        file_path=readme_path
+                    )
+                )
+                continue
+
+            # Find undocumented skills
+            # Look for skill references in README (skill name as link target or table entry)
+            undocumented = []
+            for skill_name in sorted(skill_names):
+                # Check multiple patterns:
+                # - **[skill-name](./skills/skill-name/)**
+                # - [skill-name](./skills/skill-name/)
+                # - ./skills/skill-name/
+                # - (./skills/skill-name/SKILL.md)
+                patterns_to_check = [
+                    f"./skills/{skill_name}/",
+                    f"**[{skill_name}](",
+                    f"[{skill_name}](",
+                    f"/{skill_name}/",
+                ]
+
+                found = any(pattern in readme_content for pattern in patterns_to_check)
+
+                if not found:
+                    undocumented.append(skill_name)
+
+            # Report violations for undocumented skills
+            for skill_name in undocumented:
+                violations.append(
+                    self.violation(
+                        f"Skill '{skill_name}' exists but is not documented in README.md. "
+                        f"Add an entry to the skills table linking to ./skills/{skill_name}/",
+                        file_path=skills_dir / skill_name
+                    )
+                )
+
+        return violations
+
+
+class SkillMarkdownNamingRule(Rule):
+    """
+    Enforce markdown file naming conventions in skills/ directories.
+
+    - Only SKILL.md is allowed as a .md file in the root of a skill folder
+    - All other .md files (in subdirectories) must be kebab-case
+    - SKILL.md and README.md are exempt from the kebab-case requirement
+    """
+
+    # Pattern for valid kebab-case filenames (without extension)
+    KEBAB_CASE_RE = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
+
+    # Markdown files exempt from kebab-case requirement
+    EXEMPT_NAMES = {'SKILL.md', 'README.md'}
+
+    @property
+    def rule_id(self) -> str:
+        return "skill-markdown-naming"
+
+    @property
+    def description(self) -> str:
+        return "Markdown files in skills/ must be kebab-case (except SKILL.md and README.md), and only SKILL.md is allowed at the skill root"
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+
+        for plugin_path in context.plugins:
+            skills_dir = plugin_path / "skills"
+            if not skills_dir.exists():
+                continue
+
+            for skill_dir in skills_dir.iterdir():
+                if not skill_dir.is_dir() or skill_dir.name.startswith('.'):
+                    continue
+
+                violations.extend(self._check_skill_markdown(skill_dir))
+
+        return violations
+
+    # Directories to skip during traversal (tooling artifacts, not skill content)
+    SKIP_DIRS = {'node_modules', '__pycache__', '.git', '.pytest_cache'}
+
+    def _check_skill_markdown(self, skill_dir: Path) -> List[RuleViolation]:
+        """Check markdown naming conventions within a single skill directory."""
+        violations = []
+
+        for md_file in self._iter_markdown(skill_dir):
+            name = md_file.name
+
+            # Check root-level constraint: only SKILL.md allowed at skill root
+            if md_file.parent == skill_dir and name != 'SKILL.md':
+                violations.append(
+                    self.violation(
+                        f"Only SKILL.md is allowed in the skill root directory. "
+                        f"Move '{name}' to an appropriate subdirectory such as 'references/' or 'tests/'.",
+                        file_path=md_file
+                    )
+                )
+                continue
+
+            # Skip exempt names
+            if name in self.EXEMPT_NAMES:
+                continue
+
+            # Check kebab-case naming
+            stem = md_file.stem
+            if not self.KEBAB_CASE_RE.match(stem):
+                violations.append(
+                    self.violation(
+                        f"Markdown file '{name}' is not kebab-case. "
+                        f"Rename to use lowercase letters, numbers, and hyphens "
+                        f"(e.g., '{self._suggest_kebab(stem)}.md').",
+                        file_path=md_file
+                    )
+                )
+
+        return violations
+
+    def _iter_markdown(self, skill_dir: Path):
+        """Yield .md files under skill_dir, skipping tooling directories."""
+        for item in skill_dir.iterdir():
+            if item.is_dir():
+                if item.name in self.SKIP_DIRS or item.name.startswith('.'):
+                    continue
+                yield from self._iter_markdown(item)
+            elif item.suffix == '.md':
+                yield item
+
+    @staticmethod
+    def _suggest_kebab(stem: str) -> str:
+        """Suggest a kebab-case version of a filename stem."""
+        # Normalize non-alphanumeric characters to hyphens
+        result = re.sub(r'[^A-Za-z0-9]+', '-', stem)
+        # Insert hyphens before uppercase letters (camelCase/PascalCase)
+        result = re.sub(r'(?<=[a-z0-9])([A-Z])', r'-\1', result)
+        # Lowercase everything
+        result = result.lower()
+        # Collapse multiple hyphens
+        result = re.sub(r'-+', '-', result)
+        # Strip leading/trailing hyphens
+        result = result.strip('-')
+        return result
+
+
+class SkillRequiredMetadataRule(Rule):
+    """
+    Enforce that SKILL.md frontmatter includes license and metadata.author.
+
+    Per marketplace convention, all skills must declare:
+    - license (e.g., "Proprietary")
+    - metadata.author (e.g., "Name <email>")
+    """
+
+    @property
+    def rule_id(self) -> str:
+        return "skill-required-metadata"
+
+    @property
+    def description(self) -> str:
+        return "SKILL.md must include 'license' and 'metadata.author' in frontmatter"
+
+    # Matches "Name <email>" pattern (one author entry)
+    AUTHOR_RE = re.compile(r'^[^<>]+<[^@\s]+@[^@\s]+\.[^@\s]+>$')
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+
+        for plugin_path in context.plugins:
+            skills_dir = plugin_path / "skills"
+            if not skills_dir.exists():
+                continue
+
+            for skill_dir in skills_dir.iterdir():
+                if not skill_dir.is_dir() or skill_dir.name.startswith('.'):
+                    continue
+
+                skill_md = skill_dir / "SKILL.md"
+                if not skill_md.exists():
+                    continue
+
+                frontmatter = self._parse_frontmatter(skill_md)
+                if frontmatter is None:
+                    continue  # Built-in skill-frontmatter rule handles parse errors
+
+                if not frontmatter.get('license'):
+                    violations.append(
+                        self.violation(
+                            f"SKILL.md is missing 'license' field. "
+                            f"Add 'license: Proprietary' (or appropriate license) to frontmatter.",
+                            file_path=skill_md
+                        )
+                    )
+
+                metadata = frontmatter.get('metadata')
+                if not isinstance(metadata, dict) or not metadata.get('author'):
+                    violations.append(
+                        self.violation(
+                            f"SKILL.md is missing 'metadata.author' field. "
+                            f"Add 'metadata:\\n  author: Name <email>' to frontmatter.",
+                            file_path=skill_md
+                        )
+                    )
+                elif isinstance(metadata, dict) and metadata.get('author'):
+                    author_violation = self._validate_author_format(metadata['author'])
+                    if author_violation:
+                        violations.append(
+                            self.violation(author_violation, file_path=skill_md)
+                        )
+
+        return violations
+
+    def _validate_author_format(self, author: str) -> Optional[str]:
+        """Validate that author follows 'Name <email>' format. Returns error message or None."""
+        if not isinstance(author, str) or not author.strip():
+            return (
+                "metadata.author must be a non-empty string in the format "
+                "'Name <email>'. Example: 'Jane Doe <jane.doe@okta.com>'"
+            )
+
+        if ';' in author:
+            return (
+                "metadata.author uses semicolon separator. "
+                "Use comma to separate multiple authors. "
+                "Example: 'Jane Doe <jane@okta.com>, John Doe <john@okta.com>'"
+            )
+
+        entries = author.split(',')
+
+        for entry in entries:
+            entry = entry.strip()
+            if not entry:
+                continue
+            if not self.AUTHOR_RE.match(entry):
+                return (
+                    f"metadata.author entry '{entry}' does not match expected format "
+                    f"'Name <email>'. Example: 'Jane Doe <jane.doe@okta.com>'"
+                )
+
+        return None
+
+    @staticmethod
+    def _parse_frontmatter(skill_md: Path) -> Optional[Dict[str, Any]]:
+        """Extract YAML frontmatter from a SKILL.md file."""
+        try:
+            content = skill_md.read_text()
+        except Exception:
+            return None
+
+        if not content.startswith('---'):
+            return None
+
+        # Find closing ---
+        end = content.find('---', 3)
+        if end == -1:
+            return None
+
+        try:
+            return yaml.safe_load(content[3:end])
+        except yaml.YAMLError:
+            return None

--- a/.claudelint/rules.py
+++ b/.claudelint/rules.py
@@ -213,7 +213,7 @@ class SkillReadmeDocumentationRule(Rule):
             # Read README content
             try:
                 readme_content = readme_path.read_text()
-            except Exception as e:
+            except OSError as e:
                 violations.append(
                     self.violation(
                         f"Could not read README.md: {e}",
@@ -402,9 +402,18 @@ class SkillRequiredMetadataRule(Rule):
                 if not skill_md.exists():
                     continue
 
-                frontmatter = self._parse_frontmatter(skill_md)
+                try:
+                    frontmatter = self._parse_frontmatter(skill_md)
+                except yaml.YAMLError as e:
+                    violations.append(
+                        self.violation(
+                            f"SKILL.md has malformed YAML frontmatter: {e}",
+                            file_path=skill_md
+                        )
+                    )
+                    continue
                 if frontmatter is None:
-                    continue  # Built-in skill-frontmatter rule handles parse errors
+                    continue  # Built-in skill-frontmatter rule handles missing frontmatter
 
                 if not frontmatter.get('license'):
                     violations.append(
@@ -424,7 +433,7 @@ class SkillRequiredMetadataRule(Rule):
                             file_path=skill_md
                         )
                     )
-                elif isinstance(metadata, dict) and metadata.get('author'):
+                else:
                     author_violation = self._validate_author_format(metadata['author'])
                     if author_violation:
                         violations.append(
@@ -464,10 +473,14 @@ class SkillRequiredMetadataRule(Rule):
 
     @staticmethod
     def _parse_frontmatter(skill_md: Path) -> Optional[Dict[str, Any]]:
-        """Extract YAML frontmatter from a SKILL.md file."""
+        """Extract YAML frontmatter from a SKILL.md file.
+
+        Returns None if the file has no frontmatter.
+        Raises yaml.YAMLError if frontmatter exists but is malformed.
+        """
         try:
             content = skill_md.read_text()
-        except Exception:
+        except OSError:
             return None
 
         if not content.startswith('---'):
@@ -478,7 +491,5 @@ class SkillRequiredMetadataRule(Rule):
         if end == -1:
             return None
 
-        try:
-            return yaml.safe_load(content[3:end])
-        except yaml.YAMLError:
-            return None
+        # Let yaml.YAMLError propagate so the caller can report it as a violation
+        return yaml.safe_load(content[3:end])

--- a/.github/workflows/claudelint.yml
+++ b/.github/workflows/claudelint.yml
@@ -1,0 +1,103 @@
+name: claudelint
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: claudelint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      UV_PYTHON: "3.12"
+      CLAUDELINT_VERSION: "0.3.6"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
+      with:
+        python-version: ${{ env.UV_PYTHON }}
+
+    - name: Cache uv tool env
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      with:
+        path: ~/.cache/uv
+        key: uv-${{ runner.os }}-py${{ env.UV_PYTHON }}-claudelint-${{ env.CLAUDELINT_VERSION }}
+
+    - name: Run claudelint in strict mode
+      id: claudelint
+      continue-on-error: true
+      run: |
+        set +e
+        # -q suppresses uv's download/install noise on stderr
+        # sed strips hardcoded ANSI escape codes (claudelint doesn't support NO_COLOR)
+        uvx -q "claudelint==${CLAUDELINT_VERSION}" --strict \
+          | sed 's/\x1b\[[0-9;]*m//g' \
+          | tee claudelint.txt
+        EXIT_CODE=${PIPESTATUS[0]}
+        echo "exit_code=${EXIT_CODE}" >> $GITHUB_OUTPUT
+
+        # Capture output for PR comment
+        {
+          echo "report<<EOF"
+          cat claudelint.txt
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
+
+        exit 0
+
+    - name: Prepare claudelint results
+      if: always()
+      id: prepare-comment
+      run: |
+        EXIT_CODE="${{ steps.claudelint.outputs.exit_code }}"
+        if [ "$EXIT_CODE" = "0" ]; then
+          echo "header=✅ claudelint — All checks passed" >> $GITHUB_OUTPUT
+          echo "details_open=" >> $GITHUB_OUTPUT
+        else
+          echo "header=❌ claudelint — Issues found" >> $GITHUB_OUTPUT
+          echo "details_open= open" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Post claudelint results as PR comment
+      if: ${{ always() && github.event_name == 'pull_request' }}
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        comment-tag: claudelint
+        mode: recreate
+        message: |
+          ## ${{ steps.prepare-comment.outputs.header }}
+
+          <details${{ steps.prepare-comment.outputs.details_open }}>
+          <summary>Full report</summary>
+
+          ```
+          ${{ steps.claudelint.outputs.report }}
+          ```
+
+          </details>
+
+          > [`claudelint ${{ env.CLAUDELINT_VERSION }}`](https://github.com/stbenjam/claudelint) · [config](${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/.claudelint.yaml) · [custom rules](${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/.claudelint/rules.py) · [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+    - name: Fail if claudelint failed
+      if: steps.claudelint.outputs.exit_code != '0'
+      run: exit 1
+
+    - name: Upload linter output
+      if: always()
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.4.0
+      with:
+        name: claudelint-report
+        path: claudelint.txt
+        if-no-files-found: error

--- a/.github/workflows/claudelint.yml
+++ b/.github/workflows/claudelint.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: claudelint-${{ github.event.pull_request.number }}
+  group: claudelint-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -39,7 +39,7 @@ jobs:
       id: claudelint
       continue-on-error: true
       run: |
-        set +e
+        set +e  # Don't exit on error; we capture the exit code manually below
         # -q suppresses uv's download/install noise on stderr
         # sed strips hardcoded ANSI escape codes (claudelint doesn't support NO_COLOR)
         uvx -q "claudelint==${CLAUDELINT_VERSION}" --strict \
@@ -55,7 +55,7 @@ jobs:
           echo "EOF"
         } >> $GITHUB_OUTPUT
 
-        exit 0
+        exit 0  # Always succeed so the PR comment step runs before we fail the job
 
     - name: Prepare claudelint results
       if: always()
@@ -64,10 +64,10 @@ jobs:
         EXIT_CODE="${{ steps.claudelint.outputs.exit_code }}"
         if [ "$EXIT_CODE" = "0" ]; then
           echo "header=✅ claudelint — All checks passed" >> $GITHUB_OUTPUT
-          echo "details_open=" >> $GITHUB_OUTPUT
+          echo "details_open=" >> $GITHUB_OUTPUT  # Empty = <details> closed by default
         else
           echo "header=❌ claudelint — Issues found" >> $GITHUB_OUTPUT
-          echo "details_open= open" >> $GITHUB_OUTPUT
+          echo "details_open= open" >> $GITHUB_OUTPUT  # Leading space + "open" renders as <details open>
         fi
 
     - name: Post claudelint results as PR comment

--- a/plugins/auth0-sdks/.claude-plugin/plugin.json
+++ b/plugins/auth0-sdks/.claude-plugin/plugin.json
@@ -1,5 +1,9 @@
 {
   "name": "auth0-sdks",
   "version": "1.0.0",
-  "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, and React Native with complete implementation guides."
+  "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, and React Native with complete implementation guides.",
+  "author": {
+    "name": "Auth0",
+    "email": "support@auth0.com"
+  }
 }

--- a/plugins/auth0-sdks/README.md
+++ b/plugins/auth0-sdks/README.md
@@ -1,0 +1,39 @@
+# auth0-sdks
+
+Framework-specific Auth0 SDK integration skills with complete implementation guides for login, logout, session management, protected routes, and API access.
+
+## Installation
+
+**Via Claude Code:**
+
+First, add the Auth0 marketplace if you haven't already:
+
+```bash
+/plugin marketplace add auth0/agent-skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install auth0-sdks@auth0-agent-skills
+```
+
+**Via Skills CLI:**
+
+```bash
+npx skills add auth0/agent-skills/plugins/auth0-sdks
+```
+
+## Skills
+
+| Skill | Description | Documentation |
+|-------|-------------|---------------|
+| [auth0-react](skills/auth0-react) | Integrates `@auth0/auth0-react` into React SPAs (Vite or Create React App). Covers provider setup, login/logout, protected routes, and API calls with access tokens using React hooks. | [SKILL.md](skills/auth0-react/SKILL.md) |
+| [auth0-vue](skills/auth0-vue) | Integrates `@auth0/auth0-vue` into Vue 3 SPAs (Vite or Vue CLI). Covers plugin installation, composables, navigation guards, and API calls with access tokens. | [SKILL.md](skills/auth0-vue/SKILL.md) |
+| [auth0-angular](skills/auth0-angular) | Integrates `@auth0/auth0-angular` into Angular 13+ applications. Covers module setup, route guards, HTTP interceptors for token attachment, and Angular service usage. | [SKILL.md](skills/auth0-angular/SKILL.md) |
+| [auth0-nextjs](skills/auth0-nextjs) | Integrates `@auth0/nextjs-auth0` (v4) into Next.js 13+ applications. Supports App Router and Pages Router. Covers middleware, Server Components, session management, and protected pages. | [SKILL.md](skills/auth0-nextjs/SKILL.md) |
+| [auth0-nuxt](skills/auth0-nuxt) | Integrates `@auth0/auth0-nuxt` into Nuxt 3/4 applications. Covers module configuration, server-side sessions with encrypted cookies, route middleware, and composable usage. | [SKILL.md](skills/auth0-nuxt/SKILL.md) |
+| [auth0-express](skills/auth0-express) | Integrates `express-openid-connect` into Express.js web applications. Covers session-based authentication with built-in `/login`, `/logout`, and `/callback` routes, and protecting routes with middleware. | [SKILL.md](skills/auth0-express/SKILL.md) |
+| [auth0-fastify](skills/auth0-fastify) | Integrates `@auth0/auth0-fastify` into Fastify web applications with view engines. Covers session-based authentication, built-in auth routes, and protecting routes with hooks. | [SKILL.md](skills/auth0-fastify/SKILL.md) |
+| [auth0-fastify-api](skills/auth0-fastify-api) | Integrates `@auth0/auth0-fastify-api` into stateless Fastify APIs. Covers JWT Bearer token validation, scope and permission checks, and securing API endpoints without sessions. | [SKILL.md](skills/auth0-fastify-api/SKILL.md) |
+| [auth0-react-native](skills/auth0-react-native) | Integrates `react-native-auth0` into React Native and Expo applications (iOS and Android). Covers deep linking setup, login/logout flows, biometric authentication, and secure token storage. | [SKILL.md](skills/auth0-react-native/SKILL.md) |

--- a/plugins/auth0-sdks/skills/auth0-angular/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-angular/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-angular
 description: Use when adding authentication to Angular applications with route guards and HTTP interceptors - integrates @auth0/auth0-angular SDK for SPAs
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Angular Integration

--- a/plugins/auth0-sdks/skills/auth0-express/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-express/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-express
 description: Use when adding authentication (login, logout, protected routes) to Express.js web applications - integrates express-openid-connect for session-based auth.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Express Integration

--- a/plugins/auth0-sdks/skills/auth0-fastify-api/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-fastify-api/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-fastify-api
 description: Use when securing Fastify API endpoints with JWT Bearer token validation, scope/permission checks, or stateless auth - integrates @auth0/auth0-fastify-api for REST APIs receiving access tokens from frontends or mobile apps.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Fastify API Integration

--- a/plugins/auth0-sdks/skills/auth0-fastify/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-fastify/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-fastify
 description: Use when adding authentication (login, logout, protected routes) to Fastify web applications - integrates @auth0/auth0-fastify for session-based auth. For stateless Fastify APIs use auth0-fastify-api instead.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Fastify Integration

--- a/plugins/auth0-sdks/skills/auth0-nextjs/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-nextjs/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-nextjs
 description: Use when adding authentication to Next.js applications (login, logout, protected pages, middleware, server components) - supports App Router and Pages Router with @auth0/nextjs-auth0 SDK.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Next.js Integration

--- a/plugins/auth0-sdks/skills/auth0-nuxt/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-nuxt/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-nuxt
 description: Use when implementing Auth0 authentication in Nuxt 3/4 applications, configuring session management, protecting routes with middleware, or integrating API access tokens - provides setup patterns, composable usage, and security best practices for the @auth0/auth0-nuxt SDK
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Nuxt SDK

--- a/plugins/auth0-sdks/skills/auth0-react-native/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-react-native/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-react-native
 description: Use when adding authentication to React Native or Expo mobile apps (iOS/Android) with biometric support - integrates react-native-auth0 SDK with native deep linking
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 React Native Integration

--- a/plugins/auth0-sdks/skills/auth0-react/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-react/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-react
 description: Use when adding authentication to React applications (login, logout, user sessions, protected routes) - integrates @auth0/auth0-react SDK for SPAs with Vite or Create React App
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 React Integration

--- a/plugins/auth0-sdks/skills/auth0-vue/SKILL.md
+++ b/plugins/auth0-sdks/skills/auth0-vue/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-vue
 description: Use when adding authentication to Vue.js 3 applications (login, logout, user sessions, protected routes) - integrates @auth0/auth0-vue SDK for SPAs with Vite or Vue CLI
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Vue.js Integration

--- a/plugins/auth0/.claude-plugin/plugin.json
+++ b/plugins/auth0/.claude-plugin/plugin.json
@@ -1,5 +1,9 @@
 {
   "name": "auth0",
   "version": "1.0.0",
-  "description": "Essential Auth0 skills including quickstarts, migration from other providers, and Multi-Factor Authentication (MFA)."
+  "description": "Essential Auth0 skills including quickstarts, migration from other providers, and Multi-Factor Authentication (MFA).",
+  "author": {
+    "name": "Auth0",
+    "email": "support@auth0.com"
+  }
 }

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -1,0 +1,33 @@
+# auth0
+
+Essential Auth0 skills for setting up authentication, migrating from other providers, and implementing Multi-Factor Authentication (MFA).
+
+## Installation
+
+**Via Claude Code:**
+
+First, add the Auth0 marketplace if you haven't already:
+
+```bash
+/plugin marketplace add auth0/agent-skills
+```
+
+Then install the plugin:
+
+```bash
+/plugin install auth0@auth0-agent-skills
+```
+
+**Via Skills CLI:**
+
+```bash
+npx skills add auth0/agent-skills/plugins/auth0
+```
+
+## Skills
+
+| Skill | Description | Documentation |
+|-------|-------------|---------------|
+| [auth0-quickstart](skills/auth0-quickstart) | Detects the project's framework and guides through a complete Auth0 integration from scratch. Handles tenant and application setup, environment variable configuration, and routes to the correct SDK skill. | [SKILL.md](skills/auth0-quickstart/SKILL.md) |
+| [auth0-migration](skills/auth0-migration) | Guides migration of existing authentication to Auth0 from other providers (Firebase, Cognito, Supabase, Clerk, custom). Covers user import strategies, JWT validation updates, and gradual migration patterns. | [SKILL.md](skills/auth0-migration/SKILL.md) |
+| [auth0-mfa](skills/auth0-mfa) | Implements Multi-Factor Authentication. Covers factor setup (TOTP, SMS, email, push, WebAuthn, voice), step-up authentication for sensitive operations, and adaptive MFA policies. | [SKILL.md](skills/auth0-mfa/SKILL.md) |

--- a/plugins/auth0/skills/auth0-mfa/SKILL.md
+++ b/plugins/auth0/skills/auth0-mfa/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-mfa
 description: Use when adding MFA, 2FA, TOTP, SMS codes, push notifications, passkeys, or when requiring step-up verification for sensitive operations or meeting compliance requirements (HIPAA, PCI-DSS) - covers adaptive and risk-based authentication with Auth0.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 MFA Guide

--- a/plugins/auth0/skills/auth0-migration/SKILL.md
+++ b/plugins/auth0/skills/auth0-migration/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-migration
 description: Use when migrating or switching from an existing auth provider (Firebase, Cognito, Supabase, Clerk, custom auth) to Auth0 - covers bulk user import, gradual migration strategies, code migration patterns, and JWT validation updates.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Migration Guide

--- a/plugins/auth0/skills/auth0-quickstart/SKILL.md
+++ b/plugins/auth0/skills/auth0-quickstart/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: auth0-quickstart
 description: Use when adding authentication or login to any app - detects your stack (React, Next.js, Vue, Nuxt, Angular, Express, Fastify, React Native), sets up an Auth0 account if needed, and routes to the correct SDK setup workflow.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
 ---
 
 # Auth0 Quickstart


### PR DESCRIPTION
### Description

Adds https://github.com/stbenjam/claudelint to enforce consistent structure and quality across all skills in this repository.

#### What's included:

  - `.claudelint.yaml` - configuration enabling rules for plugin structure, skill frontmatter, directory layout, README documentation, and kebab-case naming. Also enables custom rules and runs in strict mode.
  - `.claudelint/rules.py` - custom rules that enforce skill-specific requirements such as required metadata fields (license, metadata.author), skill directory structure, and skill documentation in plugin READMEs.
  - `.github/workflows/claudelint.yml` - GitHub Actions workflow that runs claudelint on every PR and push to main, posts the full report as a PR comment, and fails the build if any errors are found.
  - Fixes to existing skills and plugins to comply with the new rules: added missing license and metadata.author frontmatter to all `SKILL.md` files, and added missing `README.md` files and updated `plugin.json` for the **auth0-sdks** and **auth0** plugins.


### References

  - https://github.com/stbenjam/claudelint

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
