### PR TITLE
fix: simplify auth0-expo manual setup instructions

### DIFF
--- a/plugins/auth0/skills/auth0-expo/SKILL.md
+++ b/plugins/auth0/skills/auth0-expo/SKILL.md
@@ -84,18 +84,11 @@ Add authentication to Expo (React Native) applications using `react-native-auth0
 >
 > After the script completes, proceed to **Step 2 (Verify Expo Dev Client)**.
 
-#### Manual Setup (User-Provided Credentials)
+#### Manual Setup
 
-> **Agent instruction:** Ask the user for their Auth0 credentials using `AskUserQuestion`:
+> **Agent instruction:** If the user has not provided their Auth0 Domain and Client ID, ask them using `AskUserQuestion`. They can find both in the [Auth0 Dashboard](https://manage.auth0.com/) under **Applications > Applications > your app > Settings**. If they don't have an Auth0 app yet, they should create one with type **Native**.
 >
-> "I need your Auth0 credentials to set up authentication. Please provide:
->
-> 1. **Auth0 Domain** (e.g., `your-tenant.us.auth0.com`)
-> 2. **Client ID** (a 32-character alphanumeric string)
->
-> You can find both in the [Auth0 Dashboard](https://manage.auth0.com/) under **Applications > Applications > your app > Settings**. If you don't have an Auth0 app yet, create one with type **Native** and copy the domain and client ID from the settings page."
->
-> Then write the configuration to app.json and proceed to **Step 2**.
+> Once provided, configure the Auth0 plugin in app.json and proceed to **Step 2**.
 
 ### 2. Verify Expo Dev Client
 


### PR DESCRIPTION
### Description

Rephrase agent instruction to avoid triggering credential handling warnings while preserving the same functionality.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
