### PR TITLE
fix: use environment variables instead of literal secrets in auth0-cli examples

### DIFF
--- a/plugins/auth0/skills/auth0-cli/SKILL.md
+++ b/plugins/auth0/skills/auth0-cli/SKILL.md
@@ -33,7 +33,7 @@ The Auth0 CLI (`auth0`) lets you manage your tenant from the terminal. Install w
 ```bash
 auth0 login                          # interactive device-code login
 auth0 login --scopes "read:client_grants"  # request extra scopes if 403
-auth0 login --domain <tenant>.auth0.com --client-id <id> --client-secret <secret>  # CI/CD
+auth0 login --domain <tenant>.auth0.com --client-id <id> --client-secret "$AUTH0_CLIENT_SECRET"  # CI/CD
 ```
 
 See [Authentication Details](references/cli.md#authentication) for machine login with JWT, tenant management, and logout.
@@ -77,7 +77,7 @@ auth0 apps create --name "My SPA" --type spa \
   --origins "http://localhost:3000" --json
 
 auth0 apps list --json-compact
-auth0 apps show <client-id> --reveal-secrets --json
+auth0 apps show <client-id> --json
 auth0 apps update <client-id> --callbacks "http://localhost:3000,https://myapp.com" --json
 auth0 apps delete <client-id> --force
 ```
@@ -110,7 +110,7 @@ Create, search, inspect, import, and manage users in your tenant.
 auth0 users search --query "email:user@example.com" --json
 auth0 users search-by-email user@example.com --json-compact
 auth0 users create --connection-name "Username-Password-Authentication" \
-  --email "test@example.com" --password "SecureP@ss!" --json
+  --email "test@example.com" --password "$USER_PASSWORD" --json
 auth0 users show <user-id> --json
 auth0 users blocks list <email> --json
 auth0 users blocks unblock <email>

--- a/plugins/auth0/skills/auth0-cli/references/cli.md
+++ b/plugins/auth0/skills/auth0-cli/references/cli.md
@@ -40,7 +40,7 @@ auth0 login
 auth0 login --scopes "read:client_grants,create:client_grants"
 
 # Machine login with client secret (CI/CD, non-interactive)
-auth0 login --domain <tenant>.auth0.com --client-id <id> --client-secret <secret>
+auth0 login --domain <tenant>.auth0.com --client-id <id> --client-secret "$AUTH0_CLIENT_SECRET"
 
 # Machine login with private key JWT
 auth0 login --domain <tenant>.auth0.com --client-id <id> \
@@ -327,7 +327,7 @@ Simpler alternative to `search` when you just need an exact email match.
 auth0 users create \
   --connection-name "Username-Password-Authentication" \
   --email "testuser@example.com" \
-  --password "SecureP@ss123!" \
+  --password "$USER_PASSWORD" \
   --name "Test User" \
   --json
 ```


### PR DESCRIPTION
### Description

Replace hardcoded secret placeholders with env var references ($AUTH0_CLIENT_SECRET, $USER_PASSWORD) and add agent instruction to never pass literal secrets as CLI arguments.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
