### PR TITLE
fix: set token_endpoint_auth_method to none for SPA/native apps

### DIFF
--- a/plugins/auth0/skills/auth0-angular/references/setup.md
+++ b/plugins/auth0/skills/auth0-angular/references/setup.md
@@ -44,6 +44,7 @@ if [ -z "$APP_ID" ]; then
   APP_ID=$(auth0 apps create \
     --name "$APP_NAME" \
     --type spa \
+    --auth-method None \
     --callbacks "http://localhost:4200" \
     --logout-urls "http://localhost:4200" \
     --origins "http://localhost:4200" \

--- a/plugins/auth0/skills/auth0-cli/SKILL.md
+++ b/plugins/auth0/skills/auth0-cli/SKILL.md
@@ -72,6 +72,7 @@ Create or inspect Auth0 applications (client ID, secret, callback URLs, app type
 
 ```bash
 auth0 apps create --name "My SPA" --type spa \
+  --auth-method None \
   --callbacks "http://localhost:3000" \
   --logout-urls "http://localhost:3000" \
   --origins "http://localhost:3000" --json

--- a/plugins/auth0/skills/auth0-cli/references/cli.md
+++ b/plugins/auth0/skills/auth0-cli/references/cli.md
@@ -120,6 +120,7 @@ auth0 apps show <client-id> --reveal-secrets --json-compact
 ```bash
 # SPA (React, Vue, Angular — browser-only, no backend)
 auth0 apps create --name "My SPA" --type spa \
+  --auth-method None \
   --callbacks "http://localhost:3000" \
   --logout-urls "http://localhost:3000" \
   --origins "http://localhost:3000" \
@@ -136,7 +137,7 @@ auth0 apps create --name "My Web App" --type regular \
 auth0 apps create --name "My API Service" --type m2m --json
 
 # Native (iOS, Android, React Native)
-auth0 apps create --name "My Mobile App" --type native --json
+auth0 apps create --name "My Mobile App" --type native --auth-method None --json
 
 # Resource Server (API + client in one entity)
 auth0 apps create --name "My API Client" --type resource_server \

--- a/plugins/auth0/skills/auth0-ionic-react/SKILL.md
+++ b/plugins/auth0/skills/auth0-ionic-react/SKILL.md
@@ -71,6 +71,7 @@ Add Auth0 authentication to Ionic React applications using Capacitor. This skill
 >    auth0 apps create \
 >      --name "APP_NAME" \
 >      --type native \
+>      --auth-method None \
 >      --callbacks "PACKAGE_ID://DOMAIN/capacitor/PACKAGE_ID/callback" \
 >      --logout-urls "PACKAGE_ID://DOMAIN/capacitor/PACKAGE_ID/callback" \
 >      --origins "capacitor://localhost,http://localhost" \

--- a/plugins/auth0/skills/auth0-ionic-react/references/setup.md
+++ b/plugins/auth0/skills/auth0-ionic-react/references/setup.md
@@ -32,6 +32,7 @@
 > auth0 apps create \
 >   --name "APP_NAME" \
 >   --type native \
+>   --auth-method None \
 >   --callbacks "PACKAGE_ID://DOMAIN/capacitor/PACKAGE_ID/callback" \
 >   --logout-urls "PACKAGE_ID://DOMAIN/capacitor/PACKAGE_ID/callback" \
 >   --origins "capacitor://localhost,http://localhost" \

--- a/plugins/auth0/skills/auth0-quickstart/SKILL.md
+++ b/plugins/auth0/skills/auth0-quickstart/SKILL.md
@@ -94,6 +94,7 @@ Choose application type based on your framework:
 **Single Page Applications (React, Vue, Angular):**
 ```bash
 auth0 apps create --name "My App" --type spa \
+  --auth-method None \
   --callbacks "http://localhost:3000" \
   --logout-urls "http://localhost:3000" \
   --metadata "created_by=agent_skills"
@@ -110,6 +111,7 @@ auth0 apps create --name "My App" --type regular \
 **Native Apps (React Native):**
 ```bash
 auth0 apps create --name "My App" --type native \
+  --auth-method None \
   --callbacks "myapp://callback" \
   --logout-urls "myapp://logout" \
   --metadata "created_by=agent_skills"

--- a/plugins/auth0/skills/auth0-quickstart/references/cli.md
+++ b/plugins/auth0/skills/auth0-quickstart/references/cli.md
@@ -326,7 +326,7 @@ auth0 apps list --json
 auth0 apps list --tenant my-tenant
 
 # Debug mode
-auth0 apps create --debug --name "My App" --type spa
+auth0 apps create --debug --name "My App" --type spa --auth-method None
 ```
 
 ---

--- a/plugins/auth0/skills/auth0-react-native/references/setup.md
+++ b/plugins/auth0/skills/auth0-react-native/references/setup.md
@@ -51,6 +51,7 @@ Via CLI:
 ```bash
 auth0 login
 auth0 apps create --name "My Mobile App" --type native \
+  --auth-method None \
   --callbacks "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback" \
   --logout-urls "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback" \
   --metadata "created_by=agent_skills"

--- a/plugins/auth0/skills/auth0-react/references/setup.md
+++ b/plugins/auth0/skills/auth0-react/references/setup.md
@@ -113,6 +113,7 @@ if [ -z "$APP_ID" ]; then
   APP_ID=$(auth0 apps create \
     --name "$APP_NAME" \
     --type spa \
+    --auth-method None \
     --callbacks "http://localhost:3000,http://localhost:5173" \
     --logout-urls "http://localhost:3000,http://localhost:5173" \
     --origins "http://localhost:3000,http://localhost:5173" \
@@ -202,6 +203,7 @@ if ([string]::IsNullOrEmpty($appId)) {
   $appName = Split-Path -Leaf (Get-Location)
   Write-Host "Creating new Auth0 SPA application..."
   $appJson = auth0 apps create --name "$appName-react-app" --type spa `
+    --auth-method None `
     --callbacks "http://localhost:3000,http://localhost:5173" `
     --logout-urls "http://localhost:3000,http://localhost:5173" `
     --origins "http://localhost:3000,http://localhost:5173" `

--- a/plugins/auth0/skills/auth0-spa-js/references/setup.md
+++ b/plugins/auth0/skills/auth0-spa-js/references/setup.md
@@ -93,6 +93,7 @@ if [ -z "$APP_ID" ]; then
   APP_ID=$(auth0 apps create \
     --name "$APP_NAME" \
     --type spa \
+    --auth-method None \
     --callbacks "http://localhost:3000,http://localhost:5173" \
     --logout-urls "http://localhost:3000,http://localhost:5173" \
     --origins "http://localhost:3000,http://localhost:5173" \
@@ -157,6 +158,7 @@ if ([string]::IsNullOrEmpty($appId)) {
   $appName = Split-Path -Leaf (Get-Location)
   Write-Host "Creating new Auth0 SPA application..."
   $appJson = auth0 apps create --name "$appName-spa" --type spa `
+    --auth-method None `
     --callbacks "http://localhost:3000,http://localhost:5173" `
     --logout-urls "http://localhost:3000,http://localhost:5173" `
     --origins "http://localhost:3000,http://localhost:5173" `

--- a/plugins/auth0/skills/auth0-vue/references/setup.md
+++ b/plugins/auth0/skills/auth0-vue/references/setup.md
@@ -83,6 +83,7 @@ if [ -z "$APP_ID" ]; then
   APP_ID=$(auth0 apps create \
     --name "$APP_NAME" \
     --type spa \
+    --auth-method None \
     --callbacks "http://localhost:5173,http://localhost:3000" \
     --logout-urls "http://localhost:5173,http://localhost:3000" \
     --origins "http://localhost:5173,http://localhost:3000" \
@@ -148,6 +149,7 @@ if ([string]::IsNullOrEmpty($appId)) {
   $appName = Split-Path -Leaf (Get-Location)
   Write-Host "Creating new Auth0 SPA application..."
   $appJson = auth0 apps create --name "$appName-vue-app" --type spa `
+    --auth-method None `
     --callbacks "http://localhost:5173,http://localhost:3000" `
     --logout-urls "http://localhost:5173,http://localhost:3000" `
     --origins "http://localhost:5173,http://localhost:3000" `


### PR DESCRIPTION
## Summary

- Add `--auth-method None` to all SPA and native app creation commands across 8 skills (11 files)
- Fix `auth0-ionic-react` which was missing the flag entirely
- Fix casing of `--auth-method` flag in ionic-react (`none` → `None`)

## Problem

When skills create SPA/native apps via `auth0 apps create --type spa`, they don't explicitly set `token_endpoint_auth_method: none`. Auth0 API defaults to requiring a client secret for token exchange, but SPAs are public clients that can't hold secrets. Result: login succeeds but the auth code→token exchange fails with "Unauthorized" — a confusing failure mode reported by multiple users.

## Test plan

- [x] Verified `auth0 apps create --type spa --auth-method None` produces `"token_endpoint_auth_method": "none"` in created client JSON
- [x] Verified `--auth-method` flag is supported on `auth0 apps create` (confirmed locally via `auth0 apps create --help`)
- [ ] Run quickstart skill end-to-end with a React SPA to confirm login + token exchange succeeds

Splits the branding step into a separate PR: #TBD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Auth0 CLI setup guides and code examples to include the `--auth-method None` flag when creating SPA and Native applications. Changes applied across multiple quickstart modules with automated setup scripts for Bash and PowerShell.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/agent-skills/pull/89)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->