### PR TITLE
fix(nextjs): correctly use token from auth0.getAccessToken()

### DIFF
--- a/plugins/auth0/skills/auth0-nextjs/references/api.md
+++ b/plugins/auth0/skills/auth0-nextjs/references/api.md
@@ -24,15 +24,15 @@ import { auth0 } from '@/lib/auth0';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const { accessToken } = await auth0.getAccessToken();
+  const { token } = await auth0.getAccessToken();
 
-  if (!accessToken) {
+  if (!token) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 
   const apiResponse = await fetch('https://external-api.com/data', {
     headers: {
-      Authorization: `Bearer ${accessToken}`
+      Authorization: `Bearer ${token}`
     }
   });
 

--- a/plugins/auth0/skills/auth0-nextjs/references/integration.md
+++ b/plugins/auth0/skills/auth0-nextjs/references/integration.md
@@ -197,14 +197,14 @@ export const config = {
 import { auth0 } from '@/lib/auth0';
 
 export async function getData() {
-  const { accessToken } = await auth0.getAccessToken();
+  const { token } = await auth0.getAccessToken();
 
-  if (!accessToken) {
+  if (!token) {
     throw new Error('No access token available');
   }
 
   const response = await fetch('https://your-api.com/data', {
-    headers: { Authorization: `Bearer ${accessToken}` }
+    headers: { Authorization: `Bearer ${token}` }
   });
 
   return response.json();
@@ -225,14 +225,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
-  const { accessToken } = await auth0.getAccessToken(req, res);
+  const { token } = await auth0.getAccessToken(req, res);
 
-  if (!accessToken) {
+  if (!token) {
     return res.status(401).json({ error: 'No access token' });
   }
 
   const response = await fetch('https://your-api.com/data', {
-    headers: { Authorization: `Bearer ${accessToken}` }
+    headers: { Authorization: `Bearer ${token}` }
   });
 
   const data = await response.json();


### PR DESCRIPTION
### Description

In `nextjs-auth0`, `auth0.getAccessToken()` returns `{ token: string, ... }`, not `{ accessToken: string, ... }`. 

### References

https://github.com/auth0/nextjs-auth0/blob/4d586510a9006ebb60fb9b82ad221563c16e04ef/src/server/client.ts#L827-L833

```typescript
async getAccessToken(
    arg1?: PagesRouterRequest | NextRequest | GetAccessTokenOptions,
    arg2?: PagesRouterResponse | NextResponse,
    arg3?: GetAccessTokenOptions
  ): Promise<{
    token: string;
    expiresAt: number;
    scope?: string;
    token_type?: string;
    audience?: string;
  }>
```

### Testing

This was flagged when integrating `getAccessToken` through the skill. Integration worked fine, apart from the fact that it tried to use `{ accessToken }` first, then ran the build, and noticed failure and updated it to `{ token }`.

This PR ensures the agent starts with `{ token }` rather than have to waste a tool call on trying to compile and adjust.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
