### PR TITLE
feat: auth0 audit claude skill

### DIFF
--- a/plugins/auth0/skills/auth0-audit/.claude/commands/auth0-audit.md
+++ b/plugins/auth0/skills/auth0-audit/.claude/commands/auth0-audit.md
@@ -1,0 +1,228 @@
+Run a security audit against the configured Auth0 tenant. Produces Markdown receipts and structured JSON findings.
+
+**Usage:**
+```
+/auth0-audit [--tool actions|tokens|passkeys|all] [--tenant DOMAIN] [--cache]
+```
+
+**Arguments:**
+- `--tool`: Which audit to run. Default: `all`
+- `--tenant`: Override the `AUTH0_DOMAIN` env var for this run
+- `--cache`: Use `scripts/demo-cache.json` instead of live API calls (offline demo mode)
+
+## Step 0 — Verify MCP connection
+
+Before doing anything else, attempt a lightweight MCP call (e.g. `auth0_list_applications` with `per_page=1`) to confirm the auth0-mcp-server is reachable.
+
+- If the call **succeeds**: proceed to Step 1.
+- If the call **fails** with an MCP connection error or authentication error: stop immediately and tell the user:
+
+  > The auth0-mcp-server is not connected or not authenticated.
+  > Please run the following command in your terminal, then re-run `/auth0-audit`:
+  >
+  > ```
+  > npx @auth0/auth0-mcp-server init
+  > ```
+
+Do not proceed to any audit steps until the MCP connection is confirmed.
+
+## Step 1 — Parse arguments
+
+Extract `--tool`, `--tenant`, `--cache` from the `/auth0-audit` invocation args.
+Default `--tool` to `all` if not specified.
+If `--tenant` is provided, set `AUTH0_DOMAIN` to that value for this run.
+
+## Step 2 — Run selected tools
+
+Run tools in order: `actions` → `tokens` → `passkeys` (skip any not selected).
+
+---
+
+## Tool: ActionsWhisperer (`--tool actions`)
+
+**Purpose:** Analyze all Auth0 Actions for security risks.
+
+**Steps:**
+
+1. Use MCP tool `auth0_list_actions` to get all actions. If `--cache` is set, read from `scripts/demo-cache.json` key `actions_list` instead.
+
+2. For each action returned, use MCP tool `auth0_get_action` with the action's `id` to fetch its full details including `code`, `secrets` (names only), and `dependencies`.
+
+3. For each action, analyze the code using the **ActionsWhisperer Analysis Prompt** below.
+
+4. Collect all findings into an array. Then run:
+   ```bash
+   node tools/render-findings.js actions '<JSON_ARRAY>'
+   ```
+   where `<JSON_ARRAY>` is the JSON-stringified array of per-action findings objects.
+
+5. Print the console summary line.
+
+**ActionsWhisperer Analysis Prompt** (apply this to each action's code):
+
+```
+You are a CIAM security analyst reviewing Auth0 Actions code. Analyze the following Auth0 Action and return ONLY a valid JSON object matching the schema below. Do not include markdown, explanation, or any text outside the JSON.
+
+Action context:
+- Name: {action_name}
+- Trigger: {trigger_type}  (e.g. post-login, credentials-exchange, pre-user-registration, post-user-registration)
+- Named secrets available (values not accessible via API): {secret_names}
+- NPM dependencies declared: {dependencies}
+
+Code:
+{code}
+
+Identify and flag the following risk patterns:
+
+(a) EXTERNAL_HTTP_CALL — any fetch(), axios(), http.request(), or XMLHttpRequest to a non-hardcoded URL or to any URL not in the declared allowlist. If the URL is a string literal, include it. If it uses a variable or env secret, note it.
+
+(b) PII_METADATA_WRITE — any call to api.user.setUserMetadata() or api.idTokenClaims.setCustomClaim() where the value comes from event.request.* (ip, userAgent, geoip, hostname, query, body) — this persists request-context data as PII in the user record.
+
+(c) HARDCODED_SECRET — any string literal matching patterns for API keys, tokens, or passwords:
+  - Length 20–80 characters with high entropy (mixed alphanumeric + special chars)
+  - Matches patterns like: /[A-Za-z0-9_\-]{32,}/ in a string assignment to a variable named *key*, *token*, *secret*, *password*, *apikey*, *api_key*
+  - Do NOT flag named secret references like event.secrets.MY_SECRET — those are safe
+
+(d) EXTERNAL_CLAIM_INJECTION — any call to api.accessToken.setCustomClaim() or api.idTokenClaims.setCustomClaim() where the value originates from an external HTTP response, event.request.*, or event.authorization.* — this could inject attacker-controlled values into tokens
+
+(e) ACCESS_DENY_CONDITION — any call to api.access.deny() — document the condition, but do not automatically flag as risky; rate this "low" unless the condition itself looks exploitable
+
+(f) UNALLOWLISTED_SERVICE — any call to an external service (HTTP or SDK) that is not in the declared allowlist (assume the declared allowlist is empty unless the action's code or comments explicitly define one)
+
+IMPORTANT: event.secrets.ANYTHING is safe — do not flag secret references. Only flag hardcoded literal values.
+IMPORTANT: Do not echo any email addresses, user IDs, or PII you find in code comments.
+
+Return this JSON schema (no other text):
+{
+  "action_id": "<id>",
+  "action_name": "<name>",
+  "trigger": "<trigger_type>",
+  "risk_level": "critical|high|medium|low|none",
+  "findings": [
+    {
+      "pattern": "EXTERNAL_HTTP_CALL|PII_METADATA_WRITE|HARDCODED_SECRET|EXTERNAL_CLAIM_INJECTION|ACCESS_DENY_CONDITION|UNALLOWLISTED_SERVICE",
+      "location": "<function name or line description>",
+      "description": "<what was found, no PII>",
+      "remediation": "<specific fix recommendation>"
+    }
+  ],
+  "plain_english_summary": "<2-3 sentence plain English description of what this Action does and its risk profile>"
+}
+
+Risk level rules:
+- critical: HARDCODED_SECRET found
+- high: PII_METADATA_WRITE or EXTERNAL_CLAIM_INJECTION with externally sourced values
+- medium: EXTERNAL_HTTP_CALL or UNALLOWLISTED_SERVICE
+- low: ACCESS_DENY_CONDITION or minor issues
+- none: no findings
+```
+
+**Output files written by** `node tools/render-findings.js actions`:
+- `actions-audit.md` — full receipts grouped by trigger type
+- `actions-findings.json` — structured findings array
+
+**Console summary format:**
+```
+Analyzed N actions. Found X critical, Y high, Z medium findings.
+Top risk: [action_name] ([trigger]) — [one-line description of worst finding].
+```
+
+---
+
+## Tool: TokenGraveyard (`--tool tokens`)
+
+**Purpose:** Identify dormant and overprivileged M2M (non_interactive) applications and provide approval-gated remediation.
+
+**Steps:**
+
+1. Use MCP tool `auth0_list_applications` with filter `app_type=non_interactive` (or equivalent parameter). If `--cache`, read from `scripts/demo-cache.json` key `m2m_apps`.
+
+2. Run the TokenGraveyard analysis script to compute last-used dates and blast-radius scores:
+   ```bash
+   node tools/token-graveyard.js
+   ```
+   This script queries Auth0 logs directly for each app's last `sce` event, computes scores, writes `tokens-audit.md` and `tokens-findings.json`, and prints a ranked remediation list to stdout.
+
+3. Show the ranked remediation list to the user. For each app in the **"Revoke now"** tier, ask:
+   ```
+   Revoke client grant for "[app_name]" (client_id: [id])? [y/N]
+   ```
+   Wait for explicit `y` before proceeding. `N` or any other input skips that app.
+
+4. For each approved revocation, use MCP tool `auth0_delete_client_grant` with the grant ID.
+
+5. After all approvals processed, run:
+   ```bash
+   node tools/render-findings.js tokens-receipt '<RECEIPTS_JSON>'
+   ```
+   to write `tokens-remediation-receipt.md`.
+
+**Blast-radius scoring** (implemented in `tools/token-graveyard.js`):
+- `update:users`, `delete:users` → 4 pts each
+- `create:clients`, `update:clients`, `delete:clients` → 5 pts each
+- `read:user_idp_tokens` → 3 pts
+- `update:tenant_settings` → 5 pts
+- `read:users` → 1 pt
+- All other Management API scopes → 1 pt
+- Non-Management-API scopes → 0.5 pts
+
+**Tier assignments:**
+- **Revoke now:** never used OR (last used >90 days AND blast radius > 5)
+- **Rotate within 7 days:** last used 60–90 days OR blast radius > 8
+- **Scope-narrow within 30 days:** scope overprivilege relative to app name/purpose
+- **Monitor:** last used <30 days, normal blast radius
+
+**Console summary format:**
+```
+Found N M2M applications. X never used, Y dormant >60 days, Z with high blast radius (score >8).
+Recommended: revoke X, rotate Y, scope-narrow Z.
+```
+
+---
+
+## Tool: PasskeysReadiness (`--tool passkeys`)
+
+**Purpose:** Assess whether the tenant meets all 4 prerequisites for enabling Passkeys (WebAuthn).
+
+**Steps:**
+
+1. Run the PasskeysReadiness script:
+   ```bash
+   node tools/passkeys-readiness.js
+   ```
+   If `--cache`, pass `--cache` flag: `node tools/passkeys-readiness.js --cache`
+
+2. The script writes `passkeys-readiness.md` and prints the console summary.
+
+3. Read `passkeys-readiness.md` and present its contents to the user.
+
+**Console summary format:**
+```
+Passkeys readiness: N/4 prerequisites met. [not_ready|partially_ready|ready].
+Primary blocker: [blocking issue in one sentence, or "None — tenant is ready for Passkeys"].
+```
+
+---
+
+## Orchestration (`--tool all`)
+
+Run all three tools in sequence: ActionsWhisperer → TokenGraveyard → PasskeysReadiness.
+
+After all tools complete, write `auth0-audit-summary.md`:
+
+```markdown
+# Auth0 Security Audit Summary
+Generated: [ISO timestamp]
+Tenant: [AUTH0_DOMAIN]
+
+## Actions (ActionsWhisperer)
+[Total actions analyzed, finding counts by severity, top risk]
+
+## M2M Tokens (TokenGraveyard)
+[Total apps, dormancy breakdown, revocations executed]
+
+## Passkeys Readiness
+[Score N/4, status, primary blocker]
+```
+
+Print a 5-line console summary on completion.

--- a/plugins/auth0/skills/auth0-audit/.claude/settings.json
+++ b/plugins/auth0/skills/auth0-audit/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "auth0": {
+      "command": "node",
+      "args": ["hooks/mcp-server.js"]
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node hooks/inject-auth0-context.js"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/auth0/skills/auth0-audit/.gitignore
+++ b/plugins/auth0/skills/auth0-audit/.gitignore
@@ -1,0 +1,5 @@
+.env
+.claudecreds
+.auth0-token-cache
+node_modules/
+.claude

--- a/plugins/auth0/skills/auth0-audit/.gitignore
+++ b/plugins/auth0/skills/auth0-audit/.gitignore
@@ -2,4 +2,4 @@
 .claudecreds
 .auth0-token-cache
 node_modules/
-.claude
+./claude/settings.local.json

--- a/plugins/auth0/skills/auth0-audit/CLAUDE.md
+++ b/plugins/auth0/skills/auth0-audit/CLAUDE.md
@@ -1,0 +1,40 @@
+# Auth0 Security Audit Plugin
+
+This project is an Auth0 Customer Identity Cloud (CIC) security audit plugin for Claude Code.
+It targets Auth0 CIC only — not Okta Workforce Identity Cloud or Okta Identity Engine.
+
+**Prerequisites:**
+- Node.js ^20.19.0 || ^22.12.0 || ^24.0.0
+- `auth0-mcp-server` configured in `.claude/settings.json` (already done — runs via `hooks/mcp-server.js`)
+
+**Credential handling — IMPORTANT:**
+All Auth0 credential acquisition is handled automatically by `hooks/mcp-server.js`. Do NOT look for tokens in the OS keychain, `~/.config`, or any other system location. Do NOT attempt to run `auth0-mcp-server init` manually.
+
+The wrapper uses the device authorization flow:
+1. Checks for an existing token in the OS keychain (stored by a previous `auth0-mcp-server init` run)
+2. If no token is found, runs `npx @auth0/auth0-mcp-server init` (without options) — this opens the Auth0 device-auth page in the browser and persists the token in the OS keychain
+3. Spawns `npx @auth0/auth0-mcp-server run`
+
+The MCP tools (`auth0_list_actions`, `auth0_list_applications`, etc.) are ready to use without any additional auth steps after the first browser-based login.
+
+**Slash command:** `/auth0-audit` — see `.claude/commands/auth0-audit.md` for full implementation steps.
+
+## Project Structure
+
+```
+.claude/
+  commands/
+    auth0-audit.md      ← slash command definition (skill steps)
+  settings.json         ← MCP server + hook config
+hooks/
+  inject-auth0-context.js  ← SessionStart hook
+  mcp-server.js            ← MCP server wrapper (token caching)
+tools/
+  render-findings.js    ← ActionsWhisperer output renderer
+  token-graveyard.js    ← TokenGraveyard analysis + scoring
+  passkeys-readiness.js ← PasskeysReadiness 4-checkpoint script
+scripts/
+  setup-demo-tenant.js  ← Populates dev tenant with synthetic data
+  teardown-demo-tenant.js
+  demo-cache.json       ← Cached API responses for offline demo
+```

--- a/plugins/auth0/skills/auth0-audit/hooks/inject-auth0-context.js
+++ b/plugins/auth0/skills/auth0-audit/hooks/inject-auth0-context.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * SessionStart hook — injects Auth0 tenant context into Claude's session.
+ * Warns if AUTH0_CLIENT_SECRET is in .env but auth0-mcp-server is not configured.
+ * Output is read by Claude Code and prepended to the system context.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const cwd = process.cwd();
+
+function loadEnvFile(path) {
+  if (!existsSync(path)) return {};
+  const vars = {};
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    vars[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+  }
+  return vars;
+}
+
+function loadClaudeCreds(path) {
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+const envVars = loadEnvFile(resolve(cwd, '.env'));
+const claudeCreds = loadClaudeCreds(resolve(cwd, '.claudecreds'));
+
+const domain =
+  process.env.AUTH0_DOMAIN ||
+  claudeCreds.AUTH0_DOMAIN ||
+  envVars.AUTH0_DOMAIN ||
+  null;
+
+const settingsPath = resolve(cwd, '.claude/settings.json');
+let mcpConfigured = false;
+if (existsSync(settingsPath)) {
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    mcpConfigured = !!(settings.mcpServers && settings.mcpServers.auth0);
+  } catch { /* ignore */ }
+}
+
+const hasStaticSecret =
+  !!(envVars.AUTH0_CLIENT_SECRET || process.env.AUTH0_CLIENT_SECRET);
+
+const warnings = [];
+if (hasStaticSecret && !mcpConfigured) {
+  warnings.push(
+    'WARNING: Static Management API credential detected in .env (AUTH0_CLIENT_SECRET). ' +
+    'Consider using auth0-mcp-server for credential-safe access — it stores credentials ' +
+    'in the OS keychain and avoids committing secrets to source control.'
+  );
+}
+
+const today = new Date().toISOString().split('T')[0];
+
+const lines = [
+  '=== Auth0 Security Audit Plugin — Session Context ===',
+  '',
+  `Date: ${today}`,
+  `Tenant: ${domain || '(not configured — set AUTH0_DOMAIN in .env or .claudecreds)'}`,
+  '',
+  'Available audit tools (invoke with /auth0-audit):',
+  '  --tool actions   → ActionsWhisperer: analyze Action JS code for security risks',
+  '  --tool tokens    → TokenGraveyard: identify dormant/overprivileged M2M apps',
+  '  --tool passkeys  → PasskeysReadiness: check 4 prerequisites for enabling Passkeys',
+  '  --tool all       → Run all three tools in sequence (default)',
+  '',
+  'Context for judges: Auth0 Actions are server-side JavaScript functions that execute',
+  'at specific points in the authentication pipeline (e.g., after login, during token',
+  'exchange). They can add custom claims, call external services, and modify user',
+  'metadata — making them a critical surface for security review.',
+  '',
+  'Scope: Auth0 Customer Identity Cloud (CIC) only.',
+  'All write operations require explicit human approval before execution.',
+];
+
+if (warnings.length > 0) {
+  lines.push('');
+  for (const w of warnings) lines.push(w);
+}
+
+lines.push('');
+lines.push('=== End Auth0 Context ===');
+
+// Claude Code SessionStart hooks output plain text injected into the system context.
+process.stdout.write(lines.join('\n') + '\n');

--- a/plugins/auth0/skills/auth0-audit/hooks/mcp-server.js
+++ b/plugins/auth0/skills/auth0-audit/hooks/mcp-server.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * MCP server wrapper — ensures the auth0-mcp-server keychain token is
+ * initialised (device authorization flow) before spawning the server.
+ *
+ * On first run (or when the stored token has expired) this script executes
+ * `npx @auth0/auth0-mcp-server init`, which opens the Auth0 device-auth
+ * page in the browser and persists the resulting token in the OS keychain.
+ * Subsequent runs skip `init` and go straight to `run`.
+ */
+
+import { execSync, spawn } from 'child_process';
+
+function keychainTokenExists() {
+  try {
+    const token = execSync('security find-generic-password -s auth0-mcp -w 2>/dev/null', {
+      stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 5000,
+    }).toString().trim();
+    return Boolean(token);
+  } catch {
+    return false;
+  }
+}
+
+// ── Init (device auth) if no keychain token is present ───────────────────────
+
+if (!keychainTokenExists()) {
+  process.stderr.write('auth0-mcp: no keychain token found — running init (device auth flow)…\n');
+  try {
+    execSync('npx @auth0/auth0-mcp-server init', { stdio: 'inherit' });
+  } catch (err) {
+    process.stderr.write(`auth0-mcp: init failed: ${err.message}\n`);
+    process.exit(1);
+  }
+}
+
+// ── Spawn MCP server ──────────────────────────────────────────────────────────
+
+const child = spawn('npx', ['@auth0/auth0-mcp-server', 'run'], {
+  env: process.env,
+  stdio: 'inherit',
+});
+
+child.on('error', err => {
+  process.stderr.write(`auth0-mcp: failed to start auth0-mcp-server: ${err.message}\n`);
+  process.exit(1);
+});
+
+child.on('exit', code => process.exit(code ?? 0));
+
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(sig, () => child.kill(sig));
+}

--- a/plugins/auth0/skills/auth0-audit/package.json
+++ b/plugins/auth0/skills/auth0-audit/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hackapalooza-auth0-audit",
+  "version": "1.0.0",
+  "description": "Auth0 security audit plugin for Claude Code — ActionsWhisperer, TokenGraveyard, PasskeysReadiness",
+  "type": "module",
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0 || ^24.0.0"
+  },
+  "scripts": {
+    "passkeys": "node tools/passkeys-readiness.js",
+    "token-graveyard": "node tools/token-graveyard.js",
+    "render-findings": "node tools/render-findings.js",
+    "setup-demo": "node scripts/setup-demo-tenant.js",
+    "teardown-demo": "node scripts/teardown-demo-tenant.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.7"
+  }
+}

--- a/plugins/auth0/skills/auth0-audit/scripts/teardown-demo-tenant.js
+++ b/plugins/auth0/skills/auth0-audit/scripts/teardown-demo-tenant.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * teardown-demo-tenant.js — Block 5
+ * Removes all synthetic demo data created by setup-demo-tenant.js.
+ * Deletes Actions and M2M apps whose names start with 'demo-'.
+ *
+ * Usage: node scripts/teardown-demo-tenant.js [--dry-run]
+ * Env: AUTH0_DOMAIN, AUTH0_TOKEN
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+
+function loadEnv() {
+  const path = resolve(process.cwd(), '.env');
+  if (!existsSync(path)) return;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+loadEnv();
+
+const DOMAIN = process.env.AUTH0_DOMAIN;
+const TOKEN = process.env.AUTH0_TOKEN || process.env.AUTH0_MANAGEMENT_TOKEN;
+
+if (!DOMAIN || !TOKEN) {
+  console.error('Error: AUTH0_DOMAIN and AUTH0_TOKEN must be set in environment or .env');
+  process.exit(1);
+}
+
+async function apiFetch(method, path, retries = 3) {
+  const url = `https://${DOMAIN}${path}`;
+  if (DRY_RUN) {
+    console.log(`[DRY RUN] ${method} ${url}`);
+    return [];
+  }
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, {
+      method,
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    if (res.status === 429) {
+      await new Promise(r => setTimeout(r, Math.pow(2, attempt) * 500));
+      continue;
+    }
+    if (res.status === 404 || res.status === 204) return [];
+    if (!res.ok) throw new Error(`${method} ${path} → ${res.status}`);
+    const text = await res.text();
+    return text ? JSON.parse(text) : [];
+  }
+  return [];
+}
+
+async function deleteActions() {
+  console.log('\n→ Deleting demo Actions...');
+  const data = await apiFetch('GET', '/api/v2/actions/actions?per_page=100');
+  const actions = Array.isArray(data) ? data : (data.actions ?? []);
+  const demoActions = actions.filter(a => a.name?.startsWith('demo-'));
+
+  for (const action of demoActions) {
+    try {
+      await apiFetch('DELETE', `/api/v2/actions/actions/${action.id}`);
+      console.log(`  ✓ Deleted action: ${action.name}`);
+    } catch (e) {
+      console.warn(`  ✗ ${action.name}: ${e.message}`);
+    }
+  }
+
+  if (demoActions.length === 0) console.log('  (no demo Actions found)');
+}
+
+async function deleteM2MApps() {
+  console.log('\n→ Deleting demo M2M applications...');
+  const data = await apiFetch('GET', '/api/v2/clients?app_type=non_interactive&per_page=100&fields=client_id,name');
+  const clients = Array.isArray(data) ? data : (data.clients ?? []);
+  const demoClients = clients.filter(c => c.name?.startsWith('demo-'));
+
+  for (const client of demoClients) {
+    try {
+      // Delete client grants first
+      const grants = await apiFetch('GET', `/api/v2/client-grants?client_id=${client.client_id}`);
+      for (const grant of (Array.isArray(grants) ? grants : [])) {
+        await apiFetch('DELETE', `/api/v2/client-grants/${grant.id}`);
+      }
+      await apiFetch('DELETE', `/api/v2/clients/${client.client_id}`);
+      console.log(`  ✓ Deleted app: ${client.name}`);
+    } catch (e) {
+      console.warn(`  ✗ ${client.name}: ${e.message}`);
+    }
+  }
+
+  if (demoClients.length === 0) console.log('  (no demo M2M apps found)');
+}
+
+console.log(`Auth0 Demo Tenant Teardown${DRY_RUN ? ' [DRY RUN]' : ''}`);
+console.log(`Tenant: ${DOMAIN}`);
+console.log('NOTE: This does NOT restore tenant settings (Login mode, WebAuthn factors).');
+console.log('      Restore manually if needed: Auth0 Dashboard → Settings.');
+
+await deleteActions();
+await deleteM2MApps();
+
+console.log('\n✅ Teardown complete. Demo data removed.');

--- a/plugins/auth0/skills/auth0-audit/tools/passkeys-readiness.js
+++ b/plugins/auth0/skills/auth0-audit/tools/passkeys-readiness.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * PasskeysReadiness — Block 3
+ * Performs a 4-checkpoint assessment of Auth0 tenant readiness for Passkeys (WebAuthn).
+ *
+ * Checks:
+ *   1. Universal Login mode (GET /api/v2/prompts)
+ *   2. WebAuthn factors enabled (GET /api/v2/guardian/factors)
+ *   3. Verified custom domain (GET /api/v2/custom_domains)
+ *   4. At least one SPA or native app (GET /api/v2/clients?app_type=spa,native)
+ *
+ * Usage:
+ *   node tools/passkeys-readiness.js [--cache]
+ *
+ * Env: AUTH0_DOMAIN, AUTH0_TOKEN (or AUTH0_MANAGEMENT_TOKEN)
+ * Output: passkeys-readiness.md
+ */
+
+import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const args = process.argv.slice(2);
+const useCache = args.includes('--cache');
+
+function loadEnv() {
+  const path = resolve(process.cwd(), '.env');
+  if (!existsSync(path)) return;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+loadEnv();
+
+const DOMAIN = process.env.AUTH0_DOMAIN;
+const TOKEN = process.env.AUTH0_TOKEN || process.env.AUTH0_MANAGEMENT_TOKEN;
+
+if (!DOMAIN || !TOKEN) {
+  console.error('Error: AUTH0_DOMAIN and AUTH0_TOKEN must be set in environment or .env');
+  process.exit(1);
+}
+
+async function apiFetch(path, retries = 3) {
+  const url = `https://${DOMAIN}${path}`;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' },
+    });
+    if (res.status === 429) {
+      const wait = Math.pow(2, attempt) * 500;
+      await new Promise(r => setTimeout(r, wait));
+      continue;
+    }
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText} — GET ${path}`);
+    return res.json();
+  }
+  throw new Error(`Rate limit exceeded after ${retries} retries for GET ${path}`);
+}
+
+async function loadCachedData() {
+  const cachePath = resolve(process.cwd(), 'scripts/demo-cache.json');
+  if (!existsSync(cachePath)) throw new Error('demo-cache.json not found; run npm run setup-demo first');
+  const cache = JSON.parse(readFileSync(cachePath, 'utf8'));
+  return {
+    prompts: cache.prompts,
+    guardianFactors: cache.guardian_factors,
+    customDomains: cache.custom_domains,
+    clients: cache.spa_native_clients,
+  };
+}
+
+async function runChecks() {
+  let data;
+  if (useCache) {
+    data = await loadCachedData();
+  } else {
+    const [prompts, guardianFactors, customDomains, clients] = await Promise.all([
+      apiFetch('/api/v2/prompts').catch(() => null),
+      apiFetch('/api/v2/guardian/factors').catch(() => null),
+      apiFetch('/api/v2/custom_domains').catch(() => []),
+      apiFetch('/api/v2/clients?app_type=spa,native&fields=client_id,name,app_type&per_page=100').catch(() => []),
+    ]);
+    data = { prompts, guardianFactors, customDomains, clients };
+  }
+
+  const checks = [];
+  const blockingIssues = [];
+  const remediationSteps = [];
+
+  // Check 1: Universal Login
+  const ulMode = data.prompts?.universal_login_experience;
+  const ulPass = ulMode === 'new';
+  checks.push({
+    id: 'universal_login',
+    label: 'Universal Login (New Experience)',
+    passed: ulPass,
+    detail: `Current value: \`universal_login_experience: "${ulMode || 'unknown'}"\``,
+  });
+  if (!ulPass) {
+    blockingIssues.push('Universal Login is set to Classic mode — WebAuthn requires New Experience');
+    remediationSteps.push(
+      '**Enable Universal Login (New Experience)**\n' +
+      '```\nPATCH https://{domain}/api/v2/tenants/settings\n' +
+      'Authorization: Bearer {mgmt_token}\n' +
+      'Content-Type: application/json\n\n' +
+      '{"flags": {"universal_login": true}}\n```\n' +
+      'Or: Auth0 Dashboard → Branding → Universal Login → Enable'
+    );
+  }
+
+  // Check 2: WebAuthn factors
+  const factors = Array.isArray(data.guardianFactors) ? data.guardianFactors : [];
+  const platformFactor = factors.find(f => f.name === 'webauthn-platform');
+  const roamingFactor = factors.find(f => f.name === 'webauthn-roaming');
+  const webAuthnPass = !!(platformFactor?.enabled || roamingFactor?.enabled);
+  checks.push({
+    id: 'webauthn_factors',
+    label: 'WebAuthn Factors (Guardian)',
+    passed: webAuthnPass,
+    detail: `webauthn-platform: ${platformFactor?.enabled ? 'enabled' : 'disabled'}, webauthn-roaming: ${roamingFactor?.enabled ? 'enabled' : 'disabled'}`,
+  });
+  if (!webAuthnPass) {
+    blockingIssues.push('WebAuthn factors are disabled in Guardian');
+    if (!platformFactor?.enabled) {
+      remediationSteps.push(
+        '**Enable WebAuthn Platform Authenticator**\n' +
+        '```\nPUT https://{domain}/api/v2/guardian/factors/webauthn-platform\n' +
+        'Authorization: Bearer {mgmt_token}\n' +
+        'Content-Type: application/json\n\n' +
+        '{"enabled": true}\n```'
+      );
+    }
+    if (!roamingFactor?.enabled) {
+      remediationSteps.push(
+        '**Enable WebAuthn Roaming Authenticator (Security Keys)**\n' +
+        '```\nPUT https://{domain}/api/v2/guardian/factors/webauthn-roaming\n' +
+        'Authorization: Bearer {mgmt_token}\n' +
+        'Content-Type: application/json\n\n' +
+        '{"enabled": true}\n```'
+      );
+    }
+  }
+
+  // Check 3: Custom domain
+  const domains = Array.isArray(data.customDomains) ? data.customDomains : [];
+  const verifiedDomains = domains.filter(d => d.verified);
+  const domainPass = verifiedDomains.length > 0;
+  checks.push({
+    id: 'custom_domain',
+    label: 'Verified Custom Domain',
+    passed: domainPass,
+    detail: domainPass
+      ? `Verified domains: ${verifiedDomains.map(d => d.domain).join(', ')}`
+      : 'No verified custom domains found',
+  });
+  if (!domainPass) {
+    blockingIssues.push('No verified custom domain — WebAuthn RPID binding requires a custom domain');
+    remediationSteps.push(
+      '**Configure a Custom Domain**\n' +
+      'A custom domain (e.g., `login.yourcompany.com`) is required for WebAuthn RPID binding.\n' +
+      'Auth0 Dashboard → Branding → Custom Domains → Add Domain\n\n' +
+      'API: `POST /api/v2/custom_domains` with `{"domain": "login.yourcompany.com", "type": "auth0_managed_certs"}`'
+    );
+  }
+
+  // Check 4: SPA/native apps
+  const clientList = Array.isArray(data.clients) ? data.clients : (data.clients?.clients ?? []);
+  const appPass = clientList.length > 0;
+  checks.push({
+    id: 'eligible_apps',
+    label: 'SPA or Native Applications Registered',
+    passed: appPass,
+    detail: appPass
+      ? `${clientList.length} eligible app(s): ${clientList.slice(0, 3).map(c => c.name).join(', ')}${clientList.length > 3 ? ` +${clientList.length - 3} more` : ''}`
+      : 'No SPA or native apps found',
+  });
+  if (!appPass) {
+    blockingIssues.push('No SPA or native applications registered — Passkeys apply to these app types only');
+    remediationSteps.push(
+      '**Register a SPA or Native Application**\n' +
+      'Auth0 Dashboard → Applications → Create Application → Single Page App or Native\n\n' +
+      'API: `POST /api/v2/clients` with `{"name": "My App", "app_type": "spa", "callbacks": ["https://yourapp.com/callback"]}`'
+    );
+  }
+
+  const score = checks.filter(c => c.passed).length;
+  const status = score === 4 ? 'ready' : score >= 2 ? 'partially_ready' : 'not_ready';
+
+  return { score, status, checks, blockingIssues, remediationSteps };
+}
+
+function renderMarkdown(result) {
+  const { score, status, checks, blockingIssues, remediationSteps } = result;
+  const statusLabel = { ready: 'READY', partially_ready: 'PARTIALLY READY', not_ready: 'NOT READY' }[status];
+  const timestamp = new Date().toISOString();
+
+  const lines = [
+    '# Passkeys Readiness Assessment',
+    '',
+    `**Tenant:** ${DOMAIN}`,
+    `**Generated:** ${timestamp}`,
+    `**Score:** ${score}/4 prerequisites met — **${statusLabel}**`,
+    '',
+    '## Checkpoint Results',
+    '',
+  ];
+
+  for (const check of checks) {
+    const icon = check.passed ? '✅' : '❌';
+    lines.push(`### ${icon} ${check.label}`);
+    lines.push('');
+    lines.push(`${check.detail}`);
+    lines.push('');
+  }
+
+  if (blockingIssues.length > 0) {
+    lines.push('## Blocking Issues', '');
+    blockingIssues.forEach((issue, i) => lines.push(`${i + 1}. ${issue}`));
+    lines.push('');
+  }
+
+  if (remediationSteps.length > 0) {
+    lines.push('## Remediation Sequence', '');
+    remediationSteps.forEach((step, i) => {
+      lines.push(`### Step ${i + 1}`);
+      lines.push('');
+      lines.push(step);
+      lines.push('');
+    });
+  }
+
+  if (score === 4) {
+    lines.push('## Next Steps', '');
+    lines.push('All prerequisites are met. To enable Passkeys:');
+    lines.push('1. Navigate to Auth0 Dashboard → Security → Multi-factor Auth → Passkeys');
+    lines.push('2. Enable Passkeys for your target applications');
+    lines.push('3. Configure the policy (Always, Adaptive, or Optional)');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+const result = await runChecks();
+const markdown = renderMarkdown(result);
+
+writeFileSync(resolve(process.cwd(), 'passkeys-readiness.md'), markdown);
+
+const primaryBlocker = result.blockingIssues[0] ?? 'None — tenant is ready for Passkeys';
+const statusLabel = { ready: 'ready', partially_ready: 'partially ready', not_ready: 'not ready' }[result.status];
+console.log(`Passkeys readiness: ${result.score}/4 prerequisites met. Status: ${statusLabel}.`);
+console.log(`Primary blocker: ${primaryBlocker}`);
+console.log('Written: passkeys-readiness.md');

--- a/plugins/auth0/skills/auth0-audit/tools/render-findings.js
+++ b/plugins/auth0/skills/auth0-audit/tools/render-findings.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * render-findings.js — converts Claude-generated JSON findings to Markdown output files.
+ *
+ * Modes:
+ *   node tools/render-findings.js actions '<JSON_ARRAY>'
+ *     → writes actions-audit.md and actions-findings.json
+ *
+ *   node tools/render-findings.js tokens-receipt '<RECEIPTS_JSON>'
+ *     → writes tokens-remediation-receipt.md
+ *
+ * JSON_ARRAY for actions: array of ActionsWhisperer finding objects
+ * RECEIPTS_JSON: array of {timestamp, operation, target_client_id, target_client_name, scopes_revoked, executed_by}
+ */
+
+import { writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const [, , mode, jsonArg] = process.argv;
+
+if (!mode || !jsonArg) {
+  console.error('Usage: node tools/render-findings.js <actions|tokens-receipt> <JSON>');
+  process.exit(1);
+}
+
+let data;
+try {
+  data = JSON.parse(jsonArg);
+} catch (e) {
+  console.error('Error: could not parse JSON argument:', e.message);
+  process.exit(1);
+}
+
+function renderActionsAudit(findings) {
+  const timestamp = new Date().toISOString();
+  const RISK_ICONS = { critical: '🚨', high: '🔴', medium: '🟠', low: '🟡', none: '🟢' };
+
+  const byTrigger = {};
+  for (const f of findings) {
+    const t = f.trigger || 'unknown';
+    (byTrigger[t] = byTrigger[t] ?? []).push(f);
+  }
+
+  const TRIGGER_ORDER = [
+    'post-login',
+    'credentials-exchange',
+    'pre-user-registration',
+    'post-user-registration',
+    'unknown',
+  ];
+
+  const countsBySeverity = { critical: 0, high: 0, medium: 0, low: 0, none: 0 };
+  for (const f of findings) countsBySeverity[f.risk_level] = (countsBySeverity[f.risk_level] ?? 0) + 1;
+
+  const topRisk = [...findings].sort((a, b) => {
+    const order = { critical: 0, high: 1, medium: 2, low: 3, none: 4 };
+    return order[a.risk_level] - order[b.risk_level];
+  })[0];
+
+  const lines = [
+    '# ActionsWhisperer — Auth0 Actions Security Audit',
+    '',
+    `**Tenant:** ${process.env.AUTH0_DOMAIN || 'unknown'}`,
+    `**Generated:** ${timestamp}`,
+    `**Actions analyzed:** ${findings.length}`,
+    '',
+    '## Pipeline Summary',
+    '',
+    `| Severity | Count |`,
+    `|---|---|`,
+    ...Object.entries(countsBySeverity).map(([level, count]) =>
+      count > 0 ? `| ${RISK_ICONS[level]} ${level.charAt(0).toUpperCase() + level.slice(1)} | ${count} |` : null
+    ).filter(Boolean),
+    '',
+  ];
+
+  if (topRisk && topRisk.risk_level !== 'none') {
+    const topFinding = topRisk.findings?.[0];
+    lines.push(`**Top risk:** ${topRisk.action_name} (${topRisk.trigger}) — ${topFinding?.description ?? topRisk.plain_english_summary}`);
+    lines.push('');
+  }
+
+  for (const trigger of TRIGGER_ORDER) {
+    const actions = byTrigger[trigger];
+    if (!actions || actions.length === 0) continue;
+
+    const triggerLabel = trigger.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+    lines.push(`## ${triggerLabel} Pipeline`, '');
+
+    for (const action of actions) {
+      const icon = RISK_ICONS[action.risk_level] || '⚪';
+      lines.push(`### ${icon} ${action.action_name}`);
+      lines.push('');
+      lines.push(`**Risk level:** ${action.risk_level.toUpperCase()}`);
+      lines.push('');
+      lines.push(action.plain_english_summary || '');
+      lines.push('');
+
+      if (action.findings && action.findings.length > 0) {
+        lines.push('**Findings:**', '');
+        for (const finding of action.findings) {
+          lines.push(`#### ${finding.pattern}`);
+          lines.push('');
+          lines.push(`- **Location:** ${finding.location}`);
+          lines.push(`- **Description:** ${finding.description}`);
+          lines.push(`- **Remediation:** ${finding.remediation}`);
+          lines.push('');
+        }
+      } else {
+        lines.push('No security findings. This Action follows safe practices.');
+        lines.push('');
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function renderTokensReceipt(receipts) {
+  const timestamp = new Date().toISOString();
+  const lines = [
+    '# TokenGraveyard — Remediation Receipt',
+    '',
+    `**Generated:** ${timestamp}`,
+    `**Operations executed:** ${receipts.length}`,
+    '',
+    '## Audit Trail',
+    '',
+  ];
+
+  for (const r of receipts) {
+    lines.push(`### ${r.target_client_name ?? r.target_client_id}`);
+    lines.push('');
+    lines.push(`| Field | Value |`);
+    lines.push(`|---|---|`);
+    lines.push(`| Timestamp | \`${r.timestamp}\` |`);
+    lines.push(`| Operation | \`${r.operation}\` |`);
+    lines.push(`| Client ID | \`${r.target_client_id}\` |`);
+    lines.push(`| Client Name | ${r.target_client_name ?? '—'} |`);
+    lines.push(`| Grant ID | \`${r.grant_id ?? '—'}\` |`);
+    lines.push(`| Scopes Revoked | \`${(r.scopes_revoked ?? []).join(' ') || '—'}\` |`);
+    lines.push(`| Executed By | \`${r.executed_by ?? 'claude-session'}\` |`);
+    lines.push(`| Status | ${r.status ?? 'success'} |`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+if (mode === 'actions') {
+  const markdown = renderActionsAudit(data);
+  writeFileSync(resolve(process.cwd(), 'actions-audit.md'), markdown);
+  writeFileSync(resolve(process.cwd(), 'actions-findings.json'), JSON.stringify(data, null, 2));
+
+  const counts = data.reduce((acc, f) => {
+    acc[f.risk_level] = (acc[f.risk_level] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  console.log(`Analyzed ${data.length} actions. Found ${counts.critical ?? 0} critical, ${counts.high ?? 0} high, ${counts.medium ?? 0} medium findings.`);
+  console.log('Written: actions-audit.md, actions-findings.json');
+} else if (mode === 'tokens-receipt') {
+  const markdown = renderTokensReceipt(data);
+  writeFileSync(resolve(process.cwd(), 'tokens-remediation-receipt.md'), markdown);
+  console.log(`Written: tokens-remediation-receipt.md (${data.length} operations)`);
+} else {
+  console.error(`Unknown mode: ${mode}. Use 'actions' or 'tokens-receipt'.`);
+  process.exit(1);
+}

--- a/plugins/auth0/skills/auth0-audit/tools/token-graveyard.js
+++ b/plugins/auth0/skills/auth0-audit/tools/token-graveyard.js
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+/**
+ * TokenGraveyard — Block 2
+ * Lists all M2M (non_interactive) apps, queries last sce log event per app,
+ * computes blast-radius scores, and outputs a tiered remediation list.
+ *
+ * Usage:
+ *   node tools/token-graveyard.js [--cache] [--dormant-threshold 30|60|90]
+ *
+ * The M2M app list can optionally be piped via stdin as JSON (from MCP auth0_list_applications).
+ * If not piped, the script fetches directly from the Management API.
+ *
+ * Env: AUTH0_DOMAIN, AUTH0_TOKEN (or AUTH0_MANAGEMENT_TOKEN)
+ * Output: tokens-audit.md, tokens-findings.json
+ */
+
+import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const args = process.argv.slice(2);
+const useCache = args.includes('--cache');
+const thresholdArg = args.find(a => a.startsWith('--dormant-threshold='));
+const dormantThreshold = thresholdArg ? parseInt(thresholdArg.split('=')[1]) : 60;
+
+function loadEnv() {
+  const path = resolve(process.cwd(), '.env');
+  if (!existsSync(path)) return;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+loadEnv();
+
+const DOMAIN = process.env.AUTH0_DOMAIN;
+const TOKEN = process.env.AUTH0_TOKEN || process.env.AUTH0_MANAGEMENT_TOKEN;
+
+if (!DOMAIN || !TOKEN) {
+  console.error('Error: AUTH0_DOMAIN and AUTH0_TOKEN must be set in environment or .env');
+  process.exit(1);
+}
+
+// Decodes a JWT payload without verifying the signature (Management API tokens are trusted internally).
+function decodeJwtPayload(token) {
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+    const payload = Buffer.from(parts[1], 'base64url').toString('utf8');
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}
+
+async function ensureDeleteClientGrantsScope() {
+  const payload = decodeJwtPayload(TOKEN);
+  if (!payload) return; // can't inspect — proceed and let the API fail naturally
+
+  const scopes = (payload.scope || '').split(' ');
+  if (scopes.includes('delete:client_grants')) return; // all good
+
+  const clientId = payload.azp || payload.sub?.replace('client_id:', '') || null;
+
+  console.warn('\n⚠️  Warning: current token is missing the delete:client_grants scope.');
+  console.warn('   Revocation operations will fail without it.\n');
+
+  // Attempt to auto-add the scope to the current M2M app's Management API grant
+  if (clientId) {
+    console.log(`   Attempting to auto-add delete:client_grants to client ${clientId}...`);
+    try {
+      const grants = await apiFetch(`/api/v2/client-grants?client_id=${clientId}&audience=https://${DOMAIN}/api/v2`);
+      const grantList = Array.isArray(grants) ? grants : (grants.client_grants ?? []);
+      if (grantList.length > 0) {
+        const grant = grantList[0];
+        const updatedScopes = [...new Set([...(grant.scope || '').split(' ').filter(Boolean), 'delete:client_grants'])];
+
+        const url = `https://${DOMAIN}/api/v2/client-grants/${grant.id}`;
+        const res = await fetch(url, {
+          method: 'PATCH',
+          headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ scope: updatedScopes }),
+        });
+
+        if (res.ok) {
+          console.log('   ✅ Successfully added delete:client_grants. You will need a fresh token for it to take effect.\n');
+          console.log('   Re-run: security find-generic-password -s auth0-mcp -D and delete the cached token,');
+          console.log('   then re-authenticate with: npx @auth0/auth0-mcp-server login\n');
+          return;
+        }
+
+        const errBody = await res.json().catch(() => ({}));
+        console.warn(`   Auto-add failed (${res.status}): ${errBody.message || 'insufficient permissions'}`);
+      }
+    } catch (e) {
+      console.warn(`   Auto-add failed: ${e.message}`);
+    }
+
+    console.warn('\n   To fix manually, add delete:client_grants to the M2M app in Auth0 Dashboard:');
+    console.warn(`   Dashboard → Applications → APIs → Auth0 Management API → Machine to Machine Applications`);
+    console.warn(`   Find app with client_id: ${clientId} → expand → add "delete:client_grants" → Update\n`);
+    console.warn('   Or via Management API:');
+    console.warn(`   First get the grant ID: GET https://${DOMAIN}/api/v2/client-grants?client_id=${clientId}`);
+    console.warn(`   Then: PATCH https://${DOMAIN}/api/v2/client-grants/{grant_id}`);
+    console.warn('   Body: {"scope": ["...existing scopes...", "delete:client_grants"]}\n');
+  } else {
+    console.warn('   Could not determine client_id from token. Add delete:client_grants manually in the Auth0 Dashboard.');
+    console.warn(`   Dashboard → Applications → APIs → Auth0 Management API → Machine to Machine Applications\n`);
+  }
+}
+
+const SCOPE_WEIGHTS = {
+  'update:users': 4,
+  'delete:users': 4,
+  'create:clients': 5,
+  'update:clients': 5,
+  'delete:clients': 5,
+  'read:user_idp_tokens': 3,
+  'update:tenant_settings': 5,
+  'read:users': 1,
+};
+
+const MGMT_API_SCOPE_RE = /^(read|create|update|delete|blacklist|revoke|impersonate):/;
+
+function blastRadiusScore(scopes) {
+  let score = 0;
+  for (const scope of scopes) {
+    if (SCOPE_WEIGHTS[scope] !== undefined) {
+      score += SCOPE_WEIGHTS[scope];
+    } else if (MGMT_API_SCOPE_RE.test(scope)) {
+      score += 1;
+    } else {
+      score += 0.5;
+    }
+  }
+  return score;
+}
+
+function tier(daysSinceLast, blastScore) {
+  if (daysSinceLast === null || (daysSinceLast > 90 && blastScore > 5)) return 'revoke_now';
+  if (daysSinceLast > 60 || blastScore > 8) return 'rotate_7d';
+  if (daysSinceLast > 30) return 'scope_narrow_30d';
+  return 'monitor';
+}
+
+async function apiFetch(path, retries = 4) {
+  const url = `https://${DOMAIN}${path}`;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' },
+    });
+    if (res.status === 429) {
+      const wait = Math.pow(2, attempt) * 500;
+      await new Promise(r => setTimeout(r, wait));
+      continue;
+    }
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText} — GET ${path}`);
+    return res.json();
+  }
+  throw new Error(`Rate limit exceeded after ${retries} retries for GET ${path}`);
+}
+
+async function fetchM2MApps() {
+  const results = [];
+  let page = 0;
+  while (true) {
+    const data = await apiFetch(
+      `/api/v2/clients?app_type=non_interactive&fields=client_id,name,app_type,grant_types&include_totals=true&per_page=50&page=${page}`
+    );
+    const clients = data.clients ?? data;
+    results.push(...clients);
+    if (!data.total || results.length >= data.total) break;
+    page++;
+  }
+  return results;
+}
+
+async function fetchClientGrants(clientId) {
+  try {
+    const data = await apiFetch(`/api/v2/client-grants?client_id=${clientId}`);
+    return Array.isArray(data) ? data : (data.client_grants ?? []);
+  } catch {
+    return [];
+  }
+}
+
+async function fetchLastSceDate(clientId) {
+  try {
+    const data = await apiFetch(
+      `/api/v2/logs?q=${encodeURIComponent(`type:sce AND client_id:${clientId}`)}&sort=date:-1&per_page=1`
+    );
+    const logs = Array.isArray(data) ? data : (data.logs ?? []);
+    if (logs.length === 0) return null;
+    return new Date(logs[0].date);
+  } catch {
+    // If q filter is not supported, fall back to scanning recent logs
+    return null;
+  }
+}
+
+async function loadCachedData() {
+  const cachePath = resolve(process.cwd(), 'scripts/demo-cache.json');
+  if (!existsSync(cachePath)) throw new Error('demo-cache.json not found; run npm run setup-demo first');
+  const cache = JSON.parse(readFileSync(cachePath, 'utf8'));
+  return {
+    apps: cache.m2m_apps ?? [],
+    grants: cache.m2m_grants ?? {},
+    lastSce: cache.m2m_last_sce ?? {},
+  };
+}
+
+async function analyze() {
+  await ensureDeleteClientGrantsScope();
+
+  let apps, grantsMap, lastSceMap;
+
+  if (useCache) {
+    const cached = await loadCachedData();
+    apps = cached.apps;
+    grantsMap = cached.grants;
+    lastSceMap = cached.lastSce;
+  } else {
+    apps = await fetchM2MApps();
+
+    // Fetch grants and last-SCE in parallel, rate-limited to 5 concurrent
+    const CONCURRENCY = 5;
+    grantsMap = {};
+    lastSceMap = {};
+
+    for (let i = 0; i < apps.length; i += CONCURRENCY) {
+      const batch = apps.slice(i, i + CONCURRENCY);
+      await Promise.all(batch.map(async app => {
+        const [grants, lastSce] = await Promise.all([
+          fetchClientGrants(app.client_id),
+          fetchLastSceDate(app.client_id),
+        ]);
+        grantsMap[app.client_id] = grants;
+        lastSceMap[app.client_id] = lastSce;
+      }));
+    }
+  }
+
+  const now = Date.now();
+  const findings = apps.map(app => {
+    const grants = grantsMap[app.client_id] ?? [];
+    const allScopes = grants.flatMap(g => g.scope ? g.scope.split(' ') : []);
+    const blastScore = blastRadiusScore(allScopes);
+
+    const lastSceRaw = lastSceMap[app.client_id];
+    const lastSceDate = lastSceRaw ? new Date(lastSceRaw) : null;
+    const daysSinceLast = lastSceDate ? Math.floor((now - lastSceDate.getTime()) / 86_400_000) : null;
+
+    const appTier = tier(daysSinceLast, blastScore);
+    const grantIds = grants.map(g => g.id);
+
+    return {
+      client_id: app.client_id,
+      name: app.name,
+      blast_radius_score: Math.round(blastScore * 10) / 10,
+      scopes: allScopes,
+      grant_ids: grantIds,
+      last_sce_date: lastSceDate ? lastSceDate.toISOString() : null,
+      days_since_last_token: daysSinceLast,
+      tier: appTier,
+    };
+  });
+
+  findings.sort((a, b) => {
+    const tierOrder = { revoke_now: 0, rotate_7d: 1, scope_narrow_30d: 2, monitor: 3 };
+    const td = tierOrder[a.tier] - tierOrder[b.tier];
+    if (td !== 0) return td;
+    return b.blast_radius_score - a.blast_radius_score;
+  });
+
+  return findings;
+}
+
+function renderMarkdown(findings) {
+  const timestamp = new Date().toISOString();
+  const TIER_LABELS = {
+    revoke_now: '🔴 Revoke Now',
+    rotate_7d: '🟠 Rotate Within 7 Days',
+    scope_narrow_30d: '🟡 Scope-Narrow Within 30 Days',
+    monitor: '🟢 Monitor',
+  };
+
+  const byTier = {};
+  for (const f of findings) {
+    (byTier[f.tier] = byTier[f.tier] ?? []).push(f);
+  }
+
+  const lines = [
+    '# TokenGraveyard — M2M Application Audit',
+    '',
+    `**Tenant:** ${DOMAIN}`,
+    `**Generated:** ${timestamp}`,
+    `**Dormant threshold:** ${dormantThreshold} days`,
+    '',
+    '## Summary',
+    '',
+    `| Tier | Count |`,
+    `|---|---|`,
+    ...Object.entries(TIER_LABELS).map(([key, label]) =>
+      `| ${label} | ${(byTier[key] ?? []).length} |`
+    ),
+    `| **Total** | **${findings.length}** |`,
+    '',
+  ];
+
+  for (const [tierKey, tierLabel] of Object.entries(TIER_LABELS)) {
+    const apps = byTier[tierKey];
+    if (!apps || apps.length === 0) continue;
+
+    lines.push(`## ${tierLabel}`, '');
+
+    for (const app of apps) {
+      const lastUsed = app.days_since_last_token !== null
+        ? `${app.days_since_last_token} days ago (${app.last_sce_date?.split('T')[0]})`
+        : 'Never used';
+
+      lines.push(`### ${app.name}`);
+      lines.push('');
+      lines.push(`- **Client ID:** \`${app.client_id}\``);
+      lines.push(`- **Last token issued:** ${lastUsed}`);
+      lines.push(`- **Blast-radius score:** ${app.blast_radius_score}`);
+      if (app.scopes.length > 0) {
+        lines.push(`- **Scopes:** \`${app.scopes.join(' ')}\``);
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+const findings = await analyze();
+
+writeFileSync(resolve(process.cwd(), 'tokens-findings.json'), JSON.stringify(findings, null, 2));
+writeFileSync(resolve(process.cwd(), 'tokens-audit.md'), renderMarkdown(findings));
+
+const neverUsed = findings.filter(f => f.days_since_last_token === null).length;
+const dormant60 = findings.filter(f => f.days_since_last_token !== null && f.days_since_last_token > 60).length;
+const highBlast = findings.filter(f => f.blast_radius_score > 8).length;
+const revokeCount = findings.filter(f => f.tier === 'revoke_now').length;
+const rotateCount = findings.filter(f => f.tier === 'rotate_7d').length;
+
+console.log(`Found ${findings.length} M2M applications. ${neverUsed} never used, ${dormant60} dormant >60 days, ${highBlast} with high blast radius (score >8).`);
+console.log(`Recommended: revoke ${revokeCount}, rotate ${rotateCount}.`);
+console.log('Written: tokens-audit.md, tokens-findings.json');
+
+// Output findings JSON to stdout for the orchestrator to read
+process.stdout.write('\n__FINDINGS_JSON__\n' + JSON.stringify(findings) + '\n__END_FINDINGS_JSON__\n');


### PR DESCRIPTION
 This PR introduces the Auth0 Security Audit Plugin (/auth0-audit) for Claude Code — a slash command skill that performs a structured
  security audit of an Auth0 Customer Identity Cloud (CIC) tenant and produces Markdown receipts and structured JSON findings.

  The plugin ships three independent audit tools, orchestrated by a single /auth0-audit command:

  ActionsWhisperer — analyzes all deployed Auth0 Actions for security anti-patterns: hardcoded secrets, PII persistence to user_metadata,
  external claim injection, SSRF-prone HTTP calls, and unallowlisted service calls. Produces actions-audit.md and actions-findings.json
  grouped by pipeline trigger.

  TokenGraveyard — identifies dormant and overprivileged M2M (non-interactive) applications by querying sce log events per client, computing
  a blast-radius score from the granted Management API scopes, and assigning apps to tiers (Revoke Now / Rotate Within 7 Days / Scope-Narrow
  / Monitor). Revocations are approval-gated — the user must explicitly confirm each delete_client_grant before it executes.

  PasskeysReadiness — runs a 4-checkpoint assessment of whether the tenant meets the prerequisites for enabling Passkeys (WebAuthn): New
  Universal Login experience, WebAuthn Guardian factors enabled, verified custom domain, and at least one SPA or native app registered.
  Outputs a scored report with a step-by-step remediation sequence.

  Additional components:
  - hooks/mcp-server.js — MCP server wrapper that handles keychain token caching and device authorization flow for @auth0/auth0-mcp-server
  - hooks/inject-auth0-context.js — SessionStart hook that surfaces tenant context and available tool usage at session start
  - scripts/setup-demo-tenant.js / teardown-demo-tenant.js — idempotently populates/tears down a dev tenant with synthetic Actions and M2M
  apps for reliable demo and offline playback via --cache

  The plugin targets Auth0 CIC only and does not support Okta Workforce Identity Cloud or Okta Identity Engine.

  ▎ ⚠️  Known limitation: @auth0/auth0-mcp-server must be installed and initialized manually from within the skill directory (npx
  ▎ @auth0/auth0-mcp-server init). Global installation and automated delivery as part of the skill setup are not yet integrated. This step is
  ▎  a one-time prerequisite before the first /auth0-audit run.

  References

  - Auth0 Actions documentation
  - Auth0 Management API — Client Grants
  - Auth0 Passkeys / WebAuthn prerequisites
  - Auth0 MCP Server (@auth0/auth0-mcp-server)

  Testing

  Prerequisites:

  ▎ @auth0/auth0-mcp-server must be run manually from the skill directory before testing. Global install and delivery are not yet integrated
  ▎ — run npx @auth0/auth0-mcp-server init from plugins/auth0/skills/auth0-audit/ to complete the device authorization flow and persist the
  ▎ keychain token. Subsequent runs are handled automatically by hooks/mcp-server.js.

  Automated (offline demo mode):
  1. Run node scripts/setup-demo-tenant.js against a dev tenant to populate it and write scripts/demo-cache.json
  2. Run /auth0-audit --cache — this exercises all three tools using cached API responses without live API calls

  Live tenant testing:
  1. From the skill directory, run npx @auth0/auth0-mcp-server init once to authenticate and cache the keychain token
  2. Run /auth0-audit (defaults to --tool all)
  3. Verify actions-audit.md, tokens-audit.md, passkeys-readiness.md, and auth0-audit-summary.md are written to the working directory
  4. For TokenGraveyard revocation: confirm the approval prompt appears and no delete_client_grant is executed without explicit y input

  Environments tested: Node.js 22.x on macOS (darwin 25.4), Auth0 CIC tenant (AU region).

  - This change adds test coverage for new/changed/fixed functionality

  Checklist

  - I have added documentation for new/changed functionality in this PR or in auth0.com/docs
  - All active GitHub checks for tests, formatting, and security are passing
  - The correct base branch is being used, if not the default branch