### PR TITLE
fix(auth0-fastapi-api): correct Python import path from auth0_fastapi_api to fastapi_plugin

### DIFF
--- a/plugins/auth0/skills/auth0-fastapi-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-fastapi-api/SKILL.md
@@ -84,7 +84,7 @@ AUTH0_AUDIENCE=https://your-api.example.com
 ```python
 import os
 from fastapi import FastAPI, Depends
-from auth0_fastapi_api import Auth0FastAPI
+from fastapi_plugin import Auth0FastAPI
 from dotenv import load_dotenv
 
 load_dotenv()

--- a/plugins/auth0/skills/auth0-fastapi-api/references/api.md
+++ b/plugins/auth0/skills/auth0-fastapi-api/references/api.md
@@ -9,7 +9,7 @@ Complete reference for `auth0-fastapi-api` configuration options and methods.
 Main class for protecting FastAPI API routes with Auth0 JWT validation.
 
 ```python
-from auth0_fastapi_api import Auth0FastAPI
+from fastapi_plugin import Auth0FastAPI
 ```
 
 ### Constructor
@@ -166,7 +166,7 @@ auth0 = Auth0FastAPI(
 ### Dynamic Domain Resolver
 
 ```python
-from auth0_fastapi_api import DomainsResolverContext
+from fastapi_plugin import DomainsResolverContext
 
 def domains_resolver(context: DomainsResolverContext) -> list:
     request_url = context.get("request_url")
@@ -214,7 +214,7 @@ auth0 = Auth0FastAPI(
 ### Custom Cache Adapter
 
 ```python
-from auth0_fastapi_api import CacheAdapter
+from fastapi_plugin import CacheAdapter
 
 class RedisCache(CacheAdapter):
     def __init__(self, redis_client):
@@ -245,7 +245,7 @@ auth0 = Auth0FastAPI(
 ## Exports
 
 ```python
-from auth0_fastapi_api import (
+from fastapi_plugin import (
     Auth0FastAPI,              # Main class
     CacheAdapter,              # Interface for custom cache implementations
     ConfigurationError,        # Raised when configuration is invalid

--- a/plugins/auth0/skills/auth0-fastapi-api/references/integration.md
+++ b/plugins/auth0/skills/auth0-fastapi-api/references/integration.md
@@ -176,7 +176,7 @@ When deploying behind a reverse proxy (nginx, AWS ALB, Cloudflare CDN), you **mu
 
 ```python
 from fastapi import FastAPI
-from auth0_fastapi_api import Auth0FastAPI
+from fastapi_plugin import Auth0FastAPI
 
 app = FastAPI()
 
@@ -315,7 +315,7 @@ async def custom_http_exception_handler(request, exc):
 
 ```python
 from fastapi import FastAPI, Depends
-from auth0_fastapi_api import Auth0FastAPI
+from fastapi_plugin import Auth0FastAPI
 
 app = FastAPI()
 auth0 = Auth0FastAPI(
@@ -366,7 +366,7 @@ app.add_middleware(
 ```python
 from fastapi import FastAPI, Depends
 from fastapi.testclient import TestClient
-from auth0_fastapi_api import Auth0FastAPI
+from fastapi_plugin import Auth0FastAPI
 
 app = FastAPI()
 auth0 = Auth0FastAPI(domain="my-tenant.us.auth0.com", audience="my-api")


### PR DESCRIPTION
**Summary**

  - Fixes all Python import paths in the auth0-fastapi-api skill from auth0_fastapi_api to fastapi_plugin
  - Affects SKILL.md, references/api.md, and references/integration.md

  **Problem**

  The pip package is named auth0-fastapi-api, but the actual Python module in the SDK repo is fastapi_plugin (see pyproject.toml and fastapi_plugin/__init__.py). There is no auth0_fastapi_api module — the
  import from auth0_fastapi_api import Auth0FastAPI fails at runtime with ImportError.

  The correct import is:
  from fastapi_plugin import Auth0FastAPI

  **How this was discovered**

  Eval runs in auth0-evals for fastapi_api_quickstart revealed the issue:

  - The holistic judge failed across multiple models (claude-opus-4-6, claude-sonnet-4-6, gpt-5.4) because models with access to the actual SDK source (via MCP or web browsing) correctly used from
  `fastapi_plugin import Auth0FastAPI` — and were then penalized by the judge for not matching the skill's (incorrect) instructions.
  - Models that blindly followed the skill produced code that would fail at runtime with ImportError.