### PR TITLE
fix(claudelint): simplify import to use stable claudelint public API

### DIFF
--- a/.skillsaw/rules.py
+++ b/.skillsaw/rules.py
@@ -7,18 +7,7 @@ import yaml
 from pathlib import Path
 from typing import List, Optional, Dict, Any
 
-try:
-    # Try importing from skillsaw package (when installed via pip/uvx)
-    from skillsaw.rule import Rule, RuleViolation, Severity
-    from skillsaw.context import RepositoryContext
-except ImportError:
-    try:
-        # Fallback for development environment
-        from src.rule import Rule, RuleViolation, Severity
-        from src.context import RepositoryContext
-    except ImportError:
-        # Final fallback
-        from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
 
 
 class SkillDirectoryStructureRule(Rule):


### PR DESCRIPTION
### Description

The multi-fallback import pattern is unnecessary — the claudelint package exports Rule, RuleViolation, Severity, and RepositoryContext from its top-level module.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
