### PR TITLE
fix: remove token logging from documentation examples

### DIFF
--- a/plugins/auth0/skills/auth0-angular/references/api.md
+++ b/plugins/auth0/skills/auth0-angular/references/api.md
@@ -272,11 +272,13 @@ Gets an access token via popup window. Useful when silent authentication fails (
 ```typescript
 // Try silent, fall back to popup
 this.auth.getAccessTokenSilently().subscribe({
-  next: (token) => console.log('Token:', token),
+  next: (token) => {
+    // Use the token (e.g., attach to API requests)
+  },
   error: () => {
     // Silent auth failed, try popup
     this.auth.getAccessTokenWithPopup().subscribe(token => {
-      console.log('Got token via popup:', token);
+      // Use the token (e.g., attach to API requests)
     });
   }
 });

--- a/plugins/auth0/skills/auth0-expo/references/integration.md
+++ b/plugins/auth0/skills/auth0-expo/references/integration.md
@@ -64,7 +64,7 @@ const credentials = await auth0.webAuth.authorize(
   { scope: 'openid profile email' },
   { customScheme: 'auth0sample' }
 );
-console.log('Access Token:', credentials.accessToken);
+// Access token available at credentials.accessToken
 ```
 
 ### Login with Audience (API Access)
@@ -334,7 +334,7 @@ const apiCredentials = await getApiCredentials(
   'https://second-api.example.com',
   'read:data write:data'
 );
-console.log('API Token:', apiCredentials.accessToken);
+// Access token available at apiCredentials.accessToken
 ```
 
 ## Custom Token Exchange (RFC 8693)

--- a/plugins/auth0/skills/auth0-react/references/integration.md
+++ b/plugins/auth0/skills/auth0-react/references/integration.md
@@ -334,7 +334,7 @@ export function MfaChallenge({ mfaToken }: { mfaToken: string }) {
       // For OTP authenticators, you can skip challenge() and go straight to verify()
       const tokens = await mfa.verify({ mfaToken, otp });
       // User is now authenticated — tokens are cached by the SDK
-      console.log('MFA complete, access token:', tokens.access_token);
+      // Access token available at tokens.access_token
     } catch (err) {
       if (err instanceof MfaVerifyError) {
         setError('Invalid code. Please try again.');

--- a/plugins/auth0/skills/auth0-swift/references/integration.md
+++ b/plugins/auth0/skills/auth0-swift/references/integration.md
@@ -46,7 +46,7 @@ Auth0
     .start { result in
         switch result {
         case .success(let credentials):
-            print("Login successful: \(credentials.accessToken)")
+            // Access token available at credentials.accessToken
         case .failure(let error):
             print("Login failed: \(error)")
         }
@@ -158,7 +158,7 @@ func hasValidToken(minTTL: Int = 60) -> Bool {
 ```swift
 do {
     let credentials = try await credentialsManager.renew()
-    print("Renewed: \(credentials.accessToken)")
+    // Renewed token available at credentials.accessToken
 } catch {
     print("Renewal failed: \(error)")
 }
@@ -283,7 +283,7 @@ Auth0
     .start { result in
         switch result {
         case .success(let credentials):
-            print("Logged in: \(credentials.accessToken)")
+            // Access token available at credentials.accessToken
         case .failure(let error) where error.isMultifactorRequired:
             // Extract MFA token for MFA challenge flow
             if let mfaPayload = error.mfaRequiredErrorPayload {


### PR DESCRIPTION
### Description

Avoid logging tokens to the console in examples — replace with comments indicating where the token is available on the response object.
