### PR TITLE
fix: reorder error handler to check InsufficientScopeError before UnauthorizedError

### DIFF
--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/references/integration.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/references/integration.md
@@ -244,11 +244,11 @@ import {
 } from 'express-oauth2-jwt-bearer';
 
 app.use((err, req, res, next) => {
-  if (err instanceof UnauthorizedError || err instanceof InvalidTokenError) {
-    return res.status(401).json({ error: 'unauthorized' });
-  }
   if (err instanceof InsufficientScopeError) {
     return res.status(403).json({ error: 'forbidden' });
+  }
+  if (err instanceof UnauthorizedError || err instanceof InvalidTokenError) {
+    return res.status(401).json({ error: 'unauthorized' });
   }
   next(err);
 });


### PR DESCRIPTION
### Description

[InsufficientScopeError extends UnauthorizedError](https://github.com/auth0/node-oauth2-jwt-bearer/blob/f4c2ad26b0a841ddde27468c35404f4afd8fef91/packages/oauth2-bearer/src/errors.ts#L62-L71), so the parent class check was matching first and returning 401 instead of the correct 403.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated error handling example to check for scope authorization failures before general authentication errors, ensuring proper HTTP 403 (forbidden) responses for insufficient scope and HTTP 401 (unauthorized) responses for other JWT/auth-related failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/agent-skills/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->