### PR TITLE
feat(auth0): Add My Organization API skill

### DIFF
--- a/plugins/auth0/skills/auth0-my-organization-api/.claude-plugin/plugin.json
+++ b/plugins/auth0/skills/auth0-my-organization-api/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "team-delegated-admin-my-organization-api",
+  "description": "B2B SaaS delegated admin skills using Auth0's My Organization API.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Auth0 Delegated Administration Team",
+    "email": "authn-b2b-delegated-admin@okta.com"
+  }
+}

--- a/plugins/auth0/skills/auth0-my-organization-api/README.md
+++ b/plugins/auth0/skills/auth0-my-organization-api/README.md
@@ -1,0 +1,41 @@
+# Delegated Admin - My Organization API Plugin
+
+> [!TIP]
+> **B2B SaaS focus** - Skills for building organization-scoped admin portals using Auth0's My Organization API
+
+## Installation
+
+```bash
+/plugin install team-delegated-admin-my-organization-api@auth0-claude-marketplace
+```
+
+> [!NOTE]
+> First add the marketplace: `/plugin marketplace add atko-cic/claude-marketplace`
+
+## Skills
+
+| Skill | Description | Documentation |
+|-------|-------------|---------------|
+| **[using-my-organization-api](./skills/using-my-organization-api/)** | Build organization-scoped admin portals for B2B SaaS using Auth0's My Organization API. Includes complete implementation guide: Auth0 config, Next.js dashboard patterns, backend validation, member management, SSO setup, and security policies. | [SKILL.md](./skills/using-my-organization-api/SKILL.md) |
+
+## Plugin Management
+
+### Update Plugin
+```bash
+/plugin update team-delegated-admin-my-organization-api@auth0-claude-marketplace
+```
+
+### Remove Plugin
+```bash
+/plugin remove team-delegated-admin-my-organization-api@auth0-claude-marketplace
+```
+
+## Learn More
+
+- **[Main Marketplace](../../README.md)** - Browse all available plugins
+- **[Agent Skills Specification](https://agentskills.io/specification)** - Format specification for skills
+- **[CONTRIBUTING.md](../../CONTRIBUTING.md)** - Contributing guidelines
+
+## License
+
+Proprietary - Auth0 internal use only. See individual skills for license details.

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/SKILL.md
@@ -1,0 +1,777 @@
+---
+name: using-my-organization-api
+description: Build or extend portals that let B2B customers manage their own organization settings using Auth0’s My Organization API. Use when a user wants to let customers manage their own SSO, branding, or org settings — including any scenario where responsibility for configuration is delegated from the product owner to the customer: self-service admin portals, customer-managed SSO setup, letting customers configure their own identity providers, giving customers control over their organization without direct Auth0 access, or building a white-label admin experience. Also use when starting a delegated admin implementation from scratch, adding My Organization API to an existing delegated admin setup, or integrating pre-built UI components. Covers Auth0 config, SaaStart quickstart path, API-only integration, UI component integration, and backend validation.
+license: Proprietary
+metadata:
+  author: Auth0 Delegated Administration Team <authn-b2b-delegated-admin@okta.com>
+---
+
+# Using My Organization API
+
+> **Agent instructions — read before responding:**
+> - **Never ask if the user has an Auth0 account or tenant.** Always detect it. Check env files, the Auth0 CLI, the CLI config, and — as a final fallback — call the Auth0 MCP tool `mcp__auth0_mcp__auth0_get_tenant_name()` to retrieve the tenant domain directly. Only ask the user if all of these return nothing.
+> - Only ask about organization selection when multiple organizations exist in the tenant.
+> - **Assume React and Next.js unless the user specifies otherwise.** My Organization API and its tooling are optimized for this stack. Do not ask about framework unless the user has indicated they are not using Next.js.
+> - **Prefer Auth0 CLI and Auth0 developer tooling over manual steps wherever possible.** Use `auth0` CLI commands, the scripts in `<skill-path>/scripts/`, Auth0 SDKs (`@auth0/nextjs-auth0`, `@auth0/myorganization-js`, `@auth0/universal-components-react`), and the Auth0 Dashboard before reaching for general-purpose tools or writing custom implementations.
+> - **Be prescriptive. Do not reinvent auth flows, login pages, dashboard layouts, or session handling.** Follow the path defined in "Choose Your Path" exactly. Use SaaStart patterns as the reference for all auth and session setup. Do not invent custom implementations of things SaaStart or the Universal Components docs already define.
+> - **Determine the path from the decision tree in "Choose Your Path" — do not ask the user to choose.** Detect the project state and follow the tree. Only ask if the project state is genuinely ambiguous after detection.
+> - **Empty codebase with no specified stack:** scaffold Next.js, bootstrap with SaaStart, and use Universal Components. Inform the user of the choice, do not ask.
+> - **NEVER create a database.** Do not introduce Prisma, Supabase, MongoDB, SQLite, PostgreSQL, or any other database or ORM at any point in this implementation. **Auth0 is the source of organizations and users.** Organizations exist in Auth0. Users exist in Auth0. All org and user data must be read directly from Auth0 — via the My Organization API, Management API, or session. There is no need to store, sync, or mirror this data in a database. Creating a database to store users or organizations is incorrect and must not be done unless the user explicitly and specifically asks for it.
+> - **Do not ask the user what features or capabilities they want in the dashboard.** The features are determined by what My Organization API supports — they are not configurable. Proceed directly to implementation. My Organization API supports: SSO provider setup, organization settings, and branding. If the user asks about anything else (billing, subscriptions, app settings, user profiles, usage logs, member management, etc.), explain that it is not yet supported by My Organization API and they will need to use the Management API directly with organization-awareness built in (scoping all calls to the user's `org_id`).
+> - **Before starting the dev server, always run the pre-flight checks in "Configure Application URLs" and fix any issues found automatically** — do not wait for the user to encounter errors. Check and fix: callback/logout/web origin URLs on the Auth0 application, required env vars in `.env.local`, and org membership for the test user. If anything is missing, fix it silently and confirm what was done.
+> - **Try local before suggesting deployment.** Always attempt `npm run build` and `npm run dev` locally first. Do not suggest Vercel or any other deployment platform as a resolution path — deployment is out of scope for this skill and cannot be validated from within the agent environment.
+> - **When referencing SaaStart or any README, cite specific sections by name** (e.g. "Step Five: Run the sample application") rather than giving generic "check the README" advice.
+> - **If `EAGAIN: resource temporarily unavailable` appears**, explain that this is an OS-level file descriptor limit, not a code bug, and that it cannot be resolved from within the agent environment. Instruct the user to retry the command in their terminal outside the agent.
+
+**Delegated admin** lets your B2B customers manage their own organization—SSO providers, branding, and settings—without you doing it for them or giving them access to Auth0 directly. My Organization API is the Auth0 feature that makes this possible.
+
+## What You’ll Build
+
+An organization-scoped admin dashboard enabling:
+- 🔐 Customer-controlled SSO provider setup
+- 📋 Role-based access control (RBAC)
+- 🎨 Organization branding and display settings
+
+**Estimated implementation time:** 2–3 hours
+**Difficulty:** Intermediate (requires Auth0, Next.js, backend API knowledge)
+**Best for:** Anyone building or extending a delegated admin portal — from first-time implementers learning the API to teams adding My Organization API or UI components to an existing setup
+
+## When to Use This Skill
+
+Use this skill if you are:
+
+- **New to Auth0 or My Organization API** — you want to understand what delegated admin is and how My Organization API enables it
+- **Starting from scratch** — you're building a new delegated admin portal and want the fastest path using the SaaStart reference app
+- **Existing delegated admin setup, adding the API** — you already have delegated administration and want to integrate My Organization API calls directly into your app
+- **Existing delegated admin setup, adding UI components** — you already have delegated administration and want to drop in pre-built UI components from `@auth0/universal-components-react`
+
+## When NOT to Use This Skill
+
+❌ Tenant-level org lifecycle (creating/deleting organizations) — use the Management API directly
+❌ Non-Next.js implementations without adaptation — code examples are Next.js-specific
+❌ General Auth0 Organizations setup (use **auth0-organizations** skill instead)
+❌ User self-service account management (use **My Account API** skill instead)
+
+---
+
+## What is My Organization API?
+
+My Organization API is a **user-scoped** API — org admins call it directly from the browser using an organization-scoped access token, without proxying through your backend.
+
+| | My Organization API |
+|---|---|
+| **Called from** | Browser (client-side) |
+| **Token type** | User access token (org-scoped) |
+| **Audience** | `https://YOUR_DOMAIN/my-org/` |
+| **Used for** | SSO setup, org settings |
+
+This is why the audience URL (`/my-org/`) matters and why scopes are granted to the logged-in user rather than a backend service account.
+
+Once you understand the concept, use the **Choose Your Path** table below to determine the right implementation approach based on what you detect about the user's setup — do not ask the user which path to take.
+
+---
+
+## Choose Your Path
+
+Detect the project state and follow this decision tree. Do not ask the user to choose a path.
+
+```
+Does an existing codebase exist?
+│
+├── NO → Use SaaStart (Step 2 → SaaStart)
+│         Clone, bootstrap, and run. Do not build from scratch.
+│
+└── YES → Does the app already have UI for the delegated admin use case
+          (e.g. SSO provider management, org settings)?
+          │
+          ├── YES → Port existing Management API calls to My Org API
+          │         (Step 2 → Porting to My Org API)
+          │         Do not rebuild the UI. Just swap the API calls.
+          │
+          └── NO → Add UI using Universal Components
+                    (Step 2 → UI Components)
+                    Install missing dependencies (Shadcn, Tailwind) if needed —
+                    do NOT skip to custom UI because a dependency is missing.
+                    Only fall back to custom UI if the framework is non-React.
+```
+
+**What you need ready (all paths):**
+- Auth0 tenant with Organizations enabled
+- Node.js v20+ and npm installed
+- Auth0 CLI: `npm i -g auth0`
+
+---
+
+## Step 1: Enable My Organization API
+
+> **Always detect before asking.** Run the steps below before prompting the user about their setup. Only ask when detection is genuinely ambiguous (e.g. multiple organizations exist).
+
+### Detect Existing Configuration
+
+Run `detect-stack.mjs` to read the project's framework, package manager, Tailwind setup, existing Auth0 config, and key file paths in one pass. Use its output throughout all subsequent steps — do not grep env files or inspect package.json manually.
+
+```bash
+node <skill-path>/scripts/detect-stack.mjs <project-root>
+```
+
+Key fields to extract from the output:
+- `data.auth0.domain` — use as the tenant domain if set; otherwise fall back to CLI
+- `data.auth0.clientId` — use if set
+- `data.framework` — `nextjs` or `react-spa`
+- `data.tailwind.major` / `data.cssPath` — needed for theme extraction and verify-setup
+- `data.mainCssFile` — path to the main CSS file (needed for extract-theme.mjs)
+- `data.packageManager` / `data.installCmd` — use for all install commands
+
+If `data.auth0.domain` is not set, check the Auth0 CLI:
+```bash
+auth0 tenants list        # use the active tenant
+cat ~/.config/auth0/config.json 2>/dev/null | grep '"default_tenant"'
+```
+
+If the CLI config also returns nothing, call the Auth0 MCP tool before asking the user:
+```
+mcp__auth0_mcp__auth0_get_tenant_name()
+```
+This tool is always available in the environment and returns the tenant domain directly. Use its output as the domain for all subsequent steps.
+
+Only ask the user for their Auth0 domain if all four sources return nothing.
+
+### Validate Auth0 CLI Session
+
+First, confirm the Auth0 CLI is available in the shell — the validation script uses Node.js `execFileSync` which does not inherit the full shell PATH, so check reachability in bash first:
+
+```bash
+which auth0 || command -v auth0
+```
+
+If not found, install it:
+```bash
+# macOS
+brew install auth0
+
+# Other platforms: https://github.com/auth0/auth0-cli#installation
+```
+
+Once confirmed available, run the validation script with the full shell PATH forwarded so Node.js can find the `auth0` binary:
+
+```bash
+PATH="$PATH" node <skill-path>/scripts/validate-auth0.mjs --domain <tenant-domain>
+```
+
+If the script returns an error, follow the `fallback_instructions` in the output to re-authenticate, then re-run before continuing.
+
+### Identify Organization
+
+Once the tenant is known, check which organizations exist:
+
+```bash
+auth0 api get /api/v2/organizations
+```
+
+- **No organizations returned:** Proceed without asking — the user will create one as part of the implementation.
+- **One organization returned:** Use it automatically. Do not prompt the user.
+- **Multiple organizations returned:** List their names and ask the user: _"Which organization should this delegated admin portal be for?"_ then use the selected org's ID throughout.
+
+### Identify Application
+
+Determine which Auth0 application to configure:
+
+- **SaaStart path:** Use the application created by the bootstrap script — do not prompt the user.
+- **Existing setup (not SaaStart):** List existing apps and ask the user which one to update:
+  ```bash
+  auth0 apps list
+  ```
+  Ask: _"Which application should the delegated admin portal use?"_
+- **No existing app and not using SaaStart:** Default the application name to `Delegated Admin Dashboard`.
+
+### Prerequisites
+- Auth0 tenant with Organizations enabled
+- Application configured for organization-scoped access
+- Management API access for backend operations
+- Node.js v20+ and npm installed
+
+### Bootstrap Auth0 Tenant
+
+> **SaaStart note:** The SaaStart repo has its own bootstrap — skip this step and run `npm run auth0:bootstrap YOUR_DOMAIN` from the SaaStart repo instead.
+
+For all other paths (API-only, UI Components), run `bootstrap.mjs` to idempotently configure all required Auth0 resources: My Organization API resource server, application client, callback/logout/web origin URLs, client grants, database connection, admin role, and demo organization.
+
+```bash
+PATH="$PATH" node <skill-path>/scripts/bootstrap.mjs \
+  --domain <tenant-domain> \
+  --features myorg \
+  --framework nextjs \
+  --app-name "<app-name>" \
+  --port 3000
+```
+
+The script outputs a JSON object with `data.env_vars` — write every key/value pair into `.env.local`:
+
+```bash
+# Example: write env vars from bootstrap output to .env.local
+# (Parse the JSON output and append each key=value line)
+```
+
+The script is **idempotent** — safe to re-run if it fails partway through. If it exits with `status: "partial"`, check `error.fallback_instructions` and re-run after resolving.
+
+### Verify Setup
+
+Before starting the dev server, check that the installed Next.js version satisfies the peer dependency range declared by `@auth0/nextjs-auth0`:
+
+```bash
+node -e "
+const auth0Pkg = require('./node_modules/@auth0/nextjs-auth0/package.json');
+const nextPkg = require('./node_modules/next/package.json');
+const peer = auth0Pkg.peerDependencies?.next || 'not declared';
+console.log('Next.js installed:', nextPkg.version);
+console.log('Peer dep range:', peer);
+"
+```
+
+If the installed Next.js version is outside the declared peer range, downgrade Next.js to the latest compatible version or pin it in `package.json`. Mismatched versions cause `workUnitAsyncStorage` invariant errors at runtime.
+
+Then run `verify-setup.mjs` to confirm everything is wired up correctly before starting the dev server:
+
+```bash
+PATH="$PATH" node <skill-path>/scripts/verify-setup.mjs \
+  --project-root <project-root> \
+  --framework <framework> \
+  --css-path <cssPath>
+```
+
+For any check that returns `pass: false`, apply the fix in its `fix` field automatically — do not ask the user. Re-run until all checks pass.
+
+### Client Application Configuration
+Configure your application to access the My Organization API. The example below uses the Auth0 SPA JS / browser SDK (`@auth0/auth0-spa-js`) — see Step 2 for the Next.js server-side equivalent:
+
+```javascript
+// Browser SDK (@auth0/auth0-spa-js)
+const auth0 = new Auth0Client({
+  domain: 'YOUR_DOMAIN',
+  clientId: 'YOUR_CLIENT_ID',
+  authorizationParams: {
+    audience: 'https://YOUR_DOMAIN/my-org/',
+    scope: 'openid profile email read:my_org:details update:my_org:identity_providers'
+  }
+})
+```
+
+### Required Scopes
+```
+read:my_org:details           - Read organization profile
+update:my_org:details         - Update organization settings
+create:my_org:identity_providers - Configure SSO providers
+read:my_org:identity_providers   - View SSO configuration
+update:my_org:identity_providers - Modify SSO settings
+delete:my_org:identity_providers - Remove SSO providers
+```
+
+---
+
+## Step 2: Implement Admin Dashboard
+
+### SaaS Developer Workflow
+
+Use the [SaaStart reference application](https://github.com/auth0-ui-components/saas-starter-uicomponents) as your foundation — it's a complete working implementation you can bootstrap in minutes:
+
+> ⚠️ **The bootstrap script will create roles, organizations, and custom Actions on the tenant.** Make sure you're comfortable with these resources being added before running it.
+
+```bash
+# Clone the reference application
+git clone https://github.com/auth0-ui-components/saas-starter-uicomponents.git
+cd saas-starter-uicomponents
+
+# Install dependencies
+npm install
+
+# Configure environment
+cp .env.local.user.example .env.local.user
+```
+
+Edit `.env.local.user` with the following required values:
+```
+APP_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_AUTH0_DOMAIN=your-tenant.auth0.com
+SESSION_ENCRYPTION_SECRET=<run: openssl rand -hex 32>
+CUSTOM_CLAIMS_NAMESPACE=https://example.com
+```
+
+```bash
+# Authenticate with Auth0 CLI (required for bootstrap)
+auth0 login --domain YOUR_TENANT_DOMAIN
+
+# Bootstrap Auth0 tenant (creates all necessary resources including
+# admin/member roles, organizations, and custom actions)
+npm run auth0:bootstrap YOUR_TENANT_DOMAIN
+
+# Start development server
+npm run dev
+```
+
+**First run:** Visit `http://localhost:3000`, create an account with an organization name, and you'll land in the delegated admin dashboard.
+
+**What SaaStart already includes:** The reference app ships with the Auth0Client configuration, middleware, and permission validation patterns from Steps 2 and 3 already implemented. After bootstrapping, review these patterns to understand how the app works and customize them for your needs — you don't need to implement them from scratch.
+
+### Porting Existing Management API Calls to My Org API
+
+Use this path when an existing app already has UI for a delegated admin use case (e.g. SSO provider management) and you need to move those API calls from the Management API to My Org API. **Do not rebuild the UI** — only change the API layer.
+
+#### Step 1: Add the My Organization SDK
+
+```bash
+npm install @auth0/myorganization-js
+```
+
+Update `lib/auth0.ts` to request the My Org API audience and scopes. SaaStart users: this file is named `lib/app-client.ts` and exports `appClient` — update in place:
+
+```typescript
+// lib/auth0.ts (or lib/app-client.ts in SaaStart)
+const MY_ORG_SCOPES = [
+  'openid', 'profile', 'email', 'offline_access',
+  'read:my_org:details', 'update:my_org:details',
+  'create:my_org:identity_providers', 'read:my_org:identity_providers',
+  'update:my_org:identity_providers', 'delete:my_org:identity_providers'
+]
+
+export const auth0 = new Auth0Client({
+  domain: process.env.AUTH0_DOMAIN,
+  clientId: process.env.AUTH0_CLIENT_ID,
+  authorizationParameters: {
+    audience: `https://${process.env.AUTH0_DOMAIN}/my-org/`,
+    scope: MY_ORG_SCOPES.join(' ')
+  }
+})
+```
+
+Initialize the My Org client with the **token supplier pattern**:
+
+```typescript
+// lib/my-org-client.ts
+import { MyOrganizationClient } from '@auth0/myorganization-js'
+import { auth0 } from '@/lib/auth0'
+
+export const myOrgClient = new MyOrganizationClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  token: async ({ scope }) => {
+    const { token } = await auth0.getAccessToken({ scopes: [scope] })
+    return token
+  }
+})
+```
+
+#### Step 2: Replace Management API calls with My Org API calls
+
+The typical use case is SSO provider management. Replace calls like this:
+
+```typescript
+// Before: Management API (requires M2M token, backend-only)
+await managementClient.connections.get({ id: connectionId })
+await managementClient.connections.create({ ... })
+
+// After: My Org API (uses user's org-scoped token)
+import { myOrgClient } from '@/lib/my-org-client'
+import { MyOrganizationError } from '@auth0/myorganization-js'
+
+try {
+  const providers = await myOrgClient.identityProviders.getAll()
+  // or: await myOrgClient.identityProviders.create({ ... })
+} catch (err) {
+  if (err instanceof MyOrganizationError) {
+    console.error(err.statusCode, err.message)
+  }
+}
+```
+
+See the **[myorganization-js SDK reference](https://github.com/auth0/myorganization-js)** for the full list of available methods.
+
+#### Member Management
+> **Not yet supported by My Organization API.** This feature is planned for a future release. The pattern below uses the Management API in the interim.
+
+```typescript
+// app/dashboard/organization/members/actions.ts
+export const createInvitation = withServerActionAuth(
+  async function createInvitation(formData: FormData, session: SessionData) {
+    const email = formData.get('email')
+    const role = formData.get('role') as Role
+
+    await managementClient.organizations.createInvitation({
+      id: session.user.org_id!
+    }, {
+      invitee: { email },
+      inviter: { name: session.user.name! },
+      client_id: process.env.AUTH0_CLIENT_ID,
+      roles: role === 'admin' ? [process.env.AUTH0_ADMIN_ROLE_ID!] : []
+    })
+
+    revalidatePath('/dashboard/organization/members')
+  },
+  { role: 'admin' }
+)
+```
+
+### UI Components
+
+Use this path when an existing app does **not** yet have UI for a delegated admin use case. Add it using `@auth0/universal-components-react` — do not build custom forms from scratch. Follow the [Universal Components docs](https://auth0.com/docs/get-started/universal-components/universal-components-overview) exactly.
+
+> **Only fall back to custom UI if the framework is non-React.** Missing dependencies (Shadcn, Tailwind, react-hook-form) are not a reason to skip Universal Components — install them first. Do not interpret a missing dependency as framework incompatibility.
+
+**Before installing Universal Components, check and install all required dependencies:**
+
+```bash
+# 1. Check detect-stack output for shadcn.installed and tailwind.installed
+# If shadcn.installed: false — install and configure Shadcn UI first:
+npx shadcn@latest init
+
+# If tailwind.installed: false — install Tailwind CSS:
+npm install -D tailwindcss postcss autoprefixer
+npx tailwindcss init -p
+```
+
+Do not proceed to Universal Components until `shadcn.installed: true` and `tailwind.installed: true`.
+
+`@auth0/universal-components-react` provides pre-built React components for SSO provider setup, organization details editing, and more.
+
+**Install dependencies:**
+```bash
+npm install @auth0/universal-components-react react-hook-form
+```
+
+Also required: **Shadcn UI** and **Tailwind CSS v3** — see the [Universal Components docs](https://auth0.com/docs/get-started/universal-components/universal-components-overview) for setup.
+
+**Extract theme overrides from the project's existing CSS:**
+
+Use `extract-theme.mjs` to generate a complete Auth0 component theme override block from the project's CSS variables. Use `data.mainCssFile` and `data.cssPath` from the `detect-stack.mjs` output:
+
+```bash
+node <skill-path>/scripts/extract-theme.mjs \
+  --css-file <project-root>/<mainCssFile> \
+  --css-path <cssPath>
+```
+
+From the output:
+- Apply `data.generatedOverrideBlock` verbatim to the project's main CSS file (`:root` block)
+- Pass `data.themeSettingsVariables` as the `themeSettings` prop on `Auth0ComponentProvider`
+
+**Available components:**
+- `OrganizationDetailsEdit` — view and edit organization settings and branding (recommended starting point)
+- `SsoProviderCreate` / `SsoProviderList` — configure OIDC/SAML identity providers
+
+**Set up `Auth0ComponentProvider`:**
+
+All components require `Auth0ComponentProvider` as a wrapper — it handles token acquisition, caching, and i18n. For Next.js, use proxy mode:
+
+```tsx
+// app/layout.tsx (or a dedicated providers component)
+import { Auth0ComponentProvider } from '@auth0/universal-components-react/rwa'
+import '@auth0/universal-components-react/styles'
+
+export default function RootLayout({ children }) {
+  return (
+    <Auth0ComponentProvider
+      mode="proxy"
+      domain={process.env.NEXT_PUBLIC_AUTH0_DOMAIN}
+      proxyConfig={{ baseUrl: '/api/auth' }}
+      interactiveErrorHandler="popup"
+    >
+      {children}
+    </Auth0ComponentProvider>
+  )
+}
+```
+
+**Use a component:**
+```tsx
+// app/dashboard/organization/details/page.tsx
+import { OrganizationDetailsEdit } from '@auth0/universal-components-react/rwa'
+
+export const dynamic = 'force-dynamic'
+
+export default function OrganizationDetailsPage() {
+  return <OrganizationDetailsEdit />
+}
+```
+
+```tsx
+// app/dashboard/organization/sso/create/page.tsx
+import { SsoProviderCreate } from '@auth0/universal-components-react/rwa'
+import { useRouter } from 'next/navigation'
+
+export const dynamic = 'force-dynamic'
+
+export default function SsoProviderCreatePage() {
+  const router = useRouter()
+  return (
+    <SsoProviderCreate
+      createAction={{ onAfter: () => router.push('/dashboard/organization/sso') }}
+      backButton={{ onClick: () => router.back() }}
+    />
+  )
+}
+```
+
+See the **[Universal Components docs](https://auth0.com/docs/get-started/universal-components/universal-components-overview)** for the full component catalogue and styling options.
+
+#### Security Policies
+> **Not yet supported by My Organization API.** This feature is planned for a future release. The pattern below uses the Management API in the interim.
+
+```typescript
+// app/dashboard/organization/security-policies/actions.ts
+export const updateMfaPolicy = withServerActionAuth(
+  async function updateMfaPolicy(formData: FormData, session: SessionData) {
+    const enforce = !!formData.get('enforce')
+    const providers = ['otp', 'webauthn-roaming'].filter(p => formData.get(p))
+
+    await managementClient.organizations.update({
+      id: session.user.org_id!
+    }, {
+      metadata: {
+        mfaPolicy: JSON.stringify({
+          enforce,
+          providers,
+          skipForDomains: []
+        })
+      }
+    })
+
+    revalidatePath('/dashboard/organization/security-policies')
+  },
+  { role: 'admin' }
+)
+```
+
+---
+
+## Step 3: Backend Validation
+
+> **Add `export const dynamic = 'force-dynamic'` to every auth-gated server component page or layout that calls `auth0.getSession()` or any async Auth0 API.** This prevents the `workUnitAsyncStorage` invariant error on Next.js 15.5.x and is a safe default for all protected pages.
+
+### Organization Context Middleware
+```typescript
+// middleware.ts
+import { auth0 } from '@/lib/auth0'
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export default async function middleware(req: NextRequest) {
+  const authRes = await auth0.middleware(req)
+  const session = await auth0.getSession()
+  const orgId = session?.user.org_id
+
+  if (!orgId) {
+    return NextResponse.redirect(new URL('/onboarding', req.url))
+  }
+
+  return authRes
+}
+```
+
+### Permission Validation
+```typescript
+// lib/with-server-action-auth.ts
+export function withServerActionAuth<T extends any[], U extends any>(
+  serverActionWithSession: (...args: [...T, session: SessionData]) => U,
+  options: { role?: Role }
+) {
+  return async function (...args: T) {
+    const session = await auth0.getSession()
+
+    if (options.role && getRole(session.user) !== options.role) {
+      throw new Error(`Admin access required`)
+    }
+
+    return serverActionWithSession(...args, session)
+  }
+}
+```
+
+---
+
+## Additional Resources
+
+- **[SaaStart Reference App](https://github.com/auth0-ui-components/saas-starter-uicomponents)** - Complete implementation example
+- **[myorganization-js SDK](https://github.com/auth0/myorganization-js)** - Official JavaScript SDK for My Organization API
+- **[My Organization API Docs](https://auth0.com/docs/manage-users/my-organization-api)** - Official documentation
+- **[Organizations Overview](https://auth0.com/docs/manage-users/organizations)** - Core concepts
+- **[Universal Components](https://github.com/auth0/auth0-ui-components)** - Pre-built React components for delegated admin (org settings, SSO setup, and more)
+
+## Common Mistakes & Fixes
+
+Every mistake here has been reported by developers implementing My Organization API. Use this diagnostic guide to unblock yourself:
+
+**1. Access Denied errors with correct scopes**
+- **Cause:** Token audience is wrong (using `https://domain/` instead of `https://domain/my-org/`)
+- **Fix:**
+  1. Check your Next.js auth client configuration
+  2. Set `authorizationParameters.audience` to exactly `https://YOUR_DOMAIN/my-org/`
+  3. Redeploy and request a new token
+- **Verify:** Decode your access token at [jwt.io](https://jwt.io) and check that `.aud` claim contains `https://YOUR_DOMAIN/my-org/` ✓
+
+**2. SaaStart bootstrap fails with 401**
+- **Cause:** Auth0 CLI not authenticated or user lacks admin permissions
+- **Fix:**
+  1. Run `auth0 login --domain YOUR_DOMAIN`
+  2. Select your org tenant at the prompt
+  3. Wait for browser confirmation
+- **Verify:** Run `auth0 tenants list` and see your tenant listed ✓
+
+**3. Scope errors in token request ("Invalid scope")**
+- **Cause:** Requesting scopes that don't exist or aren't enabled on the My Organization API
+- **Fix:**
+  1. Go to Auth0 Dashboard > Applications > APIs
+  2. Click **My Organization API**
+  3. Go to **Scopes** tab and verify these scopes exist:
+     ```
+     read:my_org:details
+     update:my_org:details
+     read:my_org:identity_providers
+     create:my_org:identity_providers
+     update:my_org:identity_providers
+     delete:my_org:identity_providers
+     ```
+  4. Update your auth client config to only request available scopes
+- **Verify:** Token request succeeds and you get a valid access token ✓
+
+**4. CORS failures from browser**
+- **Cause:** Browser is blocking My Organization API requests
+- **Fix:**
+  1. No configuration needed—My Organization API has CORS enabled by default
+  2. Check your browser DevTools > Network tab for the actual error
+  3. Verify your Auth0 domain matches your app's configuration
+- **Verify:** API request succeeds with 200 status in DevTools Network tab ✓
+
+**5. Role-based access control not enforced**
+- **Cause:** Dashboard shows all buttons but backend doesn't validate permissions
+- **Fix:**
+  1. Implement `withServerActionAuth` wrapper on all protected actions
+  2. Always validate `session.user.org_id` and role server-side
+  3. Never trust client-side role checks
+- **Verify:** Try accessing as non-admin user—you should get "Admin access required" error ✓
+
+**6. API/Management API confusion**
+- **Cause:** Using wrong API for the wrong operation
+- **Fix:**
+  - **Use My Organization API** (`https://your-domain/my-org/`) for: SSO setup, org settings
+  - **Use Management API** for: Tenant-level operations outside the scope of this skill
+  - In Next.js: Management API uses `managementClient.organizations.*`; My Organization API calls come directly from client
+- **Verify:** Check which API each endpoint uses by reading the [api.md](references/api.md) reference ✓
+
+**7. Mixing My Account API and My Organization API**
+- **Cause:** Building both org self-service (delegated admin) and user self-service (profile/password)
+- **Fix:**
+  - Use **My Organization API** for delegated admin (admin-level operations)
+  - Use **My Account API** for user profile/password/settings (user-level operations)
+  - They have different audiences and scopes
+- **Verify:** My Organization API page shows team/org settings; My Account API shows individual user settings ✓
+
+**8. Forgetting offline_access scope**
+- **Cause:** Admin sessions expire mid-workflow with 401 errors
+- **Fix:**
+  1. Add `offline_access` to your My Organization API scopes
+  2. Ensure refresh tokens are stored in Next.js session
+- **Result:** Users can stay logged in for long admin tasks without interruption ✓
+
+**9. "Callback URL mismatch" or "callback URL not set" at login**
+- **Cause:** The Auth0 application doesn't have the app's callback URL in its Allowed Callback URLs list
+- **Fix:**
+  1. Go to Auth0 Dashboard > Applications > Applications > your app > Settings
+  2. Add to **Allowed Callback URLs**: `http://localhost:3000/api/auth/callback`
+  3. Add to **Allowed Logout URLs**: `http://localhost:3000`
+  4. Add to **Allowed Web Origins**: `http://localhost:3000`
+  5. Save and retry login
+  Or via CLI: `auth0 api patch "v2/clients/YOUR_CLIENT_ID" --data '{"callbacks":["http://localhost:3000/api/auth/callback"],"allowed_logout_urls":["http://localhost:3000"],"web_origins":["http://localhost:3000"]}'`
+- **Verify:** Login completes and redirects back to `http://localhost:3000/dashboard` ✓
+
+**10. "Invalid state" error after login redirect**
+- **Cause:** `AUTH0_SECRET` is missing, empty, or too short — this causes the session state cookie to be invalid or unreadable
+- **Fix:**
+  1. Generate a secret: `openssl rand -hex 32`
+  2. Add to your `.env.local`: `AUTH0_SECRET=<generated value>`
+  3. Also ensure `AUTH0_BASE_URL=http://localhost:3000` is set and matches your running app URL
+  4. Restart the dev server
+- **Verify:** Login flow completes without errors; check that `AUTH0_SECRET` is at least 32 characters ✓
+
+**11. "Not authorized" after login**
+- **Cause:** The logged-in user is not a member of the organization, or the organization's connection is not enabled for this application
+- **Fix:**
+  1. In Auth0 Dashboard > Organizations > your org > Members, confirm the user is listed
+  2. In Auth0 Dashboard > Organizations > your org > Connections, confirm your database connection is enabled
+  3. In Auth0 Dashboard > Applications > your app > Organizations, confirm the org is associated with the app
+  4. If testing with a new account, create the account first, then add it as an org member with the admin role
+- **Verify:** User can log in and `session.user.org_id` is populated ✓
+
+**12. "The client was not found" error**
+- **Cause:** `AUTH0_CLIENT_ID` in `.env.local` doesn't match any application on the tenant — usually because the bootstrap created the client but the env vars weren't written, or the wrong tenant domain is being used
+- **Fix:**
+  1. Run `auth0 apps list` and find the app created during bootstrap
+  2. Copy its `client_id` value
+  3. Update `AUTH0_CLIENT_ID` (and `AUTH0_CLIENT_SECRET`) in `.env.local` to match
+  4. Confirm `AUTH0_DOMAIN` matches the tenant the app was created on
+  5. Restart the dev server
+- **Verify:** Run `node <skill-path>/scripts/verify-setup.mjs --project-root . --framework nextjs` and confirm `env_vars_present` passes ✓
+
+**14. `workUnitAsyncStorage` invariant error on Next.js 15.5.x**
+- **Cause:** Next.js 15.5.x changed how async context is propagated in server components. Calling `auth0.getSession()` or other async Auth0 APIs from a server component page without opting out of static rendering triggers the invariant error.
+- **Fix:**
+  1. Add `export const dynamic = 'force-dynamic'` to every auth-gated server component page or layout that calls async Auth0 APIs
+  2. If the error persists, check that the installed Next.js version is within the peer dep range of `@auth0/nextjs-auth0`: `cat node_modules/@auth0/nextjs-auth0/package.json | grep -A3 peerDependencies`
+  3. If Next.js is too new, pin it: `npm install next@<compatible-version>`
+- **Verify:** Pages load without the invariant error in the console ✓
+
+**13. Dev server crashes on startup with TCP/socket errors**
+- **Cause:** A bad Auth0 configuration (missing or mismatched env vars) causes the Next.js server to throw during module initialization, which crashes the process before it can bind to the port
+- **Fix:**
+  1. Check `.env.local` for missing `AUTH0_SECRET`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, or `AUTH0_DOMAIN`
+  2. Re-run `node <skill-path>/scripts/verify-setup.mjs --project-root . --framework nextjs` and apply all fixes
+  3. Restart the dev server only after all checks pass
+- **Verify:** `npm run dev` starts without errors and binds to `http://localhost:3000` ✓
+
+## After Your Implementation
+
+Once your admin dashboard is live:
+
+1. **Test with a real org admin account** — Walk through SSO setup and org configuration end-to-end
+2. **Monitor token refresh** — Ensure offline sessions don't drop mid-workflow
+3. **Plan for scale** — If you have >100 organizations, optimize caching of organization metadata
+4. **Security audit** — Run through the backend validation checklist with your security team
+
+## Related Skills
+
+- **auth0-organizations** — General Auth0 Organizations setup and lifecycle management
+- **My Account API** — User self-service account management (profile, password, MFA)
+- **auth0-sso-configuration** — SSO provider setup (if you need deeper guidance)
+- **auth0-mfa** — Multi-factor authentication policies and enforcement
+- **auth0-roles-permissions** — Role-based access control (RBAC) implementation
+
+## Quick Reference
+
+### Scopes Needed
+```
+openid profile email offline_access
+read:my_org:details
+update:my_org:details
+read:my_org:identity_providers
+create:my_org:identity_providers
+update:my_org:identity_providers
+delete:my_org:identity_providers
+```
+
+### Audience Required
+```
+https://YOUR_AUTH0_DOMAIN/my-org/
+```
+
+### Key Environment Variables
+```
+AUTH0_DOMAIN=your-domain.us.auth0.com
+AUTH0_CLIENT_ID=your_client_id
+AUTH0_CLIENT_SECRET=your_client_secret
+AUTH0_ADMIN_ROLE_ID=role_xxxxx
+```
+
+## Documentation
+
+For step-by-step help with:
+- **Code examples by SDK** → see [examples.md](references/examples.md)
+- **Backend validation patterns** → see [backend.md](references/backend.md)
+- **Advanced topics** (Actions, webhooks) → see [advanced.md](references/advanced.md)
+- **API endpoints & CLI commands** → see [api.md](references/api.md)

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/references/advanced.md
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/references/advanced.md
@@ -1,0 +1,583 @@
+# My Organization API - Advanced Use Cases
+
+## Actions Integration
+
+### Pre-User Registration Action
+```typescript
+// actions/pre-user-registration.js
+exports.onExecutePreUserRegistration = async (event, api) => {
+  const { user, organization } = event
+
+  if (!organization) {
+    // New user registration outside organization context
+    return
+  }
+
+  // Check organization member limits
+  const memberCount = await getOrganizationMemberCount(organization.id)
+
+  if (memberCount >= organization.metadata?.memberLimit) {
+    api.access.deny('Organization member limit exceeded')
+    return
+  }
+
+  // Apply organization-specific user metadata
+  api.user.setUserMetadata('organization_id', organization.id)
+  api.user.setUserMetadata('joined_at', new Date().toISOString())
+
+  // Set default roles based on organization policy
+  const defaultRole = organization.metadata?.defaultRole || 'member'
+  api.user.setUserMetadata('role', defaultRole)
+}
+```
+
+### Post-Login Action for Organization Context
+```typescript
+// actions/post-login-organization-context.js
+exports.onExecutePostLogin = async (event, api) => {
+  const { user, organization, secrets } = event
+
+  if (!organization) {
+    // User logging in without organization context
+    // Check if they have pending invitations
+    const pendingInvitations = await getPendingInvitationsForUser(user.email, secrets)
+
+    if (pendingInvitations.length > 0) {
+      // Redirect to invitation acceptance flow
+      api.redirect.sendUserTo('https://yourapp.com/accept-invitation', {
+        query: {
+          invitation_id: pendingInvitations[0].id,
+          org_id: pendingInvitations[0].organization_id
+        }
+      })
+      return
+    }
+
+    // No organization context and no invitations
+    api.redirect.sendUserTo('https://yourapp.com/onboarding')
+    return
+  }
+
+  // User has organization context
+  // Ensure user metadata is up to date
+  api.user.setUserMetadata('current_org_id', organization.id)
+  api.user.setUserMetadata('last_login_org', organization.id)
+
+  // Apply organization-specific security policies
+  if (organization.metadata?.requireMfa) {
+    // Check if user has completed MFA
+    const hasMfa = user.multifactor && user.multifactor.length > 0
+
+    if (!hasMfa) {
+      api.multifactor.enable('any', { allowRememberBrowser: false })
+    }
+  }
+
+  // Set organization-specific claims
+  api.idToken.setCustomClaim('org_id', organization.id)
+  api.idToken.setCustomClaim('org_name', organization.display_name)
+  api.idToken.setCustomClaim('user_role', await getUserRoleInOrganization(user.user_id, organization.id, secrets))
+
+  // Handle organization switching
+  const requestedOrgId = api.getQueryParameter('organization')
+  if (requestedOrgId && requestedOrgId !== organization.id) {
+    // Validate user has access to requested organization
+    const hasAccess = await userHasAccessToOrganization(user.user_id, requestedOrgId, secrets)
+
+    if (hasAccess) {
+      api.redirect.sendUserTo('https://yourapp.com/dashboard', {
+        query: { org: requestedOrgId }
+      })
+    }
+  }
+}
+```
+
+### Machine-to-Machine Token Customization
+```typescript
+// actions/m2m-token-customization.js
+exports.onExecutePostLogin = async (event, api) => {
+  const { client, accessToken } = event
+
+  // Only apply to M2M clients with organization scope
+  if (client.client_id !== process.env.MY_ORG_API_CLIENT_ID) {
+    return
+  }
+
+  // Add organization context to M2M tokens
+  // This allows API calls to be scoped to specific organizations
+  const orgId = accessToken.getCustomClaim('org_id')
+  if (orgId) {
+    api.accessToken.setCustomClaim('organization_id', orgId)
+    api.accessToken.setCustomClaim('org_permissions', await getOrganizationPermissions(orgId))
+  }
+}
+```
+
+## Security Policies and Enforcement
+
+### Advanced MFA Policies
+```typescript
+// lib/advancedMfaPolicy.ts
+export interface AdvancedMfaPolicy {
+  enforce: boolean
+  providers: string[]
+  skipForDomains: string[]
+  adaptiveMfa: {
+    enabled: boolean
+    riskThreshold: 'low' | 'medium' | 'high'
+    trustedNetworks: string[]
+  }
+  stepUpAuthentication: {
+    enabled: boolean
+    sensitiveOperations: string[]
+    maxAge: number // seconds
+  }
+}
+
+export async function evaluateMfaRequirement(
+  user: any,
+  organization: any,
+  operation: string,
+  context: {
+    ipAddress: string
+    userAgent: string
+    location?: { country: string; city: string }
+  }
+): Promise<boolean> {
+  const policy: AdvancedMfaPolicy = organization.metadata?.advancedMfaPolicy
+
+  if (!policy?.enforce) {
+    return false
+  }
+
+  // Check domain exemptions
+  const userDomain = user.email.split('@')[1]
+  if (policy.skipForDomains.includes(userDomain)) {
+    return false
+  }
+
+  // Check step-up authentication
+  if (policy.stepUpAuthentication?.enabled) {
+    if (policy.stepUpAuthentication.sensitiveOperations.includes(operation)) {
+      return true
+    }
+
+    // Check if step-up window has expired
+    const lastMfaTime = user.last_mfa_verification
+    if (lastMfaTime) {
+      const timeSinceMfa = Date.now() - new Date(lastMfaTime).getTime()
+      if (timeSinceMfa > (policy.stepUpAuthentication.maxAge * 1000)) {
+        return true
+      }
+    }
+  }
+
+  // Check adaptive MFA
+  if (policy.adaptiveMfa?.enabled) {
+    const riskScore = await calculateRiskScore(context)
+
+    const thresholds = {
+      low: 30,
+      medium: 60,
+      high: 80
+    }
+
+    if (riskScore >= thresholds[policy.adaptiveMfa.riskThreshold]) {
+      return true
+    }
+
+    // Check trusted networks
+    if (policy.adaptiveMfa.trustedNetworks.some(network =>
+      isIpInNetwork(context.ipAddress, network)
+    )) {
+      return false
+    }
+  }
+
+  return false
+}
+
+async function calculateRiskScore(context: any): Promise<number> {
+  let score = 0
+
+  // Unknown location
+  if (!context.location) {
+    score += 40
+  }
+
+  // Unusual location
+  if (context.location && !isCommonLocationForUser(context.location)) {
+    score += 30
+  }
+
+  // Unknown device
+  if (!isKnownUserAgent(context.userAgent)) {
+    score += 20
+  }
+
+  // Non-trusted IP
+  if (!isTrustedIp(context.ipAddress)) {
+    score += 10
+  }
+
+  return Math.min(score, 100)
+}
+```
+
+### Session Management Policies
+```typescript
+// lib/sessionPolicy.ts
+export interface SessionPolicy {
+  maxAge: number // seconds
+  idleTimeout: number // seconds
+  maxConcurrentSessions: number
+  deviceTracking: boolean
+  geographicRestrictions: {
+    allowedCountries: string[]
+    blockedCountries: string[]
+  }
+  networkRestrictions: {
+    allowedIpRanges: string[]
+    blockedIpRanges: string[]
+  }
+}
+
+export async function validateSession(
+  session: any,
+  context: {
+    ipAddress: string
+    userAgent: string
+    location?: { country: string }
+  }
+): Promise<{ valid: boolean; reason?: string }> {
+  const orgId = session.user?.org_id
+
+  if (!orgId) {
+    return { valid: false, reason: 'No organization context' }
+  }
+
+  const policy = await getOrganizationSessionPolicy(orgId)
+
+  // Check session age
+  const sessionAge = Date.now() - session.iat * 1000
+  if (sessionAge > policy.maxAge * 1000) {
+    return { valid: false, reason: 'Session expired' }
+  }
+
+  // Check idle timeout
+  const lastActivity = session.last_activity || session.iat * 1000
+  const idleTime = Date.now() - lastActivity
+  if (idleTime > policy.idleTimeout * 1000) {
+    return { valid: false, reason: 'Session idle timeout' }
+  }
+
+  // Check geographic restrictions
+  if (context.location) {
+    if (policy.geographicRestrictions.blockedCountries.includes(context.location.country)) {
+      return { valid: false, reason: 'Geographic restriction' }
+    }
+
+    if (policy.geographicRestrictions.allowedCountries.length > 0 &&
+        !policy.geographicRestrictions.allowedCountries.includes(context.location.country)) {
+      return { valid: false, reason: 'Geographic restriction' }
+    }
+  }
+
+  // Check network restrictions
+  if (!isIpAllowed(context.ipAddress, policy.networkRestrictions)) {
+    return { valid: false, reason: 'Network restriction' }
+  }
+
+  // Check concurrent sessions
+  if (policy.maxConcurrentSessions > 0) {
+    const activeSessions = await getActiveSessionsForUser(session.user.sub, orgId)
+    if (activeSessions >= policy.maxConcurrentSessions) {
+      return { valid: false, reason: 'Maximum concurrent sessions exceeded' }
+    }
+  }
+
+  return { valid: true }
+}
+
+function isIpAllowed(ipAddress: string, restrictions: any): boolean {
+  // Check blocked ranges first
+  for (const range of restrictions.blockedIpRanges) {
+    if (isIpInRange(ipAddress, range)) {
+      return false
+    }
+  }
+
+  // If allowed ranges are specified, IP must be in one of them
+  if (restrictions.allowedIpRanges.length > 0) {
+    return restrictions.allowedIpRanges.some((range: string) =>
+      isIpInRange(ipAddress, range)
+    )
+  }
+
+  return true
+}
+```
+
+## SCIM Integration
+
+### SCIM Provisioning Setup
+```typescript
+// lib/scimProvisioning.ts
+import { ManagementClient } from 'auth0'
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+export async function setupScimProvisioning(orgId: string, scimConfig: {
+  endpoint: string
+  token: string
+  mapping: Record<string, string>
+}): Promise<void> {
+  // Create SCIM connection
+  const connection = await management.connections.create({
+    name: `scim-${orgId}`,
+    strategy: 'scim',
+    options: {
+      scim_endpoint: scimConfig.endpoint,
+      scim_token: scimConfig.token,
+      mapping: scimConfig.mapping
+    }
+  })
+
+  // Enable for organization
+  await management.organizations.addEnabledConnection({
+    id: orgId
+  }, {
+    connection_id: connection.id,
+    assign_membership_on_login: true
+  })
+
+  // Update organization metadata
+  await management.organizations.update({
+    id: orgId
+  }, {
+    metadata: {
+      scimEnabled: true,
+      scimConnectionId: connection.id
+    }
+  })
+}
+
+export async function syncUsersFromScim(orgId: string): Promise<void> {
+  const { data: org } = await management.organizations.get({ id: orgId })
+  const scimConnectionId = org.metadata?.scimConnectionId
+
+  if (!scimConnectionId) {
+    throw new Error('SCIM not configured for this organization')
+  }
+
+  // Trigger SCIM sync
+  await management.connections.sync({
+    id: scimConnectionId
+  })
+}
+```
+
+## Multi-Organization Management
+
+### Organization Switching
+```typescript
+// lib/organizationSwitching.ts
+export async function switchUserOrganization(
+  userId: string,
+  newOrgId: string
+): Promise<{ redirectUrl: string; token: string }> {
+  // Validate user has access to the new organization
+  const hasAccess = await userHasAccessToOrganization(userId, newOrgId)
+
+  if (!hasAccess) {
+    throw new Error('User does not have access to this organization')
+  }
+
+  // Generate organization-scoped token
+  const token = await generateOrganizationToken(userId, newOrgId)
+
+  // Get organization details for redirect
+  const { data: org } = await management.organizations.get({ id: newOrgId })
+
+  return {
+    redirectUrl: `${process.env.APP_BASE_URL}/dashboard?org=${newOrgId}`,
+    token
+  }
+}
+
+export async function getUserOrganizations(userId: string): Promise<Array<{
+  id: string
+  name: string
+  role: string
+  isCurrent: boolean
+}>> {
+  // Get all organizations where user is a member
+  const organizations = await management.organizations.getAll({
+    member: userId
+  })
+
+  const userOrgs = await Promise.all(
+    organizations.data.map(async (org) => {
+      const { data: members } = await management.organizations.getMembers({
+        id: org.id,
+        include_totals: false
+      })
+
+      const member = members.find(m => m.user_id === userId)
+      const roles = await management.organizations.getMemberRoles({
+        id: org.id,
+        user_id: userId
+      })
+
+      return {
+        id: org.id,
+        name: org.display_name,
+        role: roles.data.length > 0 ? roles.data[0].name : 'member',
+        isCurrent: org.id === getCurrentOrgFromSession()
+      }
+    })
+  )
+
+  return userOrgs
+}
+```
+
+## Audit Logging
+
+### Organization Activity Logging
+```typescript
+// lib/organizationAudit.ts
+export interface AuditEvent {
+  timestamp: Date
+  userId: string
+  organizationId: string
+  action: string
+  resource: string
+  details: Record<string, any>
+  ipAddress: string
+  userAgent: string
+}
+
+export async function logOrganizationActivity(event: Omit<AuditEvent, 'timestamp'>): Promise<void> {
+  const auditEvent: AuditEvent = {
+    ...event,
+    timestamp: new Date()
+  }
+
+  // Store in organization metadata or external audit system
+  await management.organizations.update({
+    id: event.organizationId
+  }, {
+    metadata: {
+      lastActivity: auditEvent.timestamp.toISOString(),
+      lastActivityBy: event.userId
+    }
+  })
+
+  // Send to external audit logging service
+  await sendToAuditService(auditEvent)
+
+  // Check for suspicious activity
+  await analyzeForSuspiciousActivity(auditEvent)
+}
+
+export async function getOrganizationAuditLog(
+  orgId: string,
+  filters: {
+    userId?: string
+    action?: string
+    dateRange?: { start: Date; end: Date }
+    limit?: number
+  }
+): Promise<AuditEvent[]> {
+  // Query audit logs from external system
+  return await queryAuditLogs(orgId, filters)
+}
+
+async function analyzeForSuspiciousActivity(event: AuditEvent): Promise<void> {
+  const suspiciousPatterns = [
+    // Multiple failed login attempts
+    { action: 'login_failed', threshold: 5, window: 15 * 60 * 1000 }, // 5 in 15 min
+
+    // Unusual login locations
+    { action: 'login_success', checkLocation: true },
+
+    // Privilege escalation attempts
+    { action: 'role_change', checkPrivilege: true },
+
+    // Bulk member operations
+    { action: 'member_invite', threshold: 10, window: 60 * 1000 } // 10 in 1 min
+  ]
+
+  for (const pattern of suspiciousPatterns) {
+    if (matchesPattern(event, pattern)) {
+      await triggerSecurityAlert(event, pattern)
+    }
+  }
+}
+```
+
+## Error Recovery and Resilience
+
+### Circuit Breaker Pattern
+```typescript
+// lib/circuitBreaker.ts
+export class OrganizationCircuitBreaker {
+  private failures = 0
+  private lastFailureTime = 0
+  private state: 'closed' | 'open' | 'half-open' = 'closed'
+
+  constructor(
+    private failureThreshold: number = 5,
+    private recoveryTimeout: number = 60000 // 1 minute
+  ) {}
+
+  async execute<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.state === 'open') {
+      if (Date.now() - this.lastFailureTime > this.recoveryTimeout) {
+        this.state = 'half-open'
+      } else {
+        throw new Error('Circuit breaker is open')
+      }
+    }
+
+    try {
+      const result = await operation()
+      this.onSuccess()
+      return result
+    } catch (error) {
+      this.onFailure()
+      throw error
+    }
+  }
+
+  private onSuccess() {
+    this.failures = 0
+    this.state = 'closed'
+  }
+
+  private onFailure() {
+    this.failures++
+    this.lastFailureTime = Date.now()
+
+    if (this.failures >= this.failureThreshold) {
+      this.state = 'open'
+    }
+  }
+}
+
+// Usage in organization operations
+const circuitBreaker = new OrganizationCircuitBreaker()
+
+export async function safeOrganizationOperation(orgId: string, operation: string) {
+  return circuitBreaker.execute(async () => {
+    // Perform organization operation
+    return await performOperation(orgId, operation)
+  })
+}
+```

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/references/api.md
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/references/api.md
@@ -1,0 +1,478 @@
+# My Organization API - Management API & CLI
+
+## Management API Endpoints
+
+The My Organization API primarily uses existing Auth0 Management API v2 endpoints with organization scoping. There are no dedicated "my-organization" endpoints - instead, use the standard organization endpoints with proper authentication.
+
+### Organization Management
+
+#### Get Organization Details
+```http
+GET /api/v2/organizations/{id}
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+
+**Required Scopes:** `read:organizations`
+
+**Response:**
+```json
+{
+  "id": "org_123",
+  "name": "acme-corp",
+  "display_name": "Acme Corporation",
+  "branding": {
+    "logo_url": "https://example.com/logo.png",
+    "colors": {
+      "primary": "#FF0000"
+    }
+  },
+  "metadata": {
+    "mfaPolicy": "{\"enforce\": true, \"providers\": [\"otp\"]}"
+  }
+}
+```
+
+#### Update Organization
+```http
+PATCH /api/v2/organizations/{id}
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+
+**Required Scopes:** `update:organizations`
+
+**Request Body:**
+```json
+{
+  "display_name": "Updated Organization Name",
+  "metadata": {
+    "customSetting": "value"
+  }
+}
+```
+
+### Member Management
+
+#### List Organization Members
+```http
+GET /api/v2/organizations/{id}/members
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+- `page` (query): Page number (default: 0)
+- `per_page` (query): Results per page (default: 50, max: 100)
+- `include_totals` (query): Include totals in response (default: true)
+
+**Required Scopes:** `read:organizations`
+
+**Response:**
+```json
+{
+  "members": [
+    {
+      "user_id": "auth0|123",
+      "email": "user@example.com",
+      "name": "John Doe",
+      "picture": "https://example.com/avatar.jpg"
+    }
+  ],
+  "total": 1,
+  "start": 0,
+  "limit": 50
+}
+```
+
+#### Add Organization Members
+```http
+POST /api/v2/organizations/{id}/members
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+
+**Required Scopes:** `update:organizations`
+
+**Request Body:**
+```json
+{
+  "members": ["auth0|123", "auth0|456"]
+}
+```
+
+#### Remove Organization Members
+```http
+DELETE /api/v2/organizations/{id}/members
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+
+**Required Scopes:** `update:organizations`
+
+**Request Body:**
+```json
+{
+  "members": ["auth0|123"]
+}
+```
+
+### Invitation Management
+
+#### Create Invitation
+```http
+POST /api/v2/organizations/{id}/invitations
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+
+**Required Scopes:** `create:organizations`, `read:organizations`
+
+**Request Body:**
+```json
+{
+  "invitee": {
+    "email": "newuser@example.com"
+  },
+  "inviter": {
+    "name": "Admin User"
+  },
+  "client_id": "your_client_id",
+  "roles": ["role_id_1"],
+  "ttl_sec": 604800
+}
+```
+
+**Response:**
+```json
+{
+  "id": "inv_123",
+  "organization_id": "org_123",
+  "invitee": {
+    "email": "newuser@example.com"
+  },
+  "inviter": {
+    "name": "Admin User"
+  },
+  "client_id": "your_client_id",
+  "roles": ["role_id_1"],
+  "expires_at": "2024-01-15T10:30:00.000Z",
+  "created_at": "2024-01-08T10:30:00.000Z"
+}
+```
+
+#### List Invitations
+```http
+GET /api/v2/organizations/{id}/invitations
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+
+**Required Scopes:** `read:organizations`
+
+### Role Management
+
+#### Get Member Roles
+```http
+GET /api/v2/organizations/{id}/members/{user_id}/roles
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+- `user_id` (path): User ID
+
+**Required Scopes:** `read:organizations`
+
+#### Add Member Roles
+```http
+POST /api/v2/organizations/{id}/members/{user_id}/roles
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+- `user_id` (path): User ID
+
+**Required Scopes:** `update:organizations`
+
+**Request Body:**
+```json
+{
+  "roles": ["role_id_1", "role_id_2"]
+}
+```
+
+#### Remove Member Roles
+```http
+DELETE /api/v2/organizations/{id}/members/{user_id}/roles
+```
+
+**Parameters:**
+- `id` (path): Organization ID
+- `user_id` (path): User ID
+
+**Required Scopes:** `update:organizations`
+
+**Request Body:**
+```json
+{
+  "roles": ["role_id_1"]
+}
+```
+
+## CLI Commands
+
+### Organization Management
+
+#### List Organizations
+```bash
+auth0 orgs list
+```
+
+**Options:**
+- `--number`: Number of results to retrieve (default: 50)
+- `--json`: Output results in JSON format
+
+#### Create Organization
+```bash
+auth0 orgs create \
+  --name "acme-corp" \
+  --display-name "Acme Corporation" \
+  --branding-logo-url "https://example.com/logo.png" \
+  --metadata "key1=value1,key2=value2"
+```
+
+#### Show Organization Details
+```bash
+auth0 orgs show <org_id>
+```
+
+#### Update Organization
+```bash
+auth0 orgs update <org_id> \
+  --display-name "New Name" \
+  --metadata "updatedKey=updatedValue"
+```
+
+#### Delete Organization
+```bash
+auth0 orgs delete <org_id>
+```
+
+### Member Management
+
+#### List Organization Members
+```bash
+auth0 orgs members list <org_id>
+```
+
+**Options:**
+- `--number`: Number of results to retrieve
+
+#### Add Members to Organization
+```bash
+auth0 orgs members add <org_id> \
+  --user-ids "auth0|123,auth0|456"
+```
+
+#### Remove Members from Organization
+```bash
+auth0 orgs members remove <org_id> \
+  --user-ids "auth0|123"
+```
+
+### Invitation Management
+
+#### Create Invitation
+```bash
+auth0 orgs invitations create <org_id> \
+  --email "user@example.com" \
+  --role-ids "role_id_1" \
+  --client-id "your_client_id"
+```
+
+#### List Invitations
+```bash
+auth0 orgs invitations list <org_id>
+```
+
+### Connection Management
+
+#### Add Enabled Connection
+```bash
+auth0 orgs connections add <org_id> \
+  --connection-id "con_123" \
+  --assign-membership-on-login
+```
+
+#### List Enabled Connections
+```bash
+auth0 orgs connections list <org_id>
+```
+
+## SDK Support Matrix
+
+| Feature | auth0-python | auth0-java | node-auth0 | auth0-react | auth0-angular | auth0-vue | auth0-spa-js |
+|---------|--------------|------------|------------|-------------|---------------|-----------|--------------|
+| Organization CRUD | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Member Management | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Invitations | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Role Management | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Self-Service SSO | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Organization Context | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
+
+**Legend:**
+- ✅ Full support
+- ❌ Not applicable (client-side SDK)
+
+## Error Codes
+
+### Common HTTP Status Codes
+
+| Code | Description |
+|------|-------------|
+| 200 | OK - Request successful |
+| 201 | Created - Resource created successfully |
+| 204 | No Content - Request successful, no content returned |
+| 400 | Bad Request - Invalid request parameters |
+| 401 | Unauthorized - Authentication required |
+| 403 | Forbidden - Insufficient permissions |
+| 404 | Not Found - Resource not found |
+| 409 | Conflict - Resource already exists |
+| 429 | Too Many Requests - Rate limit exceeded |
+| 500 | Internal Server Error - Server error |
+
+### Organization-Specific Errors
+
+```json
+{
+  "statusCode": 403,
+  "error": "Forbidden",
+  "message": "Insufficient scope, expected any of: read:organizations",
+  "errorCode": "insufficient_scope"
+}
+```
+
+```json
+{
+  "statusCode": 404,
+  "error": "Not Found",
+  "message": "The organization does not exist.",
+  "errorCode": "org_not_found"
+}
+```
+
+```json
+{
+  "statusCode": 400,
+  "error": "Bad Request",
+  "message": "The user is already a member of the organization.",
+  "errorCode": "user_already_member"
+}
+```
+
+## Rate Limits
+
+Rate limits vary by Auth0 plan:
+
+| Plan | Read Operations | Write Operations |
+|------|-----------------|------------------|
+| Free | 4 RPS | 2 RPS |
+| Developer | 10 RPS | 5 RPS |
+| Developer Pro | 40 RPS | 20 RPS |
+| Private Cloud | Custom | Custom |
+
+### Organization-Specific Limits
+
+- **Member operations**: Additional limits based on organization size
+- **Invitation operations**: Rate limited to prevent abuse
+- **Bulk operations**: Subject to stricter limits
+
+## Configuration Options
+
+### Organization Metadata Schema
+
+```typescript
+interface OrganizationMetadata {
+  // Security policies
+  mfaPolicy?: {
+    enforce: boolean
+    providers: string[]
+    skipForDomains: string[]
+  }
+
+  // Session management
+  sessionPolicy?: {
+    maxAge: number
+    idleTimeout: number
+    maxConcurrentSessions: number
+  }
+
+  // Custom branding
+  branding?: {
+    logoUrl?: string
+    primaryColor?: string
+    secondaryColor?: string
+  }
+
+  // Feature flags
+  features?: {
+    scimEnabled?: boolean
+    advancedMfa?: boolean
+    customDomains?: boolean
+  }
+
+  // Business logic
+  memberLimit?: number
+  defaultRole?: string
+  allowedDomains?: string[]
+}
+```
+
+### Client Application Configuration
+
+```json
+{
+  "client_id": "your_client_id",
+  "my_organization_configuration": {
+    "connection_profile_id": "cp_123",
+    "user_attribute_profile_id": "uap_456",
+    "allowed_strategies": ["oidc", "saml"],
+    "connection_deletion_behavior": "allow_if_empty",
+    "user_access_authorization": "authorized",
+    "client_credential_access_authorization": "denied"
+  }
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Insufficient scope" errors**
+   - Ensure your Management API token has the required scopes
+   - Check that the client application is authorized for the My Organization API
+
+2. **"Organization not found" errors**
+   - Verify the organization ID is correct
+   - Ensure the organization exists and is accessible
+
+3. **Invitation failures**
+   - Check that the email domain is allowed
+   - Verify the client ID is correct
+   - Ensure the inviter has permission to send invitations
+
+4. **Member limit exceeded**
+   - Check your Auth0 plan limits
+   - Consider upgrading your plan for more members
+
+### Debugging Tips
+
+- Use the Auth0 CLI with `--debug` flag for verbose output
+- Check the Management API logs in the Auth0 Dashboard
+- Verify organization metadata with `auth0 orgs show <org_id>`
+- Test API calls with curl before implementing in code

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/references/backend.md
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/references/backend.md
@@ -1,0 +1,477 @@
+# My Organization API - Backend Validation Patterns
+
+## Organization Context Validation
+
+### Next.js Middleware
+```typescript
+// middleware.ts
+import { NextResponse } from 'next/server'
+import { getSession } from '@auth0/nextjs-auth0'
+import { ManagementClient } from 'auth0'
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+export async function middleware(request: Request) {
+  const session = await getSession()
+
+  if (!session?.user) {
+    return NextResponse.redirect('/api/auth/login')
+  }
+
+  // Check if user has organization context
+  if (!session.user.org_id) {
+    return NextResponse.redirect('/onboarding')
+  }
+
+  // Validate organization exists and user is member
+  try {
+    const { data: org } = await management.organizations.get({
+      id: session.user.org_id
+    })
+
+    const { data: members } = await management.organizations.getMembers({
+      id: session.user.org_id,
+      include_totals: false
+    })
+
+    const isMember = members.some(member => member.user_id === session.user.sub)
+
+    if (!isMember) {
+      return NextResponse.redirect('/onboarding')
+    }
+
+  } catch (error) {
+    console.error('Organization validation failed:', error)
+    return NextResponse.redirect('/onboarding')
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*']
+}
+```
+
+### Express Middleware
+```typescript
+// middleware/organizationAuth.js
+const { ManagementClient } = require('auth0')
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN,
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET
+})
+
+const validateOrganizationAccess = async (req, res, next) => {
+  try {
+    const userId = req.oidc.user.sub
+    const orgId = req.oidc.user.org_id
+
+    if (!orgId) {
+      return res.status(400).json({ error: 'No organization context' })
+    }
+
+    // Verify organization exists
+    const { data: org } = await management.organizations.get({ id: orgId })
+
+    // Verify user is a member
+    const { data: members } = await management.organizations.getMembers({
+      id: orgId,
+      include_totals: false
+    })
+
+    const isMember = members.some(member => member.user_id === userId)
+
+    if (!isMember) {
+      return res.status(403).json({ error: 'Not a member of this organization' })
+    }
+
+    req.organization = org
+    req.userMembership = members.find(member => member.user_id === userId)
+
+    next()
+  } catch (error) {
+    console.error('Organization validation error:', error)
+    res.status(500).json({ error: 'Organization validation failed' })
+  }
+}
+
+module.exports = { validateOrganizationAccess }
+```
+
+## Role-Based Access Control
+
+### Server Action Authentication Wrapper (My Organization API)
+```typescript
+// lib/withServerActionAuth.ts
+import { Auth0Client } from '@auth0/nextjs-auth0/server'
+
+const auth0 = new Auth0Client({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+type Role = 'admin' | 'member'
+
+interface SessionData {
+  user: {
+    sub: string
+    name?: string
+    email?: string
+    org_id?: string
+    roles?: string[]
+  }
+}
+
+export function withServerActionAuth<T extends any[], U extends any>(
+  serverAction: (...args: [...T, session: SessionData]) => U,
+  options: { role?: Role } = {}
+) {
+  return async function (...args: T) {
+    const session = await auth0.getSession()
+
+    if (!session?.user) {
+      throw new Error('Authentication required')
+    }
+
+    if (!session.user.org_id) {
+      throw new Error('Organization context required')
+    }
+
+    if (options.role) {
+      const userRole = getUserRole(session.user)
+      if (userRole !== options.role) {
+        throw new Error(`${options.role} role required`)
+      }
+    }
+
+    return serverAction(...args, session)
+  }
+}
+
+function getUserRole(user: SessionData['user']): Role {
+  // Check if user has admin role in organization
+  // This would typically query the Management API
+  return user.roles?.includes('admin') ? 'admin' : 'member'
+}
+```
+
+### API Route Protection
+```typescript
+// app/api/organization/admin-only/route.ts
+import { withServerActionAuth } from '@/lib/withServerActionAuth'
+import { ManagementClient } from 'auth0'
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+const updateOrganizationSettings = withServerActionAuth(
+  async (formData: FormData, session) => {
+    const setting = formData.get('setting')
+    const value = formData.get('value')
+
+    await management.organizations.update({
+      id: session.user.org_id!
+    }, {
+      metadata: {
+        [setting]: value
+      }
+    })
+
+    return { success: true }
+  },
+  { role: 'admin' } // Only admins can update settings
+)
+
+export async function POST(request: Request) {
+  const formData = await request.formData()
+  return updateOrganizationSettings(formData)
+}
+```
+
+## Security Policy Enforcement
+
+### MFA Policy Validation
+```typescript
+// lib/mfaPolicy.ts
+import { ManagementClient } from 'auth0'
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+export interface MfaPolicy {
+  enforce: boolean
+  providers: string[]
+  skipForDomains: string[]
+}
+
+export const DEFAULT_MFA_POLICY: MfaPolicy = {
+  enforce: false,
+  providers: [],
+  skipForDomains: []
+}
+
+export async function getOrganizationMfaPolicy(orgId: string): Promise<MfaPolicy> {
+  try {
+    const { data: org } = await management.organizations.get({ id: orgId })
+    const policy = org.metadata?.mfaPolicy
+
+    if (policy) {
+      return JSON.parse(policy)
+    }
+  } catch (error) {
+    console.error('Failed to fetch MFA policy:', error)
+  }
+
+  return DEFAULT_MFA_POLICY
+}
+
+export async function shouldEnforceMfa(userEmail: string, orgId: string): Promise<boolean> {
+  const policy = await getOrganizationMfaPolicy(orgId)
+
+  if (!policy.enforce) {
+    return false
+  }
+
+  // Check if user's domain should be skipped
+  const userDomain = userEmail.split('@')[1]
+  return !policy.skipForDomains.includes(userDomain)
+}
+```
+
+### Session Management
+```typescript
+// lib/sessionValidation.ts
+import { ManagementClient } from 'auth0'
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+export interface SessionPolicy {
+  maxAge: number // in seconds
+  requireMfa: boolean
+  allowedIpRanges?: string[]
+}
+
+export async function validateSession(session: any): Promise<boolean> {
+  const orgId = session.user?.org_id
+
+  if (!orgId) {
+    return false
+  }
+
+  try {
+    const { data: org } = await management.organizations.get({ id: orgId })
+    const sessionPolicy: SessionPolicy = org.metadata?.sessionPolicy || {
+      maxAge: 8 * 60 * 60, // 8 hours
+      requireMfa: false
+    }
+
+    // Check session age
+    const sessionAge = Date.now() - session.iat * 1000
+    if (sessionAge > sessionPolicy.maxAge * 1000) {
+      return false
+    }
+
+    // Additional validations can be added here
+    // - IP range checking
+    // - Device validation
+    // - Geographic restrictions
+
+    return true
+  } catch (error) {
+    console.error('Session validation failed:', error)
+    return false
+  }
+}
+```
+
+## Invitation Management
+
+### Invitation Validation
+```typescript
+// lib/invitationValidation.ts
+import { ManagementClient } from 'auth0'
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+export async function validateInvitation(invitationId: string, orgId: string): Promise<boolean> {
+  try {
+    const { data: invitation } = await management.organizations.getInvitation({
+      id: orgId,
+      invitation_id: invitationId
+    })
+
+    // Check if invitation is expired
+    if (new Date(invitation.expires_at) < new Date()) {
+      return false
+    }
+
+    // Check if invitation was already used
+    if (invitation.accepted_at) {
+      return false
+    }
+
+    return true
+  } catch (error) {
+    console.error('Invitation validation failed:', error)
+    return false
+  }
+}
+
+export async function processInvitationAcceptance(
+  invitationId: string,
+  orgId: string,
+  userId: string
+): Promise<void> {
+  try {
+    // Verify invitation is still valid
+    const isValid = await validateInvitation(invitationId, orgId)
+    if (!isValid) {
+      throw new Error('Invalid or expired invitation')
+    }
+
+    // Add user to organization
+    await management.organizations.addMembers({
+      id: orgId
+    }, {
+      members: [userId]
+    })
+
+    // Mark invitation as accepted (if API supports it)
+    // Note: This might need to be handled differently based on API capabilities
+
+  } catch (error) {
+    console.error('Failed to process invitation acceptance:', error)
+    throw error
+  }
+}
+```
+
+## Domain Verification
+
+### DNS-Based Domain Ownership
+```typescript
+// lib/domainVerification.ts
+import { ManagementClient } from 'auth0'
+import { resolveTxt } from 'dns/promises'
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+const DOMAIN_VERIFICATION_RECORD_IDENTIFIER = 'auth0-domain-verification'
+
+export async function initiateDomainVerification(orgId: string, domain: string): Promise<string> {
+  // Generate verification token
+  const token = crypto.randomUUID()
+
+  // Store token in organization metadata
+  await management.organizations.update({
+    id: orgId
+  }, {
+    metadata: {
+      domainVerificationToken: token,
+      domainToVerify: domain
+    }
+  })
+
+  return token
+}
+
+export async function verifyDomainOwnership(orgId: string, domain: string): Promise<boolean> {
+  try {
+    const { data: org } = await management.organizations.get({ id: orgId })
+    const expectedToken = org.metadata?.domainVerificationToken
+
+    if (!expectedToken) {
+      return false
+    }
+
+    // Query DNS TXT records
+    const txtRecords = await resolveTxt(domain)
+
+    // Check if any record contains our verification token
+    for (const record of txtRecords) {
+      const joinedRecord = record.join('')
+      if (joinedRecord.includes(`${DOMAIN_VERIFICATION_RECORD_IDENTIFIER}=${expectedToken}`)) {
+        return true
+      }
+    }
+
+    return false
+  } catch (error) {
+    console.error('Domain verification failed:', error)
+    return false
+  }
+}
+```
+
+## Error Handling
+
+### Centralized Error Handler
+```typescript
+// lib/organizationErrors.ts
+export class OrganizationError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+    public statusCode: number = 500
+  ) {
+    super(message)
+    this.name = 'OrganizationError'
+  }
+}
+
+export const ORGANIZATION_ERRORS = {
+  NOT_FOUND: new OrganizationError('Organization not found', 'ORG_NOT_FOUND', 404),
+  ACCESS_DENIED: new OrganizationError('Access denied', 'ACCESS_DENIED', 403),
+  INVALID_INVITATION: new OrganizationError('Invalid or expired invitation', 'INVALID_INVITATION', 400),
+  MEMBER_LIMIT_EXCEEDED: new OrganizationError('Member limit exceeded', 'MEMBER_LIMIT_EXCEEDED', 400),
+  DOMAIN_VERIFICATION_FAILED: new OrganizationError('Domain verification failed', 'DOMAIN_VERIFICATION_FAILED', 400)
+}
+
+export function handleOrganizationError(error: any): OrganizationError {
+  // Map common errors to organization-specific errors
+  if (error.statusCode === 404) {
+    return ORGANIZATION_ERRORS.NOT_FOUND
+  }
+
+  if (error.message?.includes('access denied')) {
+    return ORGANIZATION_ERRORS.ACCESS_DENIED
+  }
+
+  if (error.message?.includes('invitation')) {
+    return ORGANIZATION_ERRORS.INVALID_INVITATION
+  }
+
+  // Default to generic error
+  return new OrganizationError(
+    error.message || 'An organization error occurred',
+    'UNKNOWN_ERROR',
+    error.statusCode || 500
+  )
+}
+```

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/references/examples.md
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/references/examples.md
@@ -1,0 +1,498 @@
+# My Organization API - Code Examples
+
+## Next.js (auth0/nextjs-auth0)
+
+### Installation
+```bash
+npm install @auth0/nextjs-auth0
+```
+
+### Organization-Scoped Authentication Setup (My Organization API)
+```typescript
+// lib/auth0.ts
+import { Auth0Client } from '@auth0/nextjs-auth0/server'
+
+const MY_ORG_SCOPES = [
+  'openid', 'profile', 'email', 'offline_access',
+  'read:my_org:details', 'update:my_org:details',
+  'create:my_org:identity_providers', 'read:my_org:identity_providers',
+  'update:my_org:identity_providers', 'delete:my_org:identity_providers'
+]
+
+export const auth0 = new Auth0Client({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!,
+  appBaseUrl: process.env.APP_BASE_URL!,
+  secret: process.env.SESSION_ENCRYPTION_SECRET!,
+  authorizationParameters: {
+    audience: `https://${process.env.AUTH0_DOMAIN}/my-org/`,
+    scope: MY_ORG_SCOPES.join(' ')
+  }
+})
+```
+
+### Member Management
+```typescript
+// app/api/organization/members/route.ts
+import { auth0 } from '@/lib/auth0'
+import { ManagementClient } from 'auth0'
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!
+})
+
+export async function POST(request: Request) {
+  const session = await auth0.getSession()
+
+  if (!session?.user.org_id) {
+    return Response.json({ error: 'No organization context' }, { status: 400 })
+  }
+
+  const { email, role } = await request.json()
+
+  try {
+    // Create invitation
+    await management.organizations.createInvitation({
+      id: session.user.org_id
+    }, {
+      invitee: { email },
+      inviter: { name: session.user.name! },
+      client_id: process.env.AUTH0_CLIENT_ID!,
+      roles: role === 'admin' ? [process.env.ADMIN_ROLE_ID!] : []
+    })
+
+    return Response.json({ success: true })
+  } catch (error) {
+    return Response.json({ error: 'Failed to create invitation' }, { status: 500 })
+  }
+}
+```
+
+### SSO Provider Management
+```typescript
+// app/api/organization/sso/route.ts
+export async function POST(request: Request) {
+  const session = await auth0.getSession()
+  const { provider, config } = await request.json()
+
+  try {
+    // Create SSO connection
+    const connection = await management.connections.create({
+      name: `${session.user.org_id}-${provider}`,
+      strategy: provider,
+      ...config
+    })
+
+    // Enable for organization
+    await management.organizations.addEnabledConnection({
+      id: session.user.org_id
+    }, {
+      connection_id: connection.id
+    })
+
+    return Response.json({ success: true })
+  } catch (error) {
+    return Response.json({ error: 'Failed to configure SSO' }, { status: 500 })
+  }
+}
+```
+
+## React (auth0/auth0-react)
+
+### Installation
+```bash
+npm install @auth0/auth0-react
+```
+
+### Organization Context Provider (My Organization API)
+```typescript
+// components/OrganizationProvider.tsx
+import { useAuth0 } from '@auth0/auth0-react'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const OrganizationContext = createContext(null)
+
+export function OrganizationProvider({ children }) {
+  const { user, getAccessTokenSilently } = useAuth0()
+  const [organization, setOrganization] = useState(null)
+
+  useEffect(() => {
+    if (user?.org_id) {
+      fetchOrganization(user.org_id)
+    }
+  }, [user])
+
+  const fetchOrganization = async (orgId) => {
+    try {
+      const token = await getAccessTokenSilently({
+        audience: `https://${process.env.REACT_APP_AUTH0_DOMAIN}/my-org/`,
+        scope: 'read:my_org:details'
+      })
+
+      const response = await fetch(`/api/organization/${orgId}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      })
+
+      const org = await response.json()
+      setOrganization(org)
+    } catch (error) {
+      console.error('Failed to fetch organization:', error)
+    }
+  }
+
+  return (
+    <OrganizationContext.Provider value={{ organization, fetchOrganization }}>
+      {children}
+    </OrganizationContext.Provider>
+  )
+}
+
+export const useOrganization = () => useContext(OrganizationContext)
+```
+
+### Member Invitation Component
+```typescript
+// components/InviteMember.tsx
+import { useAuth0 } from '@auth0/auth0-react'
+
+export function InviteMember() {
+  const { getAccessTokenSilently, user } = useAuth0()
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState('member')
+
+  const handleInvite = async () => {
+    try {
+      const token = await getAccessTokenSilently({
+        audience: `https://${process.env.REACT_APP_AUTH0_DOMAIN}/my-org/`,
+        scope: 'create:my_org:invitations'
+      })
+
+      const response = await fetch('/api/organization/members', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ email, role })
+      })
+
+      if (response.ok) {
+        alert('Invitation sent!')
+        setEmail('')
+      }
+    } catch (error) {
+      console.error('Failed to send invitation:', error)
+    }
+  }
+
+  return (
+    <div>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="member@example.com"
+      />
+      <select value={role} onChange={(e) => setRole(e.target.value)}>
+        <option value="member">Member</option>
+        <option value="admin">Admin</option>
+      </select>
+      <button onClick={handleInvite}>Send Invitation</button>
+    </div>
+  )
+}
+```
+
+## Express (auth0/express-openid-connect)
+
+### Installation
+```bash
+npm install express-openid-connect
+```
+
+### Organization Middleware
+```typescript
+// middleware/organization.js
+const { ManagementClient } = require('auth0')
+
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN,
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET
+})
+
+const requireOrganization = async (req, res, next) => {
+  if (!req.oidc.user?.org_id) {
+    return res.redirect('/onboarding')
+  }
+
+  try {
+    const { data: org } = await management.organizations.get({
+      id: req.oidc.user.org_id
+    })
+    req.organization = org
+    next()
+  } catch (error) {
+    res.status(403).json({ error: 'Invalid organization' })
+  }
+}
+
+module.exports = { requireOrganization }
+```
+
+### Member Management Routes
+```typescript
+// routes/organization.js
+const express = require('express')
+const { requiresAuth } = require('express-openid-connect')
+const { ManagementClient } = require('auth0')
+const { requireOrganization } = require('../middleware/organization')
+
+const router = express.Router()
+const management = new ManagementClient({
+  domain: process.env.AUTH0_DOMAIN,
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET
+})
+
+router.use(requiresAuth())
+router.use(requireOrganization)
+
+// Get organization members
+router.get('/members', async (req, res) => {
+  try {
+    const { data: members } = await management.organizations.getMembers({
+      id: req.oidc.user.org_id
+    })
+    res.json(members)
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch members' })
+  }
+})
+
+// Invite new member
+router.post('/members', async (req, res) => {
+  const { email, role } = req.body
+
+  try {
+    await management.organizations.createInvitation({
+      id: req.oidc.user.org_id
+    }, {
+      invitee: { email },
+      inviter: { name: req.oidc.user.name },
+      client_id: process.env.AUTH0_CLIENT_ID,
+      roles: role === 'admin' ? [process.env.ADMIN_ROLE_ID] : []
+    })
+
+    res.json({ success: true })
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to create invitation' })
+  }
+})
+
+module.exports = router
+```
+
+## Python (auth0-python)
+
+### Installation
+```bash
+pip install auth0-python
+```
+
+### Organization Management
+```python
+# organization_service.py
+from auth0.management import Auth0
+from auth0.authentication import GetToken
+
+class OrganizationService:
+    def __init__(self):
+        self.auth0 = Auth0(
+            domain=os.getenv('AUTH0_DOMAIN'),
+            token=self._get_management_token()
+        )
+
+    def _get_management_token(self):
+        get_token = GetToken(os.getenv('AUTH0_DOMAIN'))
+        token = get_token.client_credentials(
+            os.getenv('AUTH0_CLIENT_ID'),
+            os.getenv('AUTH0_CLIENT_SECRET'),
+            f'https://{os.getenv("AUTH0_DOMAIN")}/api/v2/'
+        )
+        return token['access_token']
+
+    def get_organization(self, org_id):
+        return self.auth0.organizations.get(org_id)
+
+    def invite_member(self, org_id, email, role='member'):
+        role_id = os.getenv('ADMIN_ROLE_ID') if role == 'admin' else None
+
+        return self.auth0.organizations.create_invitation(org_id, {
+            'invitee': {'email': email},
+            'client_id': os.getenv('AUTH0_CLIENT_ID'),
+            'roles': [role_id] if role_id else []
+        })
+
+    def update_member_role(self, org_id, user_id, role):
+        # Remove existing roles
+        current_roles = self.auth0.organizations.get_member_roles(org_id, user_id)
+        if current_roles:
+            self.auth0.organizations.delete_member_roles(org_id, user_id, {
+                'roles': [r['id'] for r in current_roles]
+            })
+
+        # Add new role
+        if role == 'admin':
+            self.auth0.organizations.add_member_roles(org_id, user_id, {
+                'roles': [os.getenv('ADMIN_ROLE_ID')]
+            })
+```
+
+### Flask Integration
+```python
+# app.py
+from flask import Flask, request, jsonify
+from auth0.authentication import GetToken
+from organization_service import OrganizationService
+
+app = Flask(__name__)
+org_service = OrganizationService()
+
+def get_user_org_id():
+    # Extract org_id from JWT token claims
+    # This would typically come from auth0 validation
+    return request.headers.get('X-Org-ID')
+
+@app.route('/api/organization/members', methods=['POST'])
+def invite_member():
+    org_id = get_user_org_id()
+    if not org_id:
+        return jsonify({'error': 'No organization context'}), 400
+
+    data = request.get_json()
+    try:
+        invitation = org_service.invite_member(
+            org_id,
+            data['email'],
+            data.get('role', 'member')
+        )
+        return jsonify({'success': True, 'invitation': invitation})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/organization/members', methods=['GET'])
+def get_members():
+    org_id = get_user_org_id()
+    if not org_id:
+        return jsonify({'error': 'No organization context'}), 400
+
+    try:
+        members = org_service.get_organization_members(org_id)
+        return jsonify(members)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+```
+
+## Java (auth0/auth0-java)
+
+### Installation
+```xml
+<dependency>
+    <groupId>com.auth0</groupId>
+    <artifactId>auth0</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+### Organization Service
+```java
+// OrganizationService.java
+import com.auth0.client.mgmt.ManagementAPI;
+import com.auth0.json.mgmt.organizations.Organization;
+import com.auth0.json.mgmt.organizations.Invitations;
+
+public class OrganizationService {
+    private final ManagementAPI managementAPI;
+
+    public OrganizationService(String domain, String clientId, String clientSecret) {
+        this.managementAPI = ManagementAPI.newBuilder(domain, clientId, clientSecret).build();
+    }
+
+    public Organization getOrganization(String orgId) throws Exception {
+        return managementAPI.organizations().get(orgId).execute().getBody();
+    }
+
+    public Invitations createInvitation(String orgId, String email, String role) throws Exception {
+        String roleId = "admin".equals(role) ? System.getenv("ADMIN_ROLE_ID") : null;
+
+        return managementAPI.organizations().createInvitation(orgId,
+            new InvitationCreateRequest()
+                .setInvitee(new Invitee().setEmail(email))
+                .setClientId(System.getenv("AUTH0_CLIENT_ID"))
+                .setRoles(roleId != null ? List.of(roleId) : List.of())
+        ).execute().getBody();
+    }
+
+    public void updateMemberRole(String orgId, String userId, String role) throws Exception {
+        // Remove existing roles
+        var currentRoles = managementAPI.organizations()
+            .getMemberRoles(orgId, userId).execute().getBody();
+
+        if (!currentRoles.isEmpty()) {
+            managementAPI.organizations().deleteMemberRoles(orgId, userId,
+                new Roles().setRoles(currentRoles.stream()
+                    .map(Role::getId).collect(Collectors.toList()))
+            ).execute();
+        }
+
+        // Add new role
+        if ("admin".equals(role)) {
+            managementAPI.organizations().addMemberRoles(orgId, userId,
+                new Roles().setRoles(List.of(System.getenv("ADMIN_ROLE_ID")))
+            ).execute();
+        }
+    }
+}
+```
+
+### Spring Boot Integration
+```java
+// OrganizationController.java
+@RestController
+@RequestMapping("/api/organization")
+public class OrganizationController {
+
+    @Autowired
+    private OrganizationService organizationService;
+
+    @GetMapping("/members")
+    public ResponseEntity<?> getMembers(@RequestHeader("X-Org-ID") String orgId) {
+        try {
+            var members = organizationService.getOrganizationMembers(orgId);
+            return ResponseEntity.ok(members);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/members")
+    public ResponseEntity<?> inviteMember(
+            @RequestHeader("X-Org-ID") String orgId,
+            @RequestBody Map<String, String> body) {
+        try {
+            var invitation = organizationService.createInvitation(
+                orgId,
+                body.get("email"),
+                body.get("role")
+            );
+            return ResponseEntity.ok(Map.of("success", true, "invitation", invitation));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+        }
+    }
+}
+```

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/bootstrap.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/bootstrap.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * bootstrap.mjs — Idempotent Auth0 tenant configuration for Universal Components.
+ * Usage: node bootstrap.mjs --domain <d> --features full|myorg|myaccount --framework nextjs|react-spa [--app-name "App"] [--port 3000]
+ * Zero external dependencies. All operations use the auth0 CLI via child_process.
+ */
+import { randomBytes } from "node:crypto";
+import { discoverExistingResources } from "./utils/discovery.mjs";
+import {
+  MYORG_API_SCOPES,
+  MYACCOUNT_API_SCOPES,
+  getAvailableMyAccountScopes,
+  ensureMyOrgResourceServer,
+  ensureMyAccountResourceServer,
+  ensureConnectionProfile,
+  ensureUserAttributeProfile,
+  ensureConnection,
+  ensureAdminRole,
+  ensureOrganization,
+  ensureTenantSettings,
+  ensurePromptSettings,
+} from "./utils/resources.mjs";
+import { ensureClient, ensureClientGrant } from "./utils/clients.mjs";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { domain: null, features: "full", framework: "react-spa", appName: "Universal Components Demo", port: "3000" };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--domain" && args[i + 1]) opts.domain = args[++i];
+    else if (args[i] === "--features" && args[i + 1]) opts.features = args[++i];
+    else if (args[i] === "--framework" && args[i + 1]) opts.framework = args[++i];
+    else if (args[i] === "--app-name" && args[i + 1]) opts.appName = args[++i];
+    else if (args[i] === "--port" && args[i + 1]) opts.port = args[++i];
+    else if (args[i] === "--help") {
+      console.log("Usage: node bootstrap.mjs --domain <tenant.auth0.com> --features full|myorg|myaccount --framework nextjs|react-spa [--port 3000]");
+      process.exit(0);
+    }
+  }
+  return opts;
+}
+
+function output(result) {
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.status === "success" ? 0 : 1);
+}
+
+function errorAt(step, completedSteps, code, message, fallback) {
+  output({
+    status: "partial",
+    completed_steps: completedSteps,
+    error: { code, message, failed_at: step, fallback_instructions: fallback },
+  });
+}
+
+const opts = parseArgs();
+if (!opts.domain) {
+  output({
+    status: "error",
+    completed_steps: [],
+    error: { code: "MISSING_DOMAIN", message: "--domain is required", failed_at: "args", fallback_instructions: "Re-run with --domain <your-tenant>.us.auth0.com" },
+  });
+}
+
+const features = {
+  enableMyOrg: opts.features === "full" || opts.features === "myorg",
+  enableMyAccount: opts.features === "full" || opts.features === "myaccount",
+};
+
+const completedSteps = [];
+
+// Step 1: Discover existing resources
+const { resources, errors: discoveryErrors } = discoverExistingResources(opts.domain);
+if (discoveryErrors.length > 0 && resources.clients.length === 0) {
+  errorAt("discovery", completedSteps, "DISCOVERY_FAILED",
+    `Failed to discover tenant resources: ${discoveryErrors.join("; ")}`,
+    "Ensure your Auth0 CLI session is valid. Run: auth0 login --domain " + opts.domain
+  );
+}
+completedSteps.push("discovery");
+
+// Step 2: Tenant settings
+const tenantResult = ensureTenantSettings();
+if (tenantResult.action === "error") {
+  errorAt("tenant_settings", completedSteps, "TENANT_SETTINGS_FAILED", tenantResult.error,
+    "Manually update tenant settings via Auth0 Dashboard > Settings."
+  );
+}
+completedSteps.push("tenant_settings");
+
+// Step 3: Prompt settings
+const promptResult = ensurePromptSettings();
+if (promptResult.action === "error") {
+  errorAt("prompts", completedSteps, "PROMPT_SETTINGS_FAILED", promptResult.error,
+    "Manually enable identifier_first in Auth0 Dashboard > Authentication > Authentication Profile."
+  );
+}
+completedSteps.push("prompts");
+
+// Step 4: Connection profile (needed for client setup)
+let connectionProfileId = null;
+if (features.enableMyOrg) {
+  const cpResult = ensureConnectionProfile(resources.connectionProfiles);
+  if (cpResult.action === "error") {
+    errorAt("connection_profile", completedSteps, "CONNECTION_PROFILE_FAILED", cpResult.error,
+      "Your tenant may not support connection profiles. Re-run the script — it will skip completed steps."
+    );
+  }
+  connectionProfileId = cpResult.data?.id;
+  completedSteps.push("connection_profile");
+}
+
+// Step 5: User attribute profile
+let userAttributeProfileId = null;
+if (features.enableMyOrg) {
+  const uapResult = ensureUserAttributeProfile(resources.userAttributeProfiles);
+  if (uapResult.action === "error") {
+    errorAt("user_attribute_profile", completedSteps, "USER_ATTRIBUTE_PROFILE_FAILED", uapResult.error,
+      "Your tenant may not support user attribute profiles. Re-run the script — it will skip completed steps."
+    );
+  }
+  userAttributeProfileId = uapResult.data?.id;
+  completedSteps.push("user_attribute_profile");
+}
+
+// Step 6: Resource servers
+if (features.enableMyOrg) {
+  const rsResult = ensureMyOrgResourceServer(resources.resourceServers, opts.domain);
+  if (rsResult.action === "error") {
+    errorAt("resource_servers", completedSteps, "RESOURCE_SERVER_CREATE_FAILED", rsResult.error,
+      "The My Organization API could not be created. Verify your tenant has the Organizations feature enabled in Auth0 Dashboard > Settings. Then re-run."
+    );
+  }
+  completedSteps.push("resource_server_myorg");
+}
+
+if (features.enableMyAccount) {
+  const rsResult = ensureMyAccountResourceServer(resources.resourceServers, opts.domain);
+  if (rsResult.action === "error") {
+    errorAt("resource_servers", completedSteps, "RESOURCE_SERVER_CREATE_FAILED", rsResult.error,
+      "The My Account API could not be created. Verify your tenant has the My Account feature enabled. Then re-run."
+    );
+  }
+  completedSteps.push("resource_server_myaccount");
+}
+
+// Step 7: Client
+const myAccountApiScopes = features.enableMyAccount
+  ? getAvailableMyAccountScopes(resources.resourceServers, opts.domain).length > 0
+    ? getAvailableMyAccountScopes(resources.resourceServers, opts.domain)
+    : MYACCOUNT_API_SCOPES
+  : [];
+
+const clientResult = ensureClient(
+  resources.clients, opts.domain, opts.framework, opts.port,
+  connectionProfileId, userAttributeProfileId, features, myAccountApiScopes
+);
+if (clientResult.action === "error") {
+  errorAt("client", completedSteps, "CLIENT_CREATE_FAILED", clientResult.error,
+    "Failed to create/update the Auth0 client. Check your tenant permissions and re-run."
+  );
+}
+const clientId = clientResult.data?.client_id;
+const clientSecret = clientResult.data?.client_secret;
+completedSteps.push("client");
+
+// Step 8: Client grants
+if (features.enableMyOrg) {
+  const grantResult = ensureClientGrant(clientId, `https://${opts.domain}/my-org/`, MYORG_API_SCOPES, resources.clientGrants);
+  if (grantResult.action === "error") {
+    errorAt("client_grants", completedSteps, "CLIENT_GRANT_FAILED", grantResult.error,
+      "Failed to create My Org API client grant. Re-run the script."
+    );
+  }
+  completedSteps.push("client_grant_myorg");
+}
+
+if (features.enableMyAccount && myAccountApiScopes.length > 0) {
+  const grantResult = ensureClientGrant(clientId, `https://${opts.domain}/me/`, myAccountApiScopes, resources.clientGrants);
+  if (grantResult.action === "error") {
+    errorAt("client_grants", completedSteps, "CLIENT_GRANT_FAILED", grantResult.error,
+      "Failed to create My Account API client grant. Re-run the script."
+    );
+  }
+  completedSteps.push("client_grant_myaccount");
+}
+
+// Step 9: Connection
+const connectionResult = ensureConnection(resources.connections, [clientId]);
+if (connectionResult.action === "error") {
+  errorAt("connection", completedSteps, "CONNECTION_FAILED", connectionResult.error,
+    "Failed to create/update database connection. Re-run the script."
+  );
+}
+const connectionId = connectionResult.data?.id;
+completedSteps.push("connection");
+
+// Step 10: Roles
+if (features.enableMyOrg) {
+  const roleResult = ensureAdminRole(resources.roles, opts.domain);
+  if (roleResult.action === "error") {
+    errorAt("roles", completedSteps, "ROLE_FAILED", roleResult.error,
+      "Failed to create/update admin role. Re-run the script."
+    );
+  }
+  completedSteps.push("roles");
+}
+
+// Step 11: Organization
+if (features.enableMyOrg) {
+  const orgResult = ensureOrganization(resources.orgs, connectionId);
+  if (orgResult.action === "error") {
+    errorAt("organization", completedSteps, "ORG_FAILED", orgResult.error,
+      "Failed to create demo organization. Re-run the script."
+    );
+  }
+  completedSteps.push("organization");
+}
+
+// Build env vars output
+const auth0Secret = randomBytes(32).toString("hex");
+const scopes = ["openid", "profile", "email"];
+if (features.enableMyOrg) scopes.push(...MYORG_API_SCOPES);
+if (features.enableMyAccount) scopes.push(...myAccountApiScopes);
+
+const envVars = { AUTH0_DOMAIN: opts.domain, AUTH0_CLIENT_ID: clientId };
+if (opts.framework === "nextjs") {
+  envVars.AUTH0_CLIENT_SECRET = clientSecret;
+  envVars.AUTH0_SECRET = auth0Secret;
+  envVars.NEXT_PUBLIC_AUTH0_DOMAIN = opts.domain;
+  envVars.NEXT_PUBLIC_AUTH0_CLIENT_ID = clientId;
+  envVars.APP_BASE_URL = `http://localhost:${opts.port}`;
+  envVars.AUTH0_SCOPE = scopes.join(" ");
+  if (features.enableMyOrg) envVars.AUTH0_AUDIENCE = `https://${opts.domain}/my-org/`;
+  if (features.enableMyAccount) envVars.AUTH0_MY_ACCOUNT_AUDIENCE = `https://${opts.domain}/me/`;
+} else {
+  envVars.VITE_AUTH0_DOMAIN = opts.domain;
+  envVars.VITE_AUTH0_CLIENT_ID = clientId;
+  if (features.enableMyOrg) envVars.VITE_AUTH0_AUDIENCE = `https://${opts.domain}/my-org/`;
+  if (features.enableMyAccount) envVars.VITE_AUTH0_MY_ACCOUNT_AUDIENCE = `https://${opts.domain}/me/`;
+}
+
+output({
+  status: "success",
+  completed_steps: completedSteps,
+  data: {
+    client_id: clientId,
+    client_secret: clientSecret || null,
+    domain: opts.domain,
+    env_vars: envVars,
+    scopes: scopes.join(" "),
+  },
+});

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/detect-stack.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/detect-stack.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * detect-stack.mjs — Detects project stack and outputs structured JSON.
+ * Usage: node detect-stack.mjs [project-root]
+ * Zero external dependencies.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const projectRoot = resolve(process.argv[2] || process.cwd());
+
+function readJson(path) {
+  try { return JSON.parse(readFileSync(path, "utf-8")); } catch { return null; }
+}
+
+function fileExists(path) { return existsSync(path); }
+
+function readFile(path) {
+  try { return readFileSync(path, "utf-8"); } catch { return null; }
+}
+
+function detectPackageManager() {
+  if (fileExists(join(projectRoot, "pnpm-lock.yaml"))) return "pnpm";
+  if (fileExists(join(projectRoot, "bun.lockb")) || fileExists(join(projectRoot, "bun.lock"))) return "bun";
+  if (fileExists(join(projectRoot, "yarn.lock"))) return "yarn";
+  return "npm";
+}
+
+function detectFramework(pkg) {
+  const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  if (deps.next) return "nextjs";
+  return "react-spa";
+}
+
+function detectBuildTool(pkg) {
+  const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  if (deps.vite) return "vite";
+  if (deps["react-scripts"]) return "cra";
+  return "unknown";
+}
+
+function detectTailwind(pkg) {
+  const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  const tw = deps.tailwindcss;
+  if (!tw) return { installed: false, version: null, major: null };
+  const match = tw.match(/(\d+)/);
+  const major = match ? parseInt(match[1], 10) : null;
+  return { installed: true, version: tw.replace(/^[\^~]/, ""), major };
+}
+
+function detectCssPath(tailwind) {
+  if (!tailwind.installed) return "scoped";
+  return tailwind.major >= 4 ? "tailwind" : "scoped";
+}
+
+function detectTypescript() {
+  return fileExists(join(projectRoot, "tsconfig.json"));
+}
+
+function detectShadcn() {
+  const configPath = join(projectRoot, "components.json");
+  const config = readJson(configPath);
+  if (!config) return { installed: false, aliasPath: null };
+  const aliasPath = config.aliases?.components || "@/components";
+  return { installed: true, aliasPath };
+}
+
+function detectAuth0(pkg, envFile, framework) {
+  const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  let sdkInstalled = null;
+  if (deps["@auth0/nextjs-auth0"]) sdkInstalled = "@auth0/nextjs-auth0";
+  else if (deps["@auth0/auth0-react"]) sdkInstalled = "@auth0/auth0-react";
+  const universalComponentsInstalled = !!deps["@auth0/universal-components-react"];
+
+  // Parse env file for existing tenant configuration
+  const config = { domain: null, clientId: null, clientSecret: null };
+  if (envFile) {
+    const content = readFile(join(projectRoot, envFile));
+    if (content) {
+      const lines = content.split("\n");
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+        const eqIdx = trimmed.indexOf("=");
+        const key = trimmed.slice(0, eqIdx).trim();
+        const val = trimmed.slice(eqIdx + 1).trim().replace(/^["']|["']$/g, "");
+        if (!val || val.startsWith("<") || val.startsWith("your-") || val === "placeholder" || val === "xxx" || val === "changeme") continue;
+
+        if (key === "AUTH0_DOMAIN" || key === "NEXT_PUBLIC_AUTH0_DOMAIN" || key === "VITE_AUTH0_DOMAIN") {
+          config.domain = val;
+        } else if (key === "AUTH0_CLIENT_ID" || key === "NEXT_PUBLIC_AUTH0_CLIENT_ID" || key === "VITE_AUTH0_CLIENT_ID") {
+          config.clientId = val;
+        } else if (key === "AUTH0_CLIENT_SECRET") {
+          config.clientSecret = val;
+        }
+      }
+    }
+  }
+
+  const configured = !!(config.domain && config.clientId);
+  return { sdkInstalled, universalComponentsInstalled, configured, ...config };
+}
+
+function findFile(candidates) {
+  for (const f of candidates) {
+    if (fileExists(join(projectRoot, f))) return f;
+  }
+  return null;
+}
+
+function detectEntryFile(framework) {
+  if (framework === "nextjs") {
+    return findFile(["src/app/layout.tsx", "src/app/layout.jsx", "src/app/layout.js", "app/layout.tsx", "app/layout.jsx", "app/layout.js"]);
+  }
+  return findFile(["src/main.tsx", "src/main.jsx", "src/main.js", "src/index.tsx", "src/index.jsx", "src/index.js"]);
+}
+
+function detectMainCssFile() {
+  return findFile([
+    "src/app/globals.css", "src/globals.css", "src/index.css", "src/styles.css",
+    "src/app.css", "app/globals.css", "styles/globals.css",
+  ]);
+}
+
+function detectMiddleware() {
+  return findFile(["src/middleware.ts", "src/middleware.js", "middleware.ts", "middleware.js"]);
+}
+
+function detectEnvFile(framework) {
+  if (framework === "nextjs") return findFile([".env.local", ".env"]);
+  return findFile([".env.local", ".env"]);
+}
+
+function detectExistingProviders(entryFile) {
+  if (!entryFile) return [];
+  const content = readFile(join(projectRoot, entryFile));
+  if (!content) return [];
+  const providers = [];
+  if (content.includes("Auth0Provider")) providers.push("Auth0Provider");
+  if (content.includes("Auth0ComponentProvider")) providers.push("Auth0ComponentProvider");
+  if (content.includes("ThemeProvider")) providers.push("ThemeProvider");
+  if (content.includes("SessionProvider")) providers.push("SessionProvider");
+  return providers;
+}
+
+// --- Main ---
+
+const pkg = readJson(join(projectRoot, "package.json"));
+if (!pkg) {
+  console.log(JSON.stringify({
+    status: "error",
+    error: { message: "No package.json found", code: "NO_PACKAGE_JSON", fallback_instructions: "Ensure you are running this script from a project root that contains a package.json file." },
+  }));
+  process.exit(1);
+}
+
+const framework = detectFramework(pkg);
+const buildTool = detectBuildTool(pkg);
+const tailwind = detectTailwind(pkg);
+const cssPath = detectCssPath(tailwind);
+const packageManager = detectPackageManager();
+const typescript = detectTypescript();
+const shadcn = detectShadcn();
+const entryFile = detectEntryFile(framework);
+const mainCssFile = detectMainCssFile();
+const middlewareFile = framework === "nextjs" ? detectMiddleware() : null;
+const envFile = detectEnvFile(framework);
+const auth0 = detectAuth0(pkg, envFile, framework);
+const existingProviders = detectExistingProviders(entryFile);
+
+const installCmd = packageManager === "pnpm" ? "pnpm add" : packageManager === "bun" ? "bun add" : packageManager === "yarn" ? "yarn add" : "npm install";
+
+console.log(JSON.stringify({
+  status: "success",
+  data: {
+    framework,
+    buildTool,
+    tailwind,
+    cssPath,
+    packageManager,
+    typescript,
+    shadcn,
+    auth0,
+    installCmd,
+    entryFile,
+    mainCssFile,
+    middlewareFile,
+    envFile,
+    existingProviders,
+  },
+}, null, 2));

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/extract-theme.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/extract-theme.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * extract-theme.mjs — Extracts CSS variables from a project's stylesheet and generates
+ * a COMPLETE Auth0 override block. Variables that can't be auto-detected get sensible
+ * defaults derived from what IS detected (e.g., primary color informs ring color).
+ *
+ * Usage: node extract-theme.mjs --css-file <path> --css-path tailwind|scoped
+ * Zero external dependencies.
+ */
+import { readFileSync } from "node:fs";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { cssFile: null, cssPath: "tailwind" };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--css-file" && args[i + 1]) opts.cssFile = args[++i];
+    else if (args[i] === "--css-path" && args[i + 1]) opts.cssPath = args[++i];
+  }
+  return opts;
+}
+
+function output(result) {
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.status === "success" ? 0 : 1);
+}
+
+/**
+ * Extracts the content of a top-level block by balancing braces.
+ */
+function extractBlockContent(css, prefix) {
+  const results = [];
+  const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(escaped + "\\s*\\{", "g");
+  let match;
+  while ((match = regex.exec(css)) !== null) {
+    const start = match.index + match[0].length;
+    let depth = 1;
+    let i = start;
+    while (i < css.length && depth > 0) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") depth--;
+      i++;
+    }
+    if (depth === 0) {
+      results.push(css.slice(start, i - 1));
+    }
+  }
+  return results;
+}
+
+function parseVarsFromBlock(block) {
+  const vars = {};
+  const varRegex = /--([\w-]+)\s*:\s*([^;]+);/g;
+  let m;
+  while ((m = varRegex.exec(block)) !== null) {
+    vars[`--${m[1]}`] = m[2].trim();
+  }
+  return vars;
+}
+
+function parseCssBlock(css, selector) {
+  const blocks = extractBlockContent(css, selector);
+  let vars = {};
+  for (const block of blocks) {
+    Object.assign(vars, parseVarsFromBlock(block));
+  }
+  return vars;
+}
+
+function parseThemeBlocks(css) {
+  const vars = {};
+  const regex = /@theme(?:\s+inline)?\s*\{/g;
+  let match;
+  while ((match = regex.exec(css)) !== null) {
+    const start = match.index + match[0].length;
+    let depth = 1;
+    let i = start;
+    while (i < css.length && depth > 0) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") depth--;
+      i++;
+    }
+    if (depth === 0) {
+      Object.assign(vars, parseVarsFromBlock(css.slice(start, i - 1)));
+    }
+  }
+  return vars;
+}
+
+// --- Color detection targets ---
+const TARGET_COLORS = [
+  "primary", "primary-foreground", "background", "foreground", "border",
+  "secondary", "secondary-foreground", "muted", "muted-foreground",
+  "accent", "accent-foreground", "destructive", "destructive-foreground",
+  "card", "card-foreground", "popover", "popover-foreground", "input", "ring",
+];
+
+const TARGET_RADII = ["radius-sm", "radius-md", "radius-lg", "radius-xl", "radius-2xl"];
+
+// Light mode defaults (from official Auth0 docs)
+const LIGHT_DEFAULTS = {
+  "primary": "oklch(37% 0 0)",
+  "primary-foreground": "oklch(100% 0 0)",
+  "background": "oklch(100% 0 0)",
+  "foreground": "oklch(9% 0 0)",
+  "card": "oklch(100% 0 0)",
+  "card-foreground": "oklch(0% 0 0)",
+  "popover": "oklch(100% 0 0)",
+  "popover-foreground": "oklch(9% 0 0)",
+  "input": "oklch(100% 0 0)",
+  "secondary": "oklch(96% 0 0)",
+  "secondary-foreground": "oklch(9% 0 0)",
+  "muted": "oklch(96% 0 0)",
+  "muted-foreground": "oklch(45% 0 0)",
+  "accent": "oklch(97% 0 0)",
+  "accent-foreground": "oklch(9% 0 0)",
+  "destructive": "oklch(93% 0.03 17)",
+  "destructive-foreground": "oklch(100% 0 0)",
+  "border": "oklch(89% 0 0)",
+  "ring": "oklch(89% 0 0)",
+};
+
+// Dark mode defaults
+const DARK_DEFAULTS = {
+  "primary": "oklch(70% 0.15 250)",
+  "primary-foreground": "oklch(10% 0 0)",
+  "background": "oklch(12% 0 0)",
+  "foreground": "oklch(95% 0 0)",
+  "card": "oklch(15% 0 0)",
+  "card-foreground": "oklch(95% 0 0)",
+  "popover": "oklch(15% 0 0)",
+  "popover-foreground": "oklch(95% 0 0)",
+  "input": "oklch(18% 0 0)",
+  "secondary": "oklch(20% 0 0)",
+  "secondary-foreground": "oklch(95% 0 0)",
+  "muted": "oklch(20% 0 0)",
+  "muted-foreground": "oklch(60% 0 0)",
+  "accent": "oklch(25% 0 0)",
+  "accent-foreground": "oklch(95% 0 0)",
+  "destructive": "oklch(30% 0.15 17)",
+  "destructive-foreground": "oklch(95% 0 0)",
+  "border": "oklch(25% 0 0)",
+  "ring": "oklch(35% 0 0)",
+};
+
+const RADII_DEFAULTS = {
+  "radius-sm": "4px",
+  "radius-md": "6px",
+  "radius-lg": "10px",
+  "radius-xl": "12px",
+  "radius-2xl": "16px",
+};
+
+/**
+ * Maps discovered CSS variables to Auth0 target names.
+ * Handles: --primary, --color-primary, --clr-primary, --c-primary
+ */
+function mapVariables(allVars, targets) {
+  const mapped = {};
+  const prefixes = ["", "color-", "clr-", "c-"];
+
+  for (const target of targets) {
+    if (allVars[`--${target}`]) {
+      mapped[target] = allVars[`--${target}`];
+      continue;
+    }
+    for (const prefix of prefixes) {
+      if (prefix === "") continue;
+      const key = `--${prefix}${target}`;
+      if (allVars[key]) {
+        mapped[target] = allVars[key];
+        break;
+      }
+    }
+  }
+  return mapped;
+}
+
+/**
+ * Maps radius variables with shadcn base --radius fallback.
+ */
+function mapRadii(allVars) {
+  const mapped = mapVariables(allVars, TARGET_RADII);
+  if (Object.keys(mapped).length > 0) return mapped;
+
+  const baseRadius = allVars["--radius"];
+  if (baseRadius) {
+    const baseVal = parseFloat(baseRadius);
+    const unit = baseRadius.replace(/[\d.]+/, "");
+    if (!isNaN(baseVal)) {
+      const scale = unit === "rem" ? baseVal * 16 : baseVal;
+      mapped["radius-sm"] = `${Math.max(scale - 4, 0)}${unit === "rem" ? "px" : unit}`;
+      mapped["radius-md"] = `${Math.max(scale - 2, 0)}${unit === "rem" ? "px" : unit}`;
+      mapped["radius-lg"] = baseRadius;
+      mapped["radius-xl"] = `${scale + 4}${unit === "rem" ? "px" : unit}`;
+      mapped["radius-2xl"] = `${scale + 6}${unit === "rem" ? "px" : unit}`;
+    }
+  }
+  return mapped;
+}
+
+/**
+ * Merges detected variables with defaults so the output is ALWAYS complete.
+ * Detected values override defaults.
+ */
+function fillDefaults(detected, defaults) {
+  const result = { ...defaults };
+  for (const [key, value] of Object.entries(detected)) {
+    result[key] = value;
+  }
+  return result;
+}
+
+function generateOverrideBlock(colors, cssPath, darkColors, hasDarkMode) {
+  const lines = ["/* Auth0 Universal Components — apply this entire block verbatim */", ":root {"];
+
+  if (cssPath === "tailwind") {
+    for (const [name, value] of Object.entries(colors)) {
+      lines.push(`  --${name}: ${value};`);
+    }
+  } else {
+    for (const [name, value] of Object.entries(colors)) {
+      lines.push(`  --auth0-${name}: ${value};`);
+    }
+  }
+  lines.push("}");
+
+  if (hasDarkMode && Object.keys(darkColors).length > 0) {
+    lines.push("");
+    lines.push(".dark {");
+    if (cssPath === "tailwind") {
+      for (const [name, value] of Object.entries(darkColors)) {
+        lines.push(`  --${name}: ${value};`);
+      }
+    } else {
+      for (const [name, value] of Object.entries(darkColors)) {
+        lines.push(`  --auth0-${name}: ${value};`);
+      }
+    }
+    lines.push("}");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Generates the themeSettings.variables object for Auth0ComponentProvider.
+ * Radius MUST be set here (not in CSS) because the theme's [data-theme] selector
+ * has higher specificity than :root and overwrites CSS-level radius values.
+ */
+function generateThemeSettingsVariables(radii, colors, darkColors, hasDarkMode) {
+  const common = {};
+  for (const [name, value] of Object.entries(radii)) {
+    common[`--${name}`] = value;
+  }
+
+  const light = {};
+  for (const [name, value] of Object.entries(colors)) {
+    light[`--auth0-${name}`] = value;
+  }
+
+  const result = { common, light };
+  if (hasDarkMode && Object.keys(darkColors).length > 0) {
+    const dark = {};
+    for (const [name, value] of Object.entries(darkColors)) {
+      dark[`--auth0-${name}`] = value;
+    }
+    result.dark = dark;
+  }
+  return result;
+}
+
+// --- Main ---
+
+const opts = parseArgs();
+if (!opts.cssFile) {
+  output({
+    status: "error",
+    error: { message: "--css-file is required", code: "MISSING_CSS_FILE", fallback_instructions: "Read the project's main CSS file manually and look for :root CSS variable declarations." },
+  });
+}
+
+let css;
+try {
+  css = readFileSync(opts.cssFile, "utf-8");
+} catch (e) {
+  output({
+    status: "error",
+    error: { message: `Cannot read file: ${opts.cssFile}`, code: "FILE_NOT_FOUND", fallback_instructions: "Verify the CSS file path exists and try again." },
+  });
+}
+
+// Parse all variable sources
+const themeVars = parseThemeBlocks(css);
+const rootVars = parseCssBlock(css, ":root");
+const allLightVars = { ...themeVars, ...rootVars };
+
+// Dark mode detection
+const darkVars = parseCssBlock(css, ".dark");
+const darkDataVars = parseCssBlock(css, '[data-theme="dark"]');
+const allDarkVars = { ...darkDataVars, ...darkVars };
+
+const hasDarkMode = Object.keys(allDarkVars).length > 0;
+const darkSelector = Object.keys(darkVars).length > 0 ? ".dark"
+  : Object.keys(darkDataVars).length > 0 ? '[data-theme="dark"]'
+  : null;
+
+// Map what we can detect
+const detectedColors = mapVariables(allLightVars, TARGET_COLORS);
+const detectedRadii = mapRadii(allLightVars);
+const detectedDarkColors = mapVariables(allDarkVars, TARGET_COLORS);
+
+// Fill ALL required variables with defaults for anything not detected
+const colors = fillDefaults(detectedColors, LIGHT_DEFAULTS);
+const radii = fillDefaults(detectedRadii, RADII_DEFAULTS);
+const darkColors = hasDarkMode ? fillDefaults(detectedDarkColors, DARK_DEFAULTS) : {};
+
+// CSS block for colors only (radius won't work in CSS due to specificity)
+const generatedOverrideBlock = generateOverrideBlock(colors, opts.cssPath, darkColors, hasDarkMode);
+
+// themeSettings.variables for Auth0ComponentProvider (radius MUST go here)
+const themeSettingsVariables = generateThemeSettingsVariables(radii, colors, darkColors, hasDarkMode);
+
+output({
+  status: "success",
+  data: {
+    detectedColors,
+    detectedRadii,
+    colors,
+    radii,
+    fonts: {},
+    darkMode: {
+      detected: hasDarkMode,
+      selector: darkSelector,
+      colors: darkColors,
+    },
+    generatedOverrideBlock,
+    themeSettingsVariables,
+  },
+});

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/utils/auth0-api.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/utils/auth0-api.mjs
@@ -1,0 +1,59 @@
+import { execFileSync } from "node:child_process";
+
+const DEFAULT_TIMEOUT = 30000;
+
+export function auth0Exec(args, { timeout = DEFAULT_TIMEOUT } = {}) {
+  try {
+    const stdout = execFileSync("auth0", args, {
+      timeout,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { ok: true, stdout: stdout.trim() };
+  } catch (e) {
+    const stderr = (e.stderr || "").toString().trim();
+    const timedOut = e.killed || e.signal === "SIGTERM";
+    return { ok: false, stderr, timedOut, exitCode: e.status };
+  }
+}
+
+export function auth0ApiCall(method, endpoint, data = null, { timeout = DEFAULT_TIMEOUT } = {}) {
+  const args = ["api", method, endpoint, "--no-input"];
+  if (data) {
+    args.push("--data", JSON.stringify(data));
+  }
+  const result = auth0Exec(args, { timeout });
+  if (!result.ok) {
+    return { ok: false, error: result.stderr, timedOut: result.timedOut };
+  }
+  try {
+    return { ok: true, data: result.stdout ? JSON.parse(result.stdout) : null };
+  } catch {
+    return { ok: true, data: result.stdout };
+  }
+}
+
+export function isSessionValid(timeout = 10000) {
+  const result = auth0Exec(["api", "get", "users", "--no-input"], { timeout });
+  return result.ok;
+}
+
+export function getCliVersion() {
+  const result = auth0Exec(["--version"], { timeout: 5000 });
+  if (!result.ok) return null;
+  const match = result.stdout.match(/(\d+\.\d+\.\d+)/);
+  return match ? match[1] : result.stdout;
+}
+
+export function getActiveTenant(timeout = 15000) {
+  const result = auth0Exec(["tenants", "list", "--csv", "--no-input"], { timeout });
+  if (!result.ok) return { ok: false, error: result.stderr, timedOut: result.timedOut };
+
+  const lines = result.stdout.split("\n").slice(1).filter((l) => l.trim());
+  const activeLine = lines.find((l) => l.includes("→"));
+  if (!activeLine) return { ok: false, error: "No active tenant found" };
+
+  const domain = activeLine.split(",")[1]?.trim();
+  const allTenants = lines.map((l) => l.split(",")[1]?.trim()).filter(Boolean);
+  return { ok: true, domain, allTenants };
+}

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/utils/clients.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/utils/clients.mjs
@@ -1,0 +1,173 @@
+import { auth0ApiCall, auth0Exec } from "./auth0-api.mjs";
+import { MYORG_API_SCOPES } from "./resources.mjs";
+
+const APP_BASE_URL = "http://localhost";
+
+function getClientName(framework) {
+  return framework === "nextjs"
+    ? "Universal Components Demo (Next.js)"
+    : "Universal Components Demo (React SPA)";
+}
+
+function getAppType(framework) {
+  return framework === "nextjs" ? "regular_web" : "spa";
+}
+
+export function ensureClient(clients, domain, framework, port, connectionProfileId, userAttributeProfileId, features, myAccountApiScopes) {
+  const clientName = getClientName(framework);
+  const existing = clients.find((c) => c.name === clientName);
+  const baseUrl = `${APP_BASE_URL}:${port}`;
+  const appType = getAppType(framework);
+  const callbackUrl = framework === "nextjs" ? `${baseUrl}/auth/callback` : baseUrl;
+  const tokenEndpointAuth = framework === "nextjs" ? "client_secret_post" : "none";
+
+  const refreshTokenPolicies = [];
+  if (features.enableMyOrg) {
+    refreshTokenPolicies.push({ audience: `https://${domain}/my-org/`, scope: MYORG_API_SCOPES });
+  }
+  if (features.enableMyAccount && myAccountApiScopes.length > 0) {
+    refreshTokenPolicies.push({ audience: `https://${domain}/me/`, scope: myAccountApiScopes });
+  }
+
+  if (!existing) {
+    const clientData = {
+      name: clientName,
+      description: "Client for Auth0 Universal Components integration.",
+      callbacks: [callbackUrl],
+      allowed_logout_urls: [baseUrl],
+      web_origins: appType === "spa" ? [baseUrl] : [],
+      app_type: appType,
+      oidc_conformant: true,
+      is_first_party: true,
+      grant_types: ["authorization_code", "refresh_token"],
+      token_endpoint_auth_method: tokenEndpointAuth,
+      jwt_configuration: { alg: "RS256", lifetime_in_seconds: 36000, secret_encoded: false },
+      refresh_token: {
+        expiration_type: "expiring",
+        rotation_type: "rotating",
+        token_lifetime: 31557600,
+        idle_token_lifetime: 2592000,
+        leeway: 0,
+        infinite_token_lifetime: false,
+        infinite_idle_token_lifetime: false,
+        policies: refreshTokenPolicies,
+      },
+    };
+
+    if (features.enableMyOrg) {
+      clientData.organization_require_behavior = "post_login_prompt";
+      clientData.organization_usage = "require";
+      clientData.my_organization_configuration = {
+        connection_profile_id: connectionProfileId,
+        user_attribute_profile_id: userAttributeProfileId,
+        connection_deletion_behavior: "allow_if_empty",
+        allowed_strategies: ["pingfederate", "adfs", "waad", "google-apps", "okta", "oidc", "samlp"],
+      };
+    }
+
+    const result = auth0ApiCall("post", "clients", clientData);
+    if (!result.ok) return { action: "error", error: result.error };
+
+    // The CLI may return the created client or empty response
+    const clientId = result.data?.client_id;
+    if (!clientId) {
+      // CLI returned success but no data — check if client was actually created
+      const listResult = auth0ApiCall("get", `clients?fields=client_id,name,client_secret&include_fields=true`);
+      if (listResult.ok && Array.isArray(listResult.data)) {
+        const created = listResult.data.find((c) => c.name === clientName);
+        if (created) return { action: "created", data: created };
+      }
+      return { action: "error", error: "Client creation failed silently. This usually means the tenant has reached its application limit. Delete unused applications in Auth0 Dashboard > Applications, then re-run." };
+    }
+
+    // Fetch full client to get client_secret
+    const full = auth0ApiCall("get", `clients/${clientId}`);
+    return { action: "created", data: full.ok ? full.data : result.data };
+  }
+
+  // Check if updates are needed
+  const full = auth0ApiCall("get", `clients/${existing.client_id}`);
+  const client = full.ok ? full.data : existing;
+
+  const updates = {};
+  let needsUpdate = false;
+
+  if (!client.callbacks?.includes(callbackUrl)) {
+    updates.callbacks = [...(client.callbacks || []), callbackUrl];
+    needsUpdate = true;
+  }
+  if (!client.allowed_logout_urls?.includes(baseUrl)) {
+    updates.allowed_logout_urls = [...(client.allowed_logout_urls || []), baseUrl];
+    needsUpdate = true;
+  }
+  if (appType === "spa" && !client.allowed_web_origins?.includes(baseUrl)) {
+    updates.web_origins = [...(client.allowed_web_origins || []), baseUrl];
+    needsUpdate = true;
+  }
+  if (client.app_type !== appType) {
+    updates.app_type = appType;
+    updates.token_endpoint_auth_method = tokenEndpointAuth;
+    needsUpdate = true;
+  }
+  if (features.enableMyOrg) {
+    if (client.organization_usage !== "require" || client.organization_require_behavior !== "post_login_prompt") {
+      updates.organization_require_behavior = "post_login_prompt";
+      updates.organization_usage = "require";
+      needsUpdate = true;
+    }
+    if (!client.my_organization_configuration ||
+        client.my_organization_configuration.connection_profile_id !== connectionProfileId ||
+        client.my_organization_configuration.user_attribute_profile_id !== userAttributeProfileId) {
+      updates.my_organization_configuration = {
+        connection_profile_id: connectionProfileId,
+        user_attribute_profile_id: userAttributeProfileId,
+        connection_deletion_behavior: "allow_if_empty",
+        allowed_strategies: ["pingfederate", "adfs", "waad", "google-apps", "okta", "oidc", "samlp"],
+      };
+      needsUpdate = true;
+    }
+  }
+
+  // Check refresh token policies
+  const existingPolicies = client.refresh_token?.policies || [];
+  for (const desired of refreshTokenPolicies) {
+    const hasPolicy = existingPolicies.some(
+      (p) => p.audience === desired.audience && JSON.stringify(p.scope?.slice().sort()) === JSON.stringify(desired.scope.slice().sort())
+    );
+    if (!hasPolicy) {
+      const filtered = existingPolicies.filter((p) => p.audience !== desired.audience);
+      updates.refresh_token = { ...(client.refresh_token || {}), rotation_type: "rotating", policies: [...filtered, ...refreshTokenPolicies] };
+      needsUpdate = true;
+      break;
+    }
+  }
+
+  if (!needsUpdate) return { action: "skip", data: client };
+
+  const patchResult = auth0ApiCall("patch", `clients/${client.client_id}`, updates);
+  if (!patchResult.ok) return { action: "error", error: patchResult.error };
+  const updated = auth0ApiCall("get", `clients/${client.client_id}`);
+  return { action: "updated", data: updated.ok ? updated.data : client };
+}
+
+// --- Client Grant operations ---
+
+export function ensureClientGrant(clientId, audience, scopes, clientGrants) {
+  const existing = clientGrants.find((g) => g.client_id === clientId && g.audience === audience);
+  if (!existing) {
+    const result = auth0ApiCall("post", "client-grants", {
+      client_id: clientId,
+      audience,
+      scope: scopes,
+      subject_type: "user",
+    });
+    return result.ok ? { action: "created", data: result.data } : { action: "error", error: result.error };
+  }
+  const existingScopes = existing.scope || [];
+  const missing = scopes.filter((s) => !existingScopes.includes(s));
+  if (missing.length === 0) return { action: "skip", data: existing };
+  const result = auth0ApiCall("patch", `client-grants/${existing.id}`, {
+    scope: [...existingScopes, ...missing],
+  });
+  return result.ok ? { action: "updated", data: result.data || existing } : { action: "error", error: result.error };
+}

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/utils/discovery.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/utils/discovery.mjs
@@ -1,0 +1,78 @@
+import { auth0ApiCall, auth0Exec } from "./auth0-api.mjs";
+
+const CLI_TIMEOUT = 30000;
+
+export function discoverExistingResources(domain) {
+  const resources = {
+    clients: [],
+    roles: [],
+    connections: [],
+    resourceServers: [],
+    clientGrants: [],
+    connectionProfiles: [],
+    userAttributeProfiles: [],
+    orgs: [],
+  };
+
+  const errors = [];
+
+  // Clients
+  const clients = auth0Exec(["apps", "list", "--json", "--no-input"], { timeout: CLI_TIMEOUT });
+  if (clients.ok && clients.stdout) {
+    try { resources.clients = JSON.parse(clients.stdout); } catch { errors.push("clients: parse error"); }
+  } else {
+    errors.push(`clients: ${clients.stderr || "empty response"}`);
+  }
+
+  // Roles
+  const roles = auth0Exec(["roles", "list", "--json", "--no-input"], { timeout: CLI_TIMEOUT });
+  if (roles.ok && roles.stdout) {
+    try { resources.roles = JSON.parse(roles.stdout); } catch { errors.push("roles: parse error"); }
+  } else {
+    errors.push(`roles: ${roles.stderr || "empty response"}`);
+  }
+
+  // Connections
+  const conns = auth0ApiCall("get", "connections");
+  if (conns.ok) {
+    resources.connections = Array.isArray(conns.data) ? conns.data : [];
+  } else {
+    errors.push(`connections: ${conns.error}`);
+  }
+
+  // Resource servers
+  const apis = auth0Exec(["apis", "list", "--json", "--no-input"], { timeout: CLI_TIMEOUT });
+  if (apis.ok && apis.stdout) {
+    try { resources.resourceServers = JSON.parse(apis.stdout); } catch { errors.push("apis: parse error"); }
+  } else {
+    errors.push(`apis: ${apis.stderr || "empty response"}`);
+  }
+
+  // Client grants
+  const grants = auth0ApiCall("get", "client-grants");
+  if (grants.ok) {
+    resources.clientGrants = Array.isArray(grants.data) ? grants.data : [];
+  } else {
+    errors.push(`client-grants: ${grants.error}`);
+  }
+
+  // Connection profiles
+  const profiles = auth0ApiCall("get", "connection-profiles");
+  if (profiles.ok && profiles.data) {
+    resources.connectionProfiles = profiles.data.connection_profiles || [];
+  }
+
+  // User attribute profiles
+  const uap = auth0ApiCall("get", "user-attribute-profiles");
+  if (uap.ok && uap.data) {
+    resources.userAttributeProfiles = uap.data.user_attribute_profiles || [];
+  }
+
+  // Organizations
+  const orgs = auth0Exec(["orgs", "list", "--json", "--no-input"], { timeout: CLI_TIMEOUT });
+  if (orgs.ok && orgs.stdout) {
+    try { resources.orgs = JSON.parse(orgs.stdout); } catch { errors.push("orgs: parse error"); }
+  }
+
+  return { resources, errors };
+}

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/utils/resources.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/utils/resources.mjs
@@ -1,0 +1,241 @@
+import { auth0ApiCall, auth0Exec } from "./auth0-api.mjs";
+
+export const MYORG_API_SCOPES = [
+  "read:my_org:details",
+  "update:my_org:details",
+  "create:my_org:identity_providers",
+  "read:my_org:identity_providers",
+  "update:my_org:identity_providers",
+  "delete:my_org:identity_providers",
+  "update:my_org:identity_providers_detach",
+  "read:my_org:domains",
+  "delete:my_org:domains",
+  "create:my_org:domains",
+  "update:my_org:domains",
+  "create:my_org:identity_providers_domains",
+  "delete:my_org:identity_providers_domains",
+  "read:my_org:identity_providers_scim_tokens",
+  "create:my_org:identity_providers_scim_tokens",
+  "delete:my_org:identity_providers_scim_tokens",
+  "create:my_org:identity_providers_provisioning",
+  "read:my_org:identity_providers_provisioning",
+  "delete:my_org:identity_providers_provisioning",
+  "read:my_org:configuration",
+];
+
+export const MYACCOUNT_API_SCOPES = [
+  "create:me:authentication_methods",
+  "read:me:authentication_methods",
+  "delete:me:authentication_methods",
+  "update:me:authentication_methods",
+  "read:me:factors",
+];
+
+export const CONNECTION_PROFILE_NAME = "Universal-Components-Profile";
+export const USER_ATTRIBUTE_PROFILE_NAME = "Universal Components Profile";
+export const DEFAULT_CONNECTION_NAME = "Universal-Components-Demo";
+export const DEMO_ORG_NAME = "demo-org";
+
+export function getAvailableMyAccountScopes(resourceServers, domain) {
+  const api = resourceServers.find((rs) => rs.identifier === `https://${domain}/me/`);
+  if (!api || !api.scopes) return [];
+  return api.scopes.map((s) => s.value);
+}
+
+// --- Resource Server operations ---
+
+export function ensureMyOrgResourceServer(resourceServers, domain) {
+  const existing = resourceServers.find((rs) => rs.identifier === `https://${domain}/my-org/`);
+  if (existing && existing.skip_consent_for_verifiable_first_party_clients === true) {
+    return { action: "skip", data: existing };
+  }
+  if (existing) {
+    const result = auth0ApiCall("patch", `resource-servers/${existing.id}`, {
+      skip_consent_for_verifiable_first_party_clients: true,
+    });
+    return result.ok ? { action: "updated", data: existing } : { action: "error", error: result.error };
+  }
+  const result = auth0ApiCall("post", "resource-servers", {
+    identifier: `https://${domain}/my-org/`,
+    name: "Auth0 My Organization API",
+    skip_consent_for_verifiable_first_party_clients: true,
+    token_dialect: "rfc9068_profile",
+  });
+  return result.ok ? { action: "created", data: result.data } : { action: "error", error: result.error };
+}
+
+export function ensureMyAccountResourceServer(resourceServers, domain) {
+  const existing = resourceServers.find((rs) => rs.identifier === `https://${domain}/me/`);
+  if (existing && existing.skip_consent_for_verifiable_first_party_clients === true) {
+    return { action: "skip", data: existing };
+  }
+  if (existing) {
+    const result = auth0ApiCall("patch", `resource-servers/${existing.id}`, {
+      skip_consent_for_verifiable_first_party_clients: true,
+    });
+    return result.ok ? { action: "updated", data: existing } : { action: "error", error: result.error };
+  }
+  const result = auth0ApiCall("post", "resource-servers", {
+    identifier: `https://${domain}/me/`,
+    name: "Auth0 My Account API",
+    skip_consent_for_verifiable_first_party_clients: true,
+    token_dialect: "rfc9068_profile",
+  });
+  return result.ok ? { action: "created", data: result.data } : { action: "error", error: result.error };
+}
+
+// --- Connection Profile operations ---
+
+export function ensureConnectionProfile(connectionProfiles) {
+  const existing = connectionProfiles.find((cp) => cp.name === CONNECTION_PROFILE_NAME);
+  const desiredConfig = {
+    organization: { show_as_button: "optional", assign_membership_on_login: "optional" },
+    connection_name_prefix_template: "con-{org_id}-",
+    enabled_features: ["scim", "universal_logout"],
+  };
+
+  if (existing) {
+    const needsUpdate =
+      existing.organization?.show_as_button !== desiredConfig.organization.show_as_button ||
+      existing.organization?.assign_membership_on_login !== desiredConfig.organization.assign_membership_on_login ||
+      existing.connection_name_prefix_template !== desiredConfig.connection_name_prefix_template;
+    if (!needsUpdate) return { action: "skip", data: existing };
+    const result = auth0ApiCall("patch", `connection-profiles/${existing.id}`, desiredConfig);
+    return result.ok ? { action: "updated", data: result.data || existing } : { action: "error", error: result.error };
+  }
+  const result = auth0ApiCall("post", "connection-profiles", { name: CONNECTION_PROFILE_NAME, ...desiredConfig });
+  return result.ok ? { action: "created", data: result.data } : { action: "error", error: result.error };
+}
+
+// --- User Attribute Profile operations ---
+
+export function ensureUserAttributeProfile(userAttributeProfiles) {
+  const existing = userAttributeProfiles.find((uap) => uap.name === USER_ATTRIBUTE_PROFILE_NAME);
+  if (existing) return { action: "skip", data: existing };
+
+  const templates = auth0ApiCall("get", "user-attribute-profiles/templates");
+  if (!templates.ok || !templates.data?.user_attribute_profile_templates?.length) {
+    return { action: "error", error: "No user attribute profile templates available" };
+  }
+  const template = templates.data.user_attribute_profile_templates[0].template;
+  template.name = USER_ATTRIBUTE_PROFILE_NAME;
+  const result = auth0ApiCall("post", "user-attribute-profiles", template);
+  return result.ok ? { action: "created", data: result.data } : { action: "error", error: result.error };
+}
+
+// --- Connection operations ---
+
+export function ensureConnection(connections, enabledClientIds) {
+  const existing = connections.find((c) => c.name === DEFAULT_CONNECTION_NAME);
+  if (!existing) {
+    const result = auth0ApiCall("post", "connections", {
+      strategy: "auth0",
+      name: DEFAULT_CONNECTION_NAME,
+      display_name: "Universal-Components",
+      enabled_clients: enabledClientIds,
+    });
+    return result.ok ? { action: "created", data: result.data } : { action: "error", error: result.error };
+  }
+  const missingClients = enabledClientIds.filter((id) => !(existing.enabled_clients || []).includes(id));
+  if (missingClients.length === 0) return { action: "skip", data: existing };
+  const result = auth0ApiCall("patch", `connections/${existing.id}`, {
+    enabled_clients: [...(existing.enabled_clients || []), ...missingClients],
+  });
+  return result.ok ? { action: "updated", data: result.data || existing } : { action: "error", error: result.error };
+}
+
+// --- Role operations ---
+
+export function ensureAdminRole(roles, domain) {
+  const existing = roles.find((r) => r.name === "admin");
+  if (!existing) {
+    const createResult = auth0Exec(
+      ["roles", "create", "--name", "admin", "--description", "Manage the organization's configuration.", "--json", "--no-input"],
+      { timeout: 15000 }
+    );
+    if (!createResult.ok) return { action: "error", error: createResult.stderr };
+    const role = JSON.parse(createResult.stdout);
+    const permsResult = auth0ApiCall("post", `roles/${role.id}/permissions`, {
+      permissions: MYORG_API_SCOPES.map((s) => ({ permission_name: s, resource_server_identifier: `https://${domain}/my-org/` })),
+    });
+    return permsResult.ok ? { action: "created", data: role } : { action: "error", error: permsResult.error };
+  }
+
+  // Check existing permissions
+  const permsResult = auth0ApiCall("get", `roles/${existing.id}/permissions`);
+  if (!permsResult.ok) return { action: "error", error: permsResult.error };
+  const currentPerms = Array.isArray(permsResult.data) ? permsResult.data : permsResult.data?.permissions || [];
+  const myOrgPerms = currentPerms.filter((p) => p.resource_server_identifier === `https://${domain}/my-org/`);
+  const existingNames = new Set(myOrgPerms.map((p) => p.permission_name));
+  const missing = MYORG_API_SCOPES.filter((s) => !existingNames.has(s));
+  if (missing.length === 0) return { action: "skip", data: existing };
+
+  const addResult = auth0ApiCall("post", `roles/${existing.id}/permissions`, {
+    permissions: missing.map((s) => ({ permission_name: s, resource_server_identifier: `https://${domain}/my-org/` })),
+  });
+  return addResult.ok ? { action: "updated", data: existing } : { action: "error", error: addResult.error };
+}
+
+// --- Organization operations ---
+
+export function ensureOrganization(orgs, connectionId) {
+  const existing = orgs.find((o) => o.name === DEMO_ORG_NAME);
+  if (!existing) {
+    const createResult = auth0Exec(
+      ["orgs", "create", "--name", DEMO_ORG_NAME, "--display", "Universal Components Demo Org", "--json", "--no-input"],
+      { timeout: 15000 }
+    );
+    if (!createResult.ok) return { action: "error", error: createResult.stderr };
+    const org = JSON.parse(createResult.stdout);
+    if (connectionId) {
+      auth0ApiCall("post", `organizations/${org.id}/enabled_connections`, {
+        connection_id: connectionId,
+        assign_membership_on_login: false,
+        is_signup_enabled: false,
+      });
+    }
+    return { action: "created", data: org };
+  }
+
+  // Check if connection is enabled
+  if (connectionId) {
+    const connCheck = auth0ApiCall("get", `organizations/${existing.id}/enabled_connections/${connectionId}`);
+    if (!connCheck.ok || !connCheck.data?.connection) {
+      auth0ApiCall("post", `organizations/${existing.id}/enabled_connections`, {
+        connection_id: connectionId,
+        assign_membership_on_login: false,
+        is_signup_enabled: false,
+      });
+      return { action: "updated", data: existing };
+    }
+  }
+  return { action: "skip", data: existing };
+}
+
+// --- Tenant config operations ---
+
+export function ensureTenantSettings() {
+  const current = auth0ApiCall("get", "tenants/settings");
+  if (!current.ok) return { action: "error", error: current.error };
+
+  const desired = {
+    customize_mfa_in_postlogin_action: true,
+    flags: { enable_client_connections: false },
+  };
+
+  const needsUpdate =
+    current.data?.customize_mfa_in_postlogin_action !== true ||
+    current.data?.flags?.enable_client_connections !== false;
+
+  if (!needsUpdate) return { action: "skip" };
+  const result = auth0ApiCall("patch", "tenants/settings", desired);
+  return result.ok ? { action: "updated" } : { action: "error", error: result.error };
+}
+
+export function ensurePromptSettings() {
+  const current = auth0ApiCall("get", "prompts");
+  if (!current.ok) return { action: "error", error: current.error };
+  if (current.data?.identifier_first === true) return { action: "skip" };
+  const result = auth0ApiCall("patch", "prompts", { identifier_first: true });
+  return result.ok ? { action: "updated" } : { action: "error", error: result.error };
+}

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/validate-auth0.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/validate-auth0.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * validate-auth0.mjs — Pre-flight check for Auth0 CLI session.
+ * Usage: node validate-auth0.mjs --domain <tenant-domain>
+ * Zero external dependencies.
+ */
+import { getCliVersion, isSessionValid, getActiveTenant } from "./utils/auth0-api.mjs";
+
+const BOOTSTRAP_SCOPES = [
+  "read:connection_profiles", "create:connection_profiles", "update:connection_profiles",
+  "read:user_attribute_profiles", "create:user_attribute_profiles", "update:user_attribute_profiles",
+  "read:client_grants", "create:client_grants", "update:client_grants", "delete:client_grants",
+  "read:connections", "create:connections", "update:connections",
+  "create:organization_connections", "create:organization_members", "create:organization_member_roles",
+  "read:clients", "create:clients", "update:clients", "read:client_keys",
+  "read:roles", "create:roles", "update:roles",
+  "read:resource_servers", "create:resource_servers", "update:resource_servers",
+  "update:tenant_settings",
+];
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let domain = null;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--domain" && args[i + 1]) domain = args[i + 1];
+  }
+  return { domain };
+}
+
+function output(result) {
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.status === "success" ? 0 : 1);
+}
+
+const { domain } = parseArgs();
+
+if (!domain) {
+  output({
+    status: "error",
+    data: { cli_installed: null, session_valid: null },
+    error: {
+      code: "MISSING_DOMAIN",
+      message: "The --domain argument is required",
+      fallback_instructions: "Re-run with: node validate-auth0.mjs --domain <your-tenant>.us.auth0.com",
+    },
+  });
+}
+
+// Step 1: Check CLI installed
+const cliVersion = getCliVersion();
+if (!cliVersion) {
+  output({
+    status: "error",
+    data: { cli_installed: false, session_valid: false },
+    error: {
+      code: "CLI_NOT_INSTALLED",
+      message: "Auth0 CLI is not installed or not in PATH",
+      fallback_instructions: "Ask the user to install the Auth0 CLI: https://github.com/auth0/auth0-cli#installation. Then re-run this script.",
+    },
+  });
+}
+
+// Step 2: Check session valid
+const sessionValid = isSessionValid();
+if (!sessionValid) {
+  const scopesArg = BOOTSTRAP_SCOPES.join(",");
+  output({
+    status: "error",
+    data: { cli_installed: true, cli_version: cliVersion, session_valid: false },
+    error: {
+      code: "SESSION_EXPIRED",
+      message: "Auth0 CLI session is expired or invalid",
+      fallback_instructions: `Run: auth0 login --domain ${domain} --scopes ${scopesArg}\nThis opens a browser for the user to authenticate. Wait for completion (up to 120s). Tell the user to complete the login in their browser.`,
+    },
+  });
+}
+
+// Step 3: Check active tenant matches
+const tenantResult = getActiveTenant();
+if (!tenantResult.ok) {
+  output({
+    status: "error",
+    data: { cli_installed: true, cli_version: cliVersion, session_valid: true },
+    error: {
+      code: "TENANT_CHECK_FAILED",
+      message: tenantResult.timedOut ? "Tenant check timed out" : tenantResult.error,
+      fallback_instructions: "The Auth0 CLI may be unresponsive. Ask the user to run: auth0 tenants list",
+    },
+  });
+}
+
+const tenantMatch = tenantResult.domain === domain;
+if (!tenantMatch) {
+  const available = tenantResult.allTenants.includes(domain);
+  output({
+    status: "error",
+    data: {
+      cli_installed: true,
+      cli_version: cliVersion,
+      session_valid: true,
+      active_tenant: tenantResult.domain,
+      tenant_match: false,
+      requested_tenant: domain,
+      tenant_available: available,
+    },
+    error: {
+      code: "TENANT_MISMATCH",
+      message: `Active tenant is "${tenantResult.domain}" but "${domain}" was requested`,
+      fallback_instructions: available
+        ? `Run: auth0 tenants use ${domain}`
+        : `Run: auth0 login --domain ${domain} --scopes ${BOOTSTRAP_SCOPES.join(",")}\nThis opens a browser for the user to authenticate. Wait for completion (up to 120s). Tell the user to complete the login in their browser.`,
+    },
+  });
+}
+
+output({
+  status: "success",
+  data: {
+    cli_installed: true,
+    cli_version: cliVersion,
+    session_valid: true,
+    active_tenant: tenantResult.domain,
+    tenant_match: true,
+  },
+});

--- a/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/verify-setup.mjs
+++ b/plugins/auth0/skills/auth0-my-organization-api/skills/using-my-organization-api/scripts/verify-setup.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * verify-setup.mjs — Post-setup validation for Auth0 Universal Components integration.
+ * Usage: node verify-setup.mjs --project-root <path> --framework nextjs|react-spa --css-path tailwind|scoped
+ * Zero external dependencies.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { projectRoot: process.cwd(), framework: "react-spa", cssPath: "tailwind" };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--project-root" && args[i + 1]) opts.projectRoot = resolve(args[++i]);
+    else if (args[i] === "--framework" && args[i + 1]) opts.framework = args[++i];
+    else if (args[i] === "--css-path" && args[i + 1]) opts.cssPath = args[++i];
+  }
+  return opts;
+}
+
+function readFile(path) {
+  try { return readFileSync(path, "utf-8"); } catch { return null; }
+}
+
+function fileExists(path) { return existsSync(path); }
+
+function findFile(root, candidates) {
+  for (const f of candidates) {
+    if (fileExists(join(root, f))) return f;
+  }
+  return null;
+}
+
+function checkEnvVars(root, framework) {
+  const envPath = findFile(root, [".env.local", ".env"]);
+  if (!envPath) return { name: "env_vars_present", pass: false, details: "No .env.local or .env file found", fix: "Create .env.local with AUTH0_DOMAIN, AUTH0_CLIENT_ID, and other required vars" };
+  const content = readFile(join(root, envPath));
+  const required = framework === "nextjs"
+    ? ["AUTH0_DOMAIN", "AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET", "AUTH0_SECRET"]
+    : ["AUTH0_DOMAIN", "AUTH0_CLIENT_ID"];
+  // Also check VITE_ prefixed vars for react-spa
+  const missing = required.filter((v) => {
+    if (content.includes(v + "=")) return false;
+    if (framework === "react-spa" && content.includes("VITE_" + v.replace("AUTH0_", "AUTH0_") + "=")) return false;
+    if (framework === "react-spa" && content.includes(`VITE_${v}=`)) return false;
+    return true;
+  });
+  if (missing.length > 0) return { name: "env_vars_present", pass: false, details: `Missing env vars: ${missing.join(", ")}`, fix: `Add ${missing.join(", ")} to ${envPath}` };
+  return { name: "env_vars_present", pass: true, details: `All required env vars found in ${envPath}` };
+}
+
+function checkPackagesInstalled(root) {
+  const pkgPath = join(root, "node_modules", "@auth0", "universal-components-react", "package.json");
+  if (fileExists(pkgPath)) return { name: "packages_installed", pass: true, details: "@auth0/universal-components-react found in node_modules" };
+  // Check if it's in package.json at least
+  const pkg = readFile(join(root, "package.json"));
+  if (pkg && pkg.includes("@auth0/universal-components-react")) {
+    return { name: "packages_installed", pass: false, details: "Package is in package.json but not in node_modules", fix: "Run your package manager's install command" };
+  }
+  return { name: "packages_installed", pass: false, details: "@auth0/universal-components-react not found", fix: "Install with: npm install @auth0/universal-components-react" };
+}
+
+function checkCssImport(root, cssPath) {
+  const importStr = cssPath === "tailwind"
+    ? "@auth0/universal-components-react/tailwind"
+    : "@auth0/universal-components-react/styles";
+
+  // Check CSS files for @import
+  const cssFile = findFile(root, [
+    "src/app/globals.css", "src/globals.css", "src/index.css", "src/styles.css",
+    "src/app.css", "app/globals.css", "styles/globals.css",
+  ]);
+  if (cssFile) {
+    const content = readFile(join(root, cssFile));
+    if (content && (content.includes(importStr) || content.includes("@auth0/universal-components-react/"))) {
+      return { name: "css_import_exists", pass: true, details: `Found Auth0 stylesheet import in ${cssFile}` };
+    }
+  }
+
+  // Check JS/TS entry files for import statement (e.g., import "@auth0/.../styles")
+  const jsFiles = ["src/main.tsx", "src/main.jsx", "src/main.js", "src/index.tsx", "src/index.jsx", "src/index.js", "src/App.tsx", "src/App.jsx"];
+  for (const f of jsFiles) {
+    const content = readFile(join(root, f));
+    if (content && (content.includes(importStr) || content.includes("@auth0/universal-components-react/"))) {
+      return { name: "css_import_exists", pass: true, details: `Found Auth0 stylesheet import in ${f}` };
+    }
+  }
+
+  const location = cssFile || "your main CSS or entry file";
+  return { name: "css_import_exists", pass: false, details: `No Auth0 stylesheet import found`, fix: `Add \`import "${importStr}";\` to your entry file, or \`@import "${importStr}";\` to ${location}` };
+}
+
+function checkProviderHierarchy(root, framework) {
+  // Scan all likely files where providers could be placed
+  const candidates = framework === "nextjs"
+    ? ["src/app/layout.tsx", "src/app/layout.jsx", "app/layout.tsx", "app/layout.jsx",
+       "src/app/providers.tsx", "src/app/providers.jsx", "src/providers.tsx", "src/providers.jsx",
+       "src/components/providers.tsx", "src/lib/auth0-provider.tsx"]
+    : ["src/main.tsx", "src/main.jsx", "src/main.js", "src/App.tsx", "src/App.jsx", "src/App.js",
+       "src/providers.tsx", "src/providers.jsx", "src/providers/index.tsx",
+       "src/components/providers.tsx", "src/lib/auth0-provider.tsx"];
+
+  let hasAuth0Provider = false;
+  let hasComponentProvider = false;
+  let filesChecked = 0;
+
+  for (const f of candidates) {
+    const content = readFile(join(root, f));
+    if (!content) continue;
+    filesChecked++;
+    if (content.includes("Auth0Provider") || content.includes("auth0Provider")) hasAuth0Provider = true;
+    if (content.includes("Auth0ComponentProvider")) hasComponentProvider = true;
+  }
+
+  if (filesChecked === 0) return { name: "provider_hierarchy", pass: false, details: "No entry/layout files found", fix: "Create the entry file with Auth0Provider and Auth0ComponentProvider" };
+  if (hasAuth0Provider && hasComponentProvider) return { name: "provider_hierarchy", pass: true, details: "Auth0Provider and Auth0ComponentProvider found" };
+  if (hasAuth0Provider && !hasComponentProvider) return { name: "provider_hierarchy", pass: false, details: "Auth0Provider found but Auth0ComponentProvider is missing", fix: "Wrap your components with Auth0ComponentProvider inside Auth0Provider" };
+  return { name: "provider_hierarchy", pass: false, details: "Auth0Provider not found in entry files", fix: "Add Auth0Provider wrapping Auth0ComponentProvider in your app entry" };
+}
+
+function checkMiddleware(root, framework) {
+  if (framework !== "nextjs") return null;
+  const mw = findFile(root, ["src/middleware.ts", "src/middleware.js", "middleware.ts", "middleware.js"]);
+  if (!mw) return { name: "middleware_exists", pass: false, details: "No middleware file found", fix: "Create src/middleware.ts with Auth0 middleware configuration" };
+  const content = readFile(join(root, mw));
+  if (content && (content.includes("auth0") || content.includes("Auth0"))) {
+    return { name: "middleware_exists", pass: true, details: `${mw} exists with auth0 middleware` };
+  }
+  return { name: "middleware_exists", pass: false, details: `${mw} exists but doesn't reference Auth0`, fix: "Add Auth0 middleware to your middleware.ts" };
+}
+
+function checkThemeVariables(root) {
+  const cssFile = findFile(root, [
+    "src/app/globals.css", "src/globals.css", "src/index.css", "src/styles.css",
+    "src/app.css", "app/globals.css", "styles/globals.css",
+  ]);
+  if (!cssFile) return { name: "theme_variables_set", pass: false, details: "No CSS file to check for theme variables", fix: "Add --primary override to your main CSS file's :root block" };
+  const content = readFile(join(root, cssFile));
+  if (content && (content.includes("--primary") || content.includes("--auth0-primary"))) {
+    return { name: "theme_variables_set", pass: true, details: "Primary color override found in CSS" };
+  }
+  return { name: "theme_variables_set", pass: false, details: "No --primary override found in CSS. Components will use Auth0 defaults.", fix: "Add `--primary: <your-brand-color>;` to :root in your main CSS file" };
+}
+
+// --- Main ---
+
+const opts = parseArgs();
+const checks = [];
+
+checks.push(checkEnvVars(opts.projectRoot, opts.framework));
+checks.push(checkPackagesInstalled(opts.projectRoot));
+checks.push(checkCssImport(opts.projectRoot, opts.cssPath));
+checks.push(checkProviderHierarchy(opts.projectRoot, opts.framework));
+const mwCheck = checkMiddleware(opts.projectRoot, opts.framework);
+if (mwCheck) checks.push(mwCheck);
+checks.push(checkThemeVariables(opts.projectRoot));
+
+const allPassed = checks.every((c) => c.pass);
+const passCount = checks.filter((c) => c.pass).length;
+
+const result = {
+  status: "success",
+  data: {
+    checks,
+    all_passed: allPassed,
+    summary: `${passCount}/${checks.length} checks passed.${allPassed ? "" : " See 'fix' field for failures."}`,
+  },
+};
+
+console.log(JSON.stringify(result, null, 2));
+process.exit(0);


### PR DESCRIPTION
### Summary            
                                                                               
-   **auth0-my-organization-api** — A single-skill plugin containing using-my-organization-api, which guides agents through building organization-scoped admin portals for B2B SaaS using Auth0's My Organization API. Covers three implementation paths:
    - bootstrapping from the SaaStart reference app
    - porting existing Management API calls to the My Org API
    - adding pre-built UI components from @auth0/universal-components-react.
Also covers backend validation, organization context middleware, and permission enforcement.

The skill ships with five supporting scripts under scripts/:

- detect-stack.mjs — reads framework, package manager, Tailwind config, and existing Auth0 env vars in one pass; output feeds all subsequent steps so the agent never greps package.json manually
- validate-auth0.mjs — checks CLI auth state against the tenant before bootstrap
- bootstrap.mjs — idempotently configures all required Auth0 resources (resource server, application, callback URLs, client grants, database connection, admin role, demo org) and outputs env vars ready to write to .env.local
- extract-theme.mjs — reads the project's CSS variables and generates an Auth0ComponentProvider theme override block
- verify-setup.mjs — pre-flight checker that runs before npm run dev; any pass: false
  check is auto-fixed by the agent

### Notable details

1. No-database principle enforced at the skill level. The SKILL.md contains an explicit agent instruction: Auth0 is the source of organizations and users. Agents must never create a database (Prisma, Supabase, etc.) to store or sync org/user data unless the user explicitly asks. This was added after repeated cases where agents introduced databases unnecessarily.
2. Path selection is agent-driven, not user-driven. A Choose Your Path decision tree in SKILL.md instructs the agent to detect project state and follow the tree silently. The agent only asks the user when detection is genuinely ambiguous (e.g. multiple orgs exist). For an empty codebase with no specified stack, the agent defaults to Next.js + SaaStart + Universal Components and informs the user rather than asking.
3. Tenant detection is fully automatic. The agent checks env files → Auth0 CLI → CLI config → mcp__auth0_mcp__auth0_get_tenant_name() before ever asking the user for their domain. The MCP tool call is always available in the environment and returns the tenant domain directly.
4. PATH forwarding for Node.js scripts. Scripts invoke the auth0 CLI binary via execFileSync, which does not inherit the full shell PATH. The skill instructs agents to pass PATH="$PATH" explicitly when calling the scripts, and to verify auth0 is in PATH via which auth0 before any script run.
5. Next.js 15.5.x compatibility. A new workUnitAsyncStorage invariant error appears on 15.5.x when auth0.getSession() is called from a statically-rendered server component. The skill adds export const dynamic = 'force-dynamic' to every auth-gated page as a blanket fix, plus a peer dep check to catch version mismatches before the dev server starts.
6. Pre-flight checks are active agent steps, not passive documentation. The verify-setup.mjs script runs before npm run dev and the agent applies all fixes automatically. This prevents a class of "it starts but immediately crashes" errors caused by missing env vars or misconfigured callback URLs.
7. EAGAIN is documented as an OS-level limit. When the file descriptor error appears (common during npm install in resource-constrained environments), the agent is instructed to explain the cause and tell the user to retry in their terminal — not retry the command from inside the agent environment.
8. Common Mistakes uses Cause → Fix → Verify format. 14 documented errors, each with a root cause, numbered fix steps, and a checkpoint confirming success. Errors include: wrong audience URL, missing AUTH0_SECRET, "client not found", "not authorized after login", callback URL mismatch, and the workUnitAsyncStorage invariant error.

### Test Plan

No automated regression harness in this PR. The skill has been manually exercised against the SaaStart path (empty repo → running dashboard), the porting path (existing Management API app), and the UI components path. A test harness is tracked as follow-up work.

### Notes for Reviewers

- The scripts/ folder was adapted from auth0-universal-components-web — the utility helpers under scripts/utils/ (auth0-api.mjs, clients.mjs, discovery.mjs, resources.mjs) are shared patterns; happy to consolidate these into a shared location if the repo has a convention for that.
- The skill description is intentionally verbose — it's the selection signal for the LLM. Open to trimming if it crosses a length threshold.
- Member management and security policies are documented as "not yet supported by My Organization API" with Management API fallback patterns included inline. Happy to move these to a separate reference file if the main skill file feels cluttered.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.
