### PR TITLE
feat: notify docs-v2 to sync skills on push

### DIFF
--- a/.github/workflows/notify-docs-sync.yml
+++ b/.github/workflows/notify-docs-sync.yml
@@ -1,0 +1,19 @@
+name: Notify docs-v2 to sync skills
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/*/skills/**'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs-v2 sync
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_V2_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/auth0/docs-v2/dispatches \
+            --method POST \
+            --field event_type=sync-agent-skills


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that fires `repository_dispatch` to `auth0/docs-v2` whenever skill files change on main. This triggers an immediate sync of skills to the docs site instead of waiting for the weekly Monday cron.

## How it works

1. Developer merges skill changes to `main`
2. This workflow fires (path filter: `plugins/*/skills/**`)
3. Sends `repository_dispatch` event (`sync-agent-skills`) to `auth0/docs-v2`
4. docs-v2's existing sync workflow runs, clones this repo, copies skills, opens PR

## Setup

- Secret `DOCS_V2_DISPATCH_TOKEN` has been added to this repo (PAT with repo scope on docs-v2)
- Corresponding `repository_dispatch` trigger added to docs-v2 in auth0/docs-v2#1147

## Test plan

- [ ] Merge this PR
- [ ] Push a trivial skill change to main (e.g., bump version in a SKILL.md)
- [ ] Confirm `notify-docs-sync` workflow fires in Actions tab
- [ ] Confirm a sync PR appears in auth0/docs-v2 within ~2 minutes