### PR TITLE
fix: align docs with single-plugin merge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,22 +37,20 @@
         "angular",
         "express",
         "fastify",
-        "fastify-api",
         "fastapi",
+        "flask",
+        "springboot",
+        "java",
         "swift",
         "android",
         "aspnetcore",
         "dotnet",
-        "springboot",
-        "java",
-        "servlet",
-        "java-mvc",
         "react-native",
         "expo",
+        "spa-js",
         "node",
         "jwt",
-        "express-oauth2-jwt-bearer",
-        "express-jwt"
+        "express-oauth2-jwt-bearer"
       ],
       "category": "authentication"
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -35,18 +35,20 @@
         "angular",
         "express",
         "fastify",
-        "fastify-api",
         "fastapi",
+        "flask",
+        "springboot",
+        "java",
         "swift",
         "android",
         "aspnetcore",
         "dotnet",
         "react-native",
         "expo",
+        "spa-js",
         "node",
         "jwt",
-        "express-oauth2-jwt-bearer",
-        "express-jwt"
+        "express-oauth2-jwt-bearer"
       ],
       "category": "authentication"
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,16 @@ We appreciate feedback and contribution to this repo! Before you get started, pl
 
 ### Adding a New Skill
 
-1. Determine which plugin your skill belongs to:
-   - `plugins/auth0/` - Core skills (quickstart, migration, MFA, etc.)
-   - `plugins/auth0-sdks/` - Language or Framework related SDK skills
-2. Create a new directory under the appropriate plugin's `skills/` directory
-3. Add a `SKILL.md` file following the [Agent Skills specification](https://agentskills.io/specification)
-4. Optionally add additional reference files
-5. Update the README.md to list your skill in the appropriate table
-6. Submit a pull request
+1. Create a new directory under `plugins/auth0/skills/`
+2. Add a `SKILL.md` file following the [Agent Skills specification](https://agentskills.io/specification)
+3. Optionally add additional reference files
+4. Update the README.md to list your skill in the appropriate table
+5. Submit a pull request
 
 ### Skill Structure
 
 ```
-plugins/auth0-sdks/skills/my-skill/
+plugins/auth0/skills/my-skill/
 ├── SKILL.md           # Required: Main skill file
 ├── references/        # Optional: Additional documentation
 │   └── reference.md
@@ -71,10 +68,10 @@ Use the skills reference library to validate your skills:
 
 ```bash
 # Validate a specific skill
-npx skills-ref validate ./plugins/auth0-sdks/skills/my-skill
+npx skills-ref validate ./plugins/auth0/skills/my-skill
 
-# Validate all skills in a plugin
-npx skills-ref validate ./plugins/auth0-sdks/skills/
+# Validate all skills
+npx skills-ref validate ./plugins/auth0/skills/
 ```
 
 ### Testing with AI Assistants
@@ -84,10 +81,10 @@ Test your skills work correctly with AI assistants:
 1. Install the plugin/skill locally:
    ```bash
    # Install entire plugin
-   npx skills add ./plugins/auth0-sdks
+   npx skills add ./plugins/auth0
 
    # Or copy to Claude skills directory
-   cp -r ./plugins/auth0-sdks/skills/my-skill ~/.claude/skills/
+   cp -r ./plugins/auth0/skills/my-skill ~/.claude/skills/
    ```
 2. Ask an AI assistant to use the skill
 3. Verify the generated code is correct

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -1,12 +1,12 @@
 # Claude Code Plugin Architecture
 
-This repository provides **two separate Claude Code plugins** managed by a single marketplace.json file.
+This repository provides a **single Claude Code plugin** managed by a marketplace.json file.
 
 ## Architecture Overview
 
-### Single Marketplace File
+### Marketplace File
 
-One `marketplace.json` at the root level lists both plugins:
+One `marketplace.json` at the root level lists the plugin:
 
 ```json
 {
@@ -14,31 +14,42 @@ One `marketplace.json` at the root level lists both plugins:
   "plugins": [
     {
       "name": "auth0",
-      "path": "plugins/auth0",
-      ...
-    },
-    {
-      "name": "auth0-sdks",
-      "path": "plugins/auth0-sdks",
+      "source": "plugins/auth0",
       ...
     }
   ]
 }
 ```
 
-### Two Plugins, Each with Skills
+### One Plugin, All Skills
 
-**Plugin 1: auth0** (Core Skills)
-- `auth0-quickstart` - Framework detection
-- `auth0-migration` - Migrate from other providers
+**Plugin: auth0** — All Auth0 agent skills in a single plugin.
+
+Core skills:
+- `auth0-quickstart` - Framework detection and routing
+- `auth0-migration` - Migrate from other auth providers
 - `auth0-mfa` - Multi-Factor Authentication
 
-**Plugin 2: auth0-sdks** (SDK Skills)
+Frontend framework skills:
 - `auth0-react` - React SPAs
-- `auth0-nextjs` - Next.js
 - `auth0-vue` - Vue.js 3
 - `auth0-angular` - Angular 12+
+- `auth0-spa-js` - Vanilla JS SPAs
+
+Backend/fullstack framework skills:
+- `auth0-nextjs` - Next.js
+- `auth0-nuxt` - Nuxt 3/4
 - `auth0-express` - Express.js
+- `auth0-flask` - Flask
+- `auth0-fastify` - Fastify web applications
+- `auth0-fastify-api` - Fastify API authentication
+- `auth0-fastapi-api` - FastAPI API authentication
+- `auth0-java-mvc-common` - Java Servlet web applications
+- `auth0-springboot-api` - Spring Boot API authentication
+- `auth0-aspnetcore-api` - ASP.NET Core API authentication
+- `express-oauth2-jwt-bearer` - Node.js/Express API JWT Bearer validation
+
+Mobile skills:
 - `auth0-android` - Android (Kotlin/Java)
 - `auth0-swift` - iOS/macOS (Swift)
 - `auth0-react-native` - React Native CLI (bare workflow)
@@ -51,31 +62,46 @@ One `marketplace.json` at the root level lists both plugins:
 ```
 auth0/agent-skills/
 ├── .claude-plugin/
-│   └── marketplace.json          # Single marketplace file listing both plugins
+│   └── marketplace.json          # Marketplace metadata
+├── .cursor-plugin/
+│   └── marketplace.json          # Cursor marketplace metadata
 ├── plugins/
-│   ├── auth0/                    # Core Plugin
-│   │   ├── .claude-plugin/
-│   │   │   └── plugin.json       # Plugin config
-│   │   └── skills/               # Skills directory
-│   │       ├── auth0-quickstart/
-│   │       ├── auth0-migration/
-│   │       └── auth0-mfa/
-│   └── auth0-sdks/               # SDK Plugin
+│   └── auth0/                    # Single unified plugin
 │       ├── .claude-plugin/
-│       │   └── plugin.json       # Plugin config
-│       └── skills/               # Skills directory
+│       │   └── plugin.json       # Claude plugin config
+│       ├── .cursor-plugin/
+│       │   └── plugin.json       # Cursor plugin config
+│       ├── .codex-plugin/
+│       │   └── plugin.json       # Codex plugin config
+│       └── skills/
+│           ├── auth0-quickstart/
+│           ├── auth0-migration/
+│           ├── auth0-mfa/
 │           ├── auth0-react/
-│           ├── auth0-nextjs/
 │           ├── auth0-vue/
 │           ├── auth0-angular/
+│           ├── auth0-spa-js/
+│           ├── auth0-nextjs/
+│           ├── auth0-nuxt/
 │           ├── auth0-express/
+│           ├── auth0-flask/
+│           ├── auth0-fastify/
+│           ├── auth0-fastify-api/
+│           ├── auth0-fastapi-api/
+│           ├── auth0-java-mvc-common/
+│           ├── auth0-springboot-api/
+│           ├── auth0-aspnetcore-api/
+│           ├── express-oauth2-jwt-bearer/
 │           ├── auth0-react-native/
 │           ├── auth0-expo/
 │           ├── auth0-android/
 │           └── auth0-swift/
+├── .gitignore
+├── CODE_OF_CONDUCT.md
+├── CONTRIBUTING.md
+├── LICENSE
 ├── PLUGIN.md
-├── README.md
-└── LICENSE
+└── README.md
 ```
 
 ---
@@ -84,68 +110,23 @@ auth0/agent-skills/
 
 ### .claude-plugin/marketplace.json
 
-**Purpose**: Master marketplace listing for both plugins
+**Purpose**: Master marketplace listing for the plugin
 
 **Location**: `.claude-plugin/marketplace.json`
 
 **Contains**:
 - Repository metadata (name, version, author, license)
-- Array of plugins with their configurations
-- Each plugin definition includes:
-  - Plugin name (required, kebab-case)
-  - Plugin source path (required) - e.g., `plugins/auth0`
-  - Plugin description, version, keywords, category
-  - Skills are auto-discovered from the `skills/` directory within each plugin
+- Plugin configuration with source path
+- Skills are auto-discovered from the `skills/` directory within the plugin
 
-**Example**:
-```json
-{
-  "name": "auth0-agent-skills",
-  "displayName": "Auth0 Agent Skills",
-  "version": "1.0.0",
-  "plugins": [
-    {
-      "name": "auth0",
-      "source": "plugins/auth0",
-      "description": "Essential Auth0 skills including quickstarts, migration from other providers, and Multi-Factor Authentication (MFA).",
-      "version": "1.0.0",
-      "keywords": ["auth0", "quickstart", "migration", "mfa", "security"],
-      "category": "authentication"
-    },
-    {
-      "name": "auth0-sdks",
-      "source": "plugins/auth0-sdks",
-      "description": "Framework-specific Auth0 SDK integration skills for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Swift, Android, ASP.NET Core, React Native, and Expo with complete implementation guides.",
-      "version": "1.0.0",
-      "keywords": ["auth0", "sdk", "react", "nextjs", "vue", "nuxt", "angular", "express", "fastify", "fastapi", "swift", "android", "react-native", "expo"],
-      "category": "integration"
-    }
-  ]
-}
-```
-
-### plugins/*/\.claude-plugin/plugin.json
+### plugins/auth0/.claude-plugin/plugin.json
 
 **Purpose**: Plugin-specific configuration
-
-**Location**:
-- `plugins/auth0/.claude-plugin/plugin.json`
-- `plugins/auth0-sdks/.claude-plugin/plugin.json`
 
 **Contains**:
 - Plugin name, display name, and version
 - Plugin description
 - Skills are auto-discovered from the `skills/` directory
-
-**Example** (`plugins/auth0/.claude-plugin/plugin.json`):
-```json
-{
-  "name": "auth0",
-  "displayName": "Auth0 Skills",
-  "version": "1.0.0",
-  "description": "Essential Auth0 skills including quickstarts, migration from other providers, and Multi-Factor Authentication (MFA)."
-}
-```
 
 ---
 
@@ -153,25 +134,16 @@ auth0/agent-skills/
 
 ### Method 1: Marketplace (Recommended)
 
-**Install Both Plugins:**
 1. Open Claude Code
-2. Navigate to **Settings → Plugins**
+2. Navigate to **Settings > Plugins**
 3. Search "Auth0"
-4. Install "Auth0 Agent Skills" (installs both plugins)
-
-**Install Individual Plugin:**
-- Search for "Auth0 Core Skills" or "Auth0 SDK Skills"
-- Install the specific plugin you need
+4. Install "Auth0 Agent Skills"
 
 ### Method 2: CLI Installation
 
 ```bash
-# Install all skills from both plugins
+# Install all skills
 npx skills add auth0/agent-skills
-
-# Install specific plugin
-npx skills add auth0/agent-skills/plugins/auth0
-npx skills add auth0/agent-skills/plugins/auth0-sdks
 
 # Install individual skill
 npx skills add auth0/agent-skills/plugins/auth0/skills/auth0-quickstart
@@ -185,121 +157,34 @@ cd agent-skills
 
 # Copy all skills
 cp -r plugins/auth0/skills/* ~/.claude/skills/
-cp -r plugins/auth0-sdks/skills/* ~/.claude/skills/
 ```
-
----
-
-## Benefits of This Architecture
-
-### Single Marketplace Entry
-✅ **Unified discovery** - Users find both plugins under one entry
-✅ **Consistent branding** - One Auth0 listing in marketplace
-✅ **Easier management** - Single metadata file to maintain
-✅ **Bundle option** - Can install all at once
-
-### Separate Plugins
-✅ **Flexibility** - Users can install only what they need
-✅ **Smaller downloads** - Each plugin is focused
-✅ **Independent updates** - Update SDK skills without core
-✅ **Clear boundaries** - Logical separation of concerns
-
-### Skills in Plugin Directories
-✅ **Self-contained** - Each plugin includes its own skills
-✅ **No shared dependencies** - Skills belong to their plugin
-✅ **Easy distribution** - Plugin is a complete package
-✅ **Clear ownership** - Obvious which skills belong to which plugin
-
----
-
-## Plugin Independence
-
-Both plugins are **fully independent** and can be installed separately:
-
-- **auth0** plugin: Core skills (quickstart, migration, MFA)
-- **auth0-sdks** plugin: Framework-specific integrations
-
-**Benefits:**
-- ✅ Install only what you need
-- ✅ No forced dependencies
-- ✅ Maximum flexibility
-- ✅ Smaller installations
-
-**Recommendation:** Install both for complete Auth0 coverage, but either plugin works standalone.
-
----
-
-## Publishing to Marketplace
-
-### Update Version
-
-Edit `marketplace.json`:
-```json
-{
-  "version": "1.1.0",
-  "plugins": [
-    {
-      "name": "auth0",
-      "version": "1.1.0",
-      ...
-    },
-    {
-      "name": "auth0-sdks",
-      "version": "1.1.0",
-      ...
-    }
-  ]
-}
-```
-
-Also update each `plugins/*/plugin.json`.
-
-### Create Release
-
-```bash
-git add .
-git commit -m "Release v1.1.0"
-git tag v1.1.0
-git push origin main --tags
-```
-
-### Submit to Marketplace
-
-1. Submit repository to Claude Code marketplace
-2. Marketplace will read `marketplace.json`
-3. Both plugins will be listed under "Auth0 Agent Skills"
-4. Users can install one or both plugins
 
 ---
 
 ## Use Cases
 
 ### Install Everything (Most Common)
-User installs "Auth0 Agent Skills" from marketplace → gets both plugins with all 17 skills
-
-### Install Core Only
-User only needs framework detection and MFA → installs just `auth0` plugin (3 skills)
-
-### Install SDKs Only
-User already has quickstart setup → installs just `auth0-sdks` plugin (14 skills)
-Note: Will auto-install `auth0` due to dependency
+User installs "Auth0 Agent Skills" from marketplace -> gets the plugin with all 22 skills.
 
 ### Install One Framework
-Developer working on React app → uses CLI to install just `auth0-react` skill
+Developer working on React app -> uses CLI to install just `auth0-react` skill.
 
 ---
 
-## Pricing Model
+## Publishing
 
-Both plugins marked as **"paid"**:
+### Update Version
 
-```json
-{
-  "pricing": "paid"
-}
+Edit `.claude-plugin/marketplace.json` and `plugins/auth0/.claude-plugin/plugin.json`.
+
+### Create Release
+
+```bash
+git add .
+git commit -m "Release vX.Y.Z"
+git tag vX.Y.Z
+git push origin main --tags
 ```
-
-Indicates enterprise/customer-only distribution with Auth0 support.
 
 ---
 
@@ -308,15 +193,3 @@ Indicates enterprise/customer-only distribution with Auth0 support.
 - **GitHub Issues**: https://github.com/auth0/agent-skills/issues
 - **Email**: support@auth0.com
 - **Documentation**: README.md for usage, PLUGIN.md for architecture
-
----
-
-## Version History
-
-- **v1.0.0** - Initial marketplace release
-  - Single marketplace.json listing both plugins
-  - Plugins in their own directories with their skills
-  - Clear separation: core (3 skills) vs SDKs (6 skills)
-  - Progressive disclosure for large skills
-  - Skills auto-discovery within plugins
-  - Plugin independence (no forced dependencies)

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -73,6 +73,7 @@ auth0/agent-skills/
 │       │   └── plugin.json       # Cursor plugin config
 │       ├── .codex-plugin/
 │       │   └── plugin.json       # Codex plugin config
+│       ├── README.md
 │       └── skills/
 │           ├── auth0-quickstart/
 │           ├── auth0-migration/

--- a/plugins/auth0/.cursor-plugin/plugin.json
+++ b/plugins/auth0/.cursor-plugin/plugin.json
@@ -21,17 +21,19 @@
     "angular",
     "express",
     "fastify",
-    "fastify-api",
     "fastapi",
+    "flask",
+    "springboot",
+    "java",
     "swift",
     "android",
     "aspnetcore",
     "dotnet",
     "react-native",
     "expo",
+    "spa-js",
     "node",
     "jwt",
-    "express-oauth2-jwt-bearer",
-    "express-jwt"
+    "express-oauth2-jwt-bearer"
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #50 which merged `auth0-sdks` into `auth0`. These files were missed in that PR:

- **PLUGIN.md**: Complete rewrite — was still documenting two-plugin architecture with 20+ stale references to `auth0-sdks`
- **CONTRIBUTING.md**: Updated all paths from `plugins/auth0-sdks/` to `plugins/auth0/`
- **Keyword normalization**: Claude and Cursor marketplace/plugin configs had inconsistent keyword lists — normalized to a canonical 27-keyword set. Added missing `flask`, `springboot`, `java`, `spa-js`; removed stale `servlet`, `java-mvc`, `express-jwt`, `fastify-api`.

### Not in scope

`plugins/auth0/.codex-plugin/plugin.json` was never tracked by git — it exists locally but was never committed. Adding Codex support should be a separate PR.

## Test plan

- [ ] Verify no remaining `auth0-sdks` references: `grep -rn "auth0-sdks" --include="*.json" --include="*.md" .`
- [ ] Verify PLUGIN.md directory tree matches actual repo structure
- [ ] Verify CONTRIBUTING.md paths resolve to real directories
- [ ] Verify keyword lists match across configs: `diff <(jq -r '.plugins[0].keywords[]' .claude-plugin/marketplace.json | sort) <(jq -r '.plugins[0].keywords[]' .cursor-plugin/marketplace.json | sort)`