### PR TITLE
feat: add branding step to auth0-quickstart

### DIFF
--- a/plugins/auth0/skills/auth0-quickstart/SKILL.md
+++ b/plugins/auth0/skills/auth0-quickstart/SKILL.md
@@ -123,14 +123,14 @@ auth0 apps show <app-id> # Get client ID and secret
 
 **More CLI commands:** See [CLI Reference](references/cli.md)
 
-### Apply Branding (Recommended)
+### Apply Branding (Optional)
 
 After creating your application, apply branding so the Auth0 Universal Login page matches your app:
 
 ```bash
 auth0 ul update \
   --accent "#YOUR_BRAND_COLOR" \
-  --background "#FFFFFF" \
+  --background "#YOUR_BACKGROUND_COLOR" \
   --logo "https://your-app.com/logo.png" \
   --favicon "https://your-app.com/favicon.ico"
 ```

--- a/plugins/auth0/skills/auth0-quickstart/SKILL.md
+++ b/plugins/auth0/skills/auth0-quickstart/SKILL.md
@@ -123,6 +123,20 @@ auth0 apps show <app-id> # Get client ID and secret
 
 **More CLI commands:** See [CLI Reference](references/cli.md)
 
+### Apply Branding (Recommended)
+
+After creating your application, apply branding so the Auth0 Universal Login page matches your app:
+
+```bash
+auth0 ul update \
+  --accent "#YOUR_BRAND_COLOR" \
+  --background "#FFFFFF" \
+  --logo "https://your-app.com/logo.png" \
+  --favicon "https://your-app.com/favicon.ico"
+```
+
+This ensures users see your app's branding on the login screen instead of the default Auth0 branding. You can also use the `acul-screen-generator` skill for full custom login screen design.
+
 ---
 
 ## Step 4: Use Framework-Specific Skill


### PR DESCRIPTION
## Summary

Add an "Apply Branding" step to the `auth0-quickstart` skill so Universal Login matches the app's look-and-feel out of the box.

## Changes

After app creation, the quickstart now recommends:
```bash
auth0 ul update \
  --accent "#YOUR_BRAND_COLOR" \
  --background "#FFFFFF" \
  --logo "https://your-app.com/logo.png" \
  --favicon "https://your-app.com/favicon.ico"
```

Also references the `acul-screen-generator` skill for full custom login screen design.

## Context

Split from #87 to keep PRs atomic. The bug fix (adding `--auth-method None`) ships separately in #89.

## Test plan

- [ ] Verify branding step renders correctly in skill output
- [ ] Confirm `auth0 ul update` command works with the documented flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Apply Branding (Optional)" subsection to the Auth0 quickstart explaining how to apply app branding to Universal Login (accent color, background, logo, favicon) via CLI commands, and pointing to an additional tool for full custom login screen design.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/agent-skills/pull/90)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->