### PR TITLE
fix(acul-screen-generator): add missing metadata section to SKILL.md

### DIFF
--- a/plugins/auth0/skills/acul-screen-generator/SKILL.md
+++ b/plugins/auth0/skills/acul-screen-generator/SKILL.md
@@ -4,6 +4,9 @@ description: Generates complete, branded Auth0 Advanced Custom Universal Login (
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
+  openclaw:
+    emoji: "🔐"
+    homepage: https://github.com/auth0/agent-skills
 ---
 
 # ACUL Screen Generator


### PR DESCRIPTION
### Description

Now that we merged #42 , we need to update skills that were missing the metadata, which is acul-screen-generator for now.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
