### PR TITLE
Improve Claude Code marketplace listing

### DIFF
--- a/plugins/auth0/.claude-plugin/plugin.json
+++ b/plugins/auth0/.claude-plugin/plugin.json
@@ -1,9 +1,24 @@
 {
-  "name": "auth0",
+  "name": "Auth0",
   "version": "1.0.0",
-  "description": "Auth0 skills for quickstarts, migration, MFA, Advanced Custom Universal Login (ACUL) screen generation, and framework-specific SDK integrations for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Java MVC, Spring Boot, Swift, Android, ASP.NET Core, React Native, and Expo.",
+  "description": "Enterprise-grade auth, easy to implement. Add login, SSO, MFA, and access control to any app with framework-aware guidance.",
   "author": {
     "name": "Auth0",
-    "email": "support@auth0.com"
-  }
+    "url": "https://auth0.com"
+  },
+  "homepage": "https://auth0.com/docs",
+  "keywords": [
+    "auth0",
+    "authentication",
+    "authorization",
+    "sso",
+    "mfa",
+    "enterprise",
+    "identity",
+    "oauth2",
+    "openid-connect",
+    "rbac",
+    "universal-login",
+    "sdk"
+  ]
 }

--- a/plugins/auth0/.claude-plugin/plugin.json
+++ b/plugins/auth0/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "Auth0",
+  "name": "auth0",
   "version": "1.0.0",
   "description": "Enterprise-grade auth, easy to implement. Add login, SSO, MFA, and access control to any app with framework-aware guidance.",
   "author": {

--- a/plugins/auth0/.claude-plugin/plugin.json
+++ b/plugins/auth0/.claude-plugin/plugin.json
@@ -4,6 +4,7 @@
   "description": "Enterprise-grade auth, easy to implement. Add login, SSO, MFA, and access control to any app with framework-aware guidance.",
   "author": {
     "name": "Auth0",
+    "email": "support@auth0.com",
     "url": "https://auth0.com"
   },
   "homepage": "https://auth0.com",

--- a/plugins/auth0/.claude-plugin/plugin.json
+++ b/plugins/auth0/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Auth0",
     "url": "https://auth0.com"
   },
-  "homepage": "https://auth0.com/docs",
+  "homepage": "https://auth0.com",
   "keywords": [
     "auth0",
     "authentication",

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -31,7 +31,7 @@ Tell the plugin what you need in plain English:
 **Via Claude Code:**
 
 ```bash
-/install-plugin auth0
+/plugin install auth0@claude-plugins-official
 ```
 
 **Via Skills CLI:**

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -1,21 +1,37 @@
-# auth0
+# Auth0
 
-Auth0 skills for setting up authentication, migrating from other providers, implementing Multi-Factor Authentication (MFA), framework-specific SDK integrations and CLI.
+Build faster with enterprise-grade identity. This plugin brings Auth0's authentication and authorization platform into your development workflow — detecting your stack, scaffolding the right integration, and guiding you through production-ready implementation.
+
+## Enterprise features, ready to deploy
+
+- **Single Sign-On & Organizations** — Federated login flows, self-serve admin consoles, and multi-tenant identity management at scale.
+- **Multifactor Authentication** — Contextual MFA policies with TOTP, SMS, push, WebAuthn, and risk-based step-up challenges.
+- **Role-Based Access Control** — Fine-grained authorization with permissions, roles, and custom claims across your APIs.
+- **Custom Login Experiences** — From no-code to pro-code: generate branded Universal Login screens matching your design system.
+- **User Migration** — Move from Firebase, AWS Cognito, Supabase, Clerk, or custom auth with zero-downtime trickle migration.
+- **API Protection** — JWT validation, token exchange, and OAuth2 best practices across Node, Python, .NET, Java, and Go.
+
+## Framework-aware implementation
+
+The plugin detects your stack and integrates the right Auth0 SDK — Next.js, React, Vue, Angular, Express, FastAPI, Spring Boot, Swift, Android, and 25+ others. No boilerplate. Current patterns.
+
+## How to use
+
+Tell the plugin what you need in plain English:
+
+- "Add authentication to this app"
+- "Set up enterprise SSO with SAML"
+- "Add MFA to the login flow"
+- "Migrate users from Cognito"
+- "Protect this API with role-based access"
+- "Create a custom login page"
 
 ## Installation
 
 **Via Claude Code:**
 
-First, add the Auth0 marketplace if you haven't already:
-
 ```bash
-/plugin marketplace add auth0/agent-skills
-```
-
-Then install the plugin:
-
-```bash
-/plugin install auth0@auth0-agent-skills
+/install-plugin auth0
 ```
 
 **Via Skills CLI:**
@@ -26,29 +42,29 @@ npx skills add auth0/agent-skills/plugins/auth0
 
 ## Skills
 
-| Skill                                                         | Description                                                                                                                                                                                                                                              | Documentation                                         |
-|---------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| [auth0-quickstart](skills/auth0-quickstart)                   | Detects the project's framework and guides through a complete Auth0 integration from scratch. Handles tenant and application setup, environment variable configuration, and routes to the correct SDK skill.                                             | [SKILL.md](skills/auth0-quickstart/SKILL.md)          |
-| [auth0-migration](skills/auth0-migration)                     | Guides migration of existing authentication to Auth0 from other providers (Firebase, Cognito, Supabase, Clerk, custom). Covers user import strategies, JWT validation updates, and gradual migration patterns.                                           | [SKILL.md](skills/auth0-migration/SKILL.md)           |
-| [auth0-mfa](skills/auth0-mfa)                                 | Implements Multi-Factor Authentication. Covers factor setup (TOTP, SMS, email, push, WebAuthn, voice), step-up authentication for sensitive operations, and adaptive MFA policies.                                                                       | [SKILL.md](skills/auth0-mfa/SKILL.md)                 |
-| [acul-screen-generator](skills/acul-screen-generator)         | Generates complete, branded ACUL screen implementations using the React or Vanilla JS SDK. Handles project setup, screen generation, theming, and dev mode wiring.                                                                            | [SKILL.md](skills/acul-screen-generator/SKILL.md) |
-| [auth0-spa-js](skills/auth0-spa-js)                           | Integrates `@auth0/auth0-spa-js` into Vanilla JS, Svelte, SolidJS, and any framework-agnostic SPA. Covers client initialization, login/logout, token retrieval, refresh token rotation, and calling protected APIs without a framework-specific wrapper. | [SKILL.md](skills/auth0-spa-js/SKILL.md)              |
-| [auth0-react](skills/auth0-react)                             | Integrates `@auth0/auth0-react` into React SPAs (Vite or Create React App). Covers provider setup, login/logout, protected routes, and API calls with access tokens using React hooks.                                                                   | [SKILL.md](skills/auth0-react/SKILL.md)               |
-| [auth0-vue](skills/auth0-vue)                                 | Integrates `@auth0/auth0-vue` into Vue 3 SPAs (Vite or Vue CLI). Covers plugin installation, composables, navigation guards, and API calls with access tokens.                                                                                           | [SKILL.md](skills/auth0-vue/SKILL.md)                 |
-| [auth0-angular](skills/auth0-angular)                         | Integrates `@auth0/auth0-angular` into Angular 13+ applications. Covers module setup, route guards, HTTP interceptors for token attachment, and Angular service usage.                                                                                   | [SKILL.md](skills/auth0-angular/SKILL.md)             |
-| [auth0-nextjs](skills/auth0-nextjs)                           | Integrates `@auth0/nextjs-auth0` (v4) into Next.js 13+ applications. Supports App Router and Pages Router. Covers middleware, Server Components, session management, and protected pages.                                                                | [SKILL.md](skills/auth0-nextjs/SKILL.md)              |
-| [auth0-nuxt](skills/auth0-nuxt)                               | Integrates `@auth0/auth0-nuxt` into Nuxt 3/4 applications. Covers module configuration, server-side sessions with encrypted cookies, route middleware, and composable usage.                                                                             | [SKILL.md](skills/auth0-nuxt/SKILL.md)                |
-| [auth0-express](skills/auth0-express)                         | Integrates `express-openid-connect` into Express.js web applications. Covers session-based authentication with built-in `/login`, `/logout`, and `/callback` routes, and protecting routes with middleware.                                              | [SKILL.md](skills/auth0-express/SKILL.md)             |
-| [auth0-flask](skills/auth0-flask)                             | Integrates `auth0-server-python` into Flask web applications. Covers session-based authentication using Flask's built-in session, login/callback/profile/logout flows, and stateless cookie or Redis-backed storage.                                     | [SKILL.md](skills/auth0-flask/SKILL.md)               |
-| [auth0-fastify](skills/auth0-fastify)                         | Integrates `@auth0/auth0-fastify` into Fastify web applications with view engines. Covers session-based authentication, built-in auth routes, and protecting routes with hooks.                                                                          | [SKILL.md](skills/auth0-fastify/SKILL.md)             |
-| [auth0-fastify-api](skills/auth0-fastify-api)                 | Integrates `@auth0/auth0-fastify-api` into stateless Fastify APIs. Covers JWT Bearer token validation, scope and permission checks, and securing API endpoints without sessions.                                                                         | [SKILL.md](skills/auth0-fastify-api/SKILL.md)         |
-| [auth0-react-native](skills/auth0-react-native)               | Integrates `react-native-auth0` into React Native CLI (bare workflow) applications (iOS and Android). Covers native deep linking setup, login/logout flows, biometric authentication, and secure token storage.                                          | [SKILL.md](skills/auth0-react-native/SKILL.md)        |
-| [auth0-expo](skills/auth0-expo)                               | Integrates `react-native-auth0` into Expo (managed workflow) mobile apps. Covers Expo Config Plugin setup, custom scheme deep linking, login/logout flows, biometric authentication, and EAS builds.                                                     | [SKILL.md](skills/auth0-expo/SKILL.md)                |
-| [auth0-android](skills/auth0-android)                         | Integrates `com.auth0.android:auth0` into native Android applications (Kotlin/Java). Covers Web Auth login/logout, biometric-protected credential storage, and MFA.                                                                                      | [SKILL.md](skills/auth0-android/SKILL.md)             |
-| [auth0-swift](skills/auth0-swift)                             | Integrates `Auth0.swift` into native iOS/macOS applications (Swift). Covers Web Auth login/logout, biometric-protected credential storage, and MFA.                                                                                                      | [SKILL.md](skills/auth0-swift/SKILL.md)               |
-| [auth0-springboot-api](skills/auth0-springboot-api)           | Secures Spring Boot API endpoints with JWT Bearer token validation using `com.auth0:auth0-springboot-api`. Covers auto-configuration, scope-based authorization, and DPoP proof-of-possession support.                                                   | [SKILL.md](skills/auth0-springboot-api/SKILL.md)      |
-| [auth0-java-mvc-common](skills/auth0-java-mvc-common)         | Integrates `com.auth0:mvc-auth-commons` into Java Servlet web applications. Covers AuthenticationController setup, login/callback/logout servlets, session-based auth, Organizations, and Multiple Custom Domains.                                        | [SKILL.md](skills/auth0-java-mvc-common/SKILL.md)     |
-| [auth0-aspnetcore-api](skills/auth0-aspnetcore-api)           | Secures ASP.NET Core Web API endpoints with JWT Bearer token validation using `Auth0.AspNetCore.Authentication.Api`. Covers scope/permission checks, DPoP proof-of-possession token binding, and stateless auth for REST APIs.                           | [SKILL.md](skills/auth0-aspnetcore-api/SKILL.md)      |
-| [auth0-fastapi-api](skills/auth0-fastapi-api)                 | Secures FastAPI API endpoints with JWT Bearer token validation using `auth0-fastapi-api`. Covers scope/permission checks, DPoP proof-of-possession token binding, and stateless auth for REST APIs.                                                      | [SKILL.md](skills/auth0-fastapi-api/SKILL.md)         |
-| [express-oauth2-jwt-bearer](skills/express-oauth2-jwt-bearer) | Secures Node.js/Express API endpoints with JWT Bearer token validation using `express-oauth2-jwt-bearer`. Covers scope and permission-based RBAC, claim validation, DPoP support, and stateless auth for REST APIs.                                      | [SKILL.md](skills/express-oauth2-jwt-bearer/SKILL.md) |
-| [auth0-cli](skills/auth0-cli)                                 | Reference for Auth0 CLI commands  manage applications, APIs, users, roles, organizations, actions, logs, custom domains, Universal Login, Terraform export, and raw Management API access from the terminal.                                             | [SKILL.md](skills/auth0-cli/SKILL.md)                 |
+| Skill | Description |
+|-------|-------------|
+| [auth0-quickstart](skills/auth0-quickstart) | Detects your framework and guides through a complete Auth0 integration from scratch. |
+| [auth0-migration](skills/auth0-migration) | Migrate from Firebase, Cognito, Supabase, Clerk, or custom auth systems. |
+| [auth0-mfa](skills/auth0-mfa) | Implement MFA with TOTP, SMS, email, push, WebAuthn, and adaptive policies. |
+| [acul-screen-generator](skills/acul-screen-generator) | Generate branded login screens with Advanced Customization for Universal Login. |
+| [auth0-react](skills/auth0-react) | React SPA integration with hooks, protected routes, and API calls. |
+| [auth0-nextjs](skills/auth0-nextjs) | Next.js 13+ with App Router, middleware, and Server Components. |
+| [auth0-vue](skills/auth0-vue) | Vue 3 SPA with composables and navigation guards. |
+| [auth0-angular](skills/auth0-angular) | Angular 13+ with route guards and HTTP interceptors. |
+| [auth0-nuxt](skills/auth0-nuxt) | Nuxt 3/4 with server-side sessions and route middleware. |
+| [auth0-express](skills/auth0-express) | Express.js session-based auth with built-in routes. |
+| [auth0-fastify](skills/auth0-fastify) | Fastify session-based auth with hooks. |
+| [auth0-flask](skills/auth0-flask) | Flask session-based auth with login/callback flows. |
+| [auth0-react-native](skills/auth0-react-native) | React Native with deep linking and biometric auth. |
+| [auth0-expo](skills/auth0-expo) | Expo managed workflow with Config Plugin and EAS builds. |
+| [auth0-android](skills/auth0-android) | Native Android (Kotlin/Java) with Web Auth and biometrics. |
+| [auth0-swift](skills/auth0-swift) | Native iOS/macOS (Swift) with Web Auth and biometrics. |
+| [auth0-springboot-api](skills/auth0-springboot-api) | Spring Boot API with JWT validation and DPoP support. |
+| [auth0-java-mvc-common](skills/auth0-java-mvc-common) | Java Servlet web apps with session-based auth. |
+| [auth0-aspnetcore-api](skills/auth0-aspnetcore-api) | ASP.NET Core API with JWT validation and DPoP. |
+| [auth0-fastapi-api](skills/auth0-fastapi-api) | FastAPI with JWT validation and permission checks. |
+| [auth0-fastify-api](skills/auth0-fastify-api) | Fastify API with JWT Bearer validation. |
+| [express-oauth2-jwt-bearer](skills/express-oauth2-jwt-bearer) | Express API with JWT validation and RBAC. |
+| [auth0-spa-js](skills/auth0-spa-js) | Vanilla JS, Svelte, SolidJS — framework-agnostic SPA auth. |
+| [auth0-cli](skills/auth0-cli) | Auth0 CLI reference for terminal-based management. |


### PR DESCRIPTION
## Summary

- Adds `author.url` and `homepage` to plugin.json (enables "Made by" link if rendered from plugin metadata)
- Restores `support@auth0.com` email in author field
- Adds keywords for discoverability
- Rewrites `README.md` with enterprise-focused marketplace copy (renders as below-fold content on [claude.com/plugins/auth0](https://claude.com/plugins/auth0))

## Context

The current marketplace listing has:
- No "Made by" link (other plugins like Vercel show this)
- The same long description repeated in both the hero and below the fold
- A README that reads like a skill inventory rather than a product page

The display name and hero tagline are controlled by the [Anthropic registry](https://github.com/anthropics/claude-plugins-official/issues/1736) — this PR handles what we control in our repo.

## What this PR does NOT change

- Plugin `name` field stays `"auth0"` (lowercase) to avoid breaking plugin resolution
- No skill logic or functionality changes

## Test plan

- [ ] Verify plugin still installs correctly via `/plugin install auth0@claude-plugins-official`
- [ ] Confirm below-fold content updates on claude.com/plugins/auth0 after merge
- [ ] Verify "Made by" link appears (may require Anthropic-side change first)