### PR TITLE
fix: use git-subdir source URLs in marketplace.json for Claude.ai sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,8 @@
 {
   "name": "auth0-agent-skills",
+  "metadata": {
+    "description": "Agent skills for integrating Auth0 authentication into any application, framework, or platform."
+  },
   "owner": {
     "name": "Auth0",
     "email": "support@auth0.com"
@@ -7,7 +10,11 @@
   "plugins": [
     {
       "name": "auth0",
-      "source": "./plugins/auth0",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/auth0/agent-skills.git",
+        "path": "plugins/auth0"
+      },
       "description": "Essential Auth0 skills including quickstarts, migration from other providers, and Multi-Factor Authentication (MFA).",
       "version": "1.0.0",
       "repository": "https://github.com/auth0/agent-skills.git",
@@ -21,7 +28,11 @@
     },
     {
       "name": "auth0-sdks",
-      "source": "./plugins/auth0-sdks",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/auth0/agent-skills.git",
+        "path": "plugins/auth0-sdks"
+      },
       "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, Android, ASP.NET Core, and React Native with complete implementation guides.",
       "version": "1.0.0",
       "repository": "https://github.com/auth0/agent-skills.git",


### PR DESCRIPTION
## Summary
- Changed plugin `source` fields from relative paths (`./plugins/auth0`) to explicit `git-subdir` objects with full GitHub URLs — relative paths don't resolve when the Claude.ai marketplace sync fetches `marketplace.json` remotely
- Added `metadata.description` to satisfy the marketplace schema (was triggering a validator warning)

## Context
Per the [Claude Code plugin marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces#plugins-with-relative-paths-fail-in-url-based-marketplaces):

> URL-based marketplaces only download the `marketplace.json` file itself. They do not download plugin files from the server. Relative paths in the marketplace entry reference files on the remote server that were not downloaded.

The fix uses the [`git-subdir` source format](https://code.claude.com/docs/en/plugin-marketplaces#git-subdirectories) to point each plugin at its subdirectory within this repo.

## Test plan
- [x] `claude plugin validate .` passes with zero errors and zero warnings
- [ ] Verify Claude.ai marketplace sync picks up both plugins after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)