### PR TITLE
chore: bump plugin version to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,8 +15,8 @@
         "url": "https://github.com/auth0/agent-skills.git",
         "path": "plugins/auth0"
       },
-      "description": "Auth0 skills for quickstarts, migration, MFA, Advanced Custom Universal Login (ACUL) screen generation, and framework-specific SDK integrations for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Spring Boot, Java MVC, Swift, Android, ASP.NET Core, React Native, Expo, Ionic Vue (Capacitor), Ionic Angular (Capacitor) and Ionic React(Capacitor).",
-      "version": "1.0.0",
+      "description": "Auth0 skills for quickstarts, migration, MFA, branding, custom domains, Advanced Custom Universal Login (ACUL) screen generation, and framework-specific SDK integrations for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Flask, Go, Spring Boot, Java MVC, Swift, Android, ASP.NET Core, React Native, Expo, Ionic React (Capacitor), Ionic Angular (Capacitor), and Ionic Vue (Capacitor).",
+      "version": "1.1.0",
       "repository": "https://github.com/auth0/agent-skills.git",
       "license": "Apache-2.0",
       "author": {
@@ -28,6 +28,8 @@
         "quickstart",
         "migration",
         "mfa",
+        "branding",
+        "custom-domains",
         "security",
         "acul",
         "universal-login",
@@ -41,6 +43,8 @@
         "fastify",
         "fastapi",
         "flask",
+        "go",
+        "go-jwt-middleware",
         "springboot",
         "java",
         "servlet",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,16 +5,16 @@
     "email": "support@auth0.com"
   },
   "metadata": {
-    "description": "Auth0 agent skills for authentication, SDK integration, migration, and MFA.",
-    "version": "1.0.0",
+    "description": "Auth0 agent skills for authentication, SDK integration, migration, branding, custom domains, and MFA.",
+    "version": "1.1.0",
     "pluginRoot": "plugins"
   },
   "plugins": [
     {
       "name": "auth0",
       "source": "auth0",
-      "description": "Auth0 skills for quickstarts, migration, MFA, and framework-specific SDK integrations for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Swift, Android, ASP.NET Core, React Native, Expo, Ionic Vue (Capacitor), Ionic Angular (Capacitor) and Ionic React (Capacitor).",
-      "version": "1.0.0",
+      "description": "Auth0 skills for quickstarts, migration, MFA, branding, custom domains, Advanced Custom Universal Login (ACUL) screen generation, and framework-specific SDK integrations for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Flask, Go, Spring Boot, Java MVC, Swift, Android, ASP.NET Core, React Native, Expo, Ionic React (Capacitor), Ionic Angular (Capacitor), and Ionic Vue (Capacitor).",
+      "version": "1.1.0",
       "repository": "https://github.com/auth0/agent-skills.git",
       "license": "Apache-2.0",
       "author": {
@@ -26,7 +26,11 @@
         "quickstart",
         "migration",
         "mfa",
+        "branding",
+        "custom-domains",
         "security",
+        "acul",
+        "universal-login",
         "sdk",
         "react",
         "nextjs",
@@ -37,8 +41,11 @@
         "fastify",
         "fastapi",
         "flask",
+        "go",
+        "go-jwt-middleware",
         "springboot",
         "java",
+        "java-mvc",
         "swift",
         "android",
         "aspnetcore",
@@ -53,7 +60,8 @@
         "spa-js",
         "node",
         "jwt",
-        "express-oauth2-jwt-bearer"
+        "express-oauth2-jwt-bearer",
+        "cli"
       ],
       "category": "authentication"
     }

--- a/plugins/auth0/.claude-plugin/plugin.json
+++ b/plugins/auth0/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auth0",
-  "version": "1.0.0",
-  "description": "Auth0 skills for quickstarts, migration, MFA, Advanced Custom Universal Login (ACUL) screen generation, and framework-specific SDK integrations for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Go, Java MVC, Spring Boot, Swift, Android, ASP.NET Core, React Native, Expo, Ionic React (Capacitor), Ionic Angular (Capacitor), and Ionic Vue (Capacitor).",
+  "version": "1.1.0",
+  "description": "Auth0 skills for quickstarts, migration, MFA, branding, custom domains, Advanced Custom Universal Login (ACUL) screen generation, and framework-specific SDK integrations for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Flask, Go, Spring Boot, Java MVC, Swift, Android, ASP.NET Core, React Native, Expo, Ionic React (Capacitor), Ionic Angular (Capacitor), and Ionic Vue (Capacitor).",
   "author": {
     "name": "Auth0",
     "email": "support@auth0.com"

--- a/plugins/auth0/.codex-plugin/plugin.json
+++ b/plugins/auth0/.codex-plugin/plugin.json
@@ -1,12 +1,14 @@
 {
   "name": "auth0",
-  "displayName": "Auth0",
   "version": "1.1.0",
   "description": "Auth0 skills for quickstarts, migration, MFA, branding, custom domains, Advanced Custom Universal Login (ACUL) screen generation, and framework-specific SDK integrations for React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, Flask, Go, Spring Boot, Java MVC, Swift, Android, ASP.NET Core, React Native, Expo, Ionic React (Capacitor), Ionic Angular (Capacitor), and Ionic Vue (Capacitor).",
+  "skills": "./skills/",
   "author": {
     "name": "Auth0",
     "email": "support@auth0.com"
   },
+  "repository": "https://github.com/auth0/agent-skills",
+  "license": "Apache-2.0",
   "keywords": [
     "auth0",
     "quickstart",


### PR DESCRIPTION
## Summary

- Bumps version from `1.0.0` → `1.1.0` in both `.claude-plugin/marketplace.json` and `plugins/auth0/.claude-plugin/plugin.json`
- Updates descriptions and keywords to include skills added since v1.0.0:
  - `auth0-branding`
  - `auth0-custom-domains`
  - `go-jwt-middleware`
  - `auth0-ionic-react`
  - `auth0-ionic-angular`
  - `auth0-ionic-vue`

## Why

Claude Code marketplace checks the version field to determine if an update is available. Without a version bump, `claude plugins update auth0` reports "already updated to v1.0.0" and never pulls the new skills.

## After merge

Tag `v1.1.0` on the merge commit so the marketplace can resolve the version:
```bash
git tag v1.1.0 && git push origin v1.1.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 1.1.0 across manifests.
  * Expanded plugin descriptions to include branding, custom domains, migration/MFA features, and broader framework/SDK coverage (e.g., Go, Java, FastAPI/Flask).
  * Added and reorganized keywords for discoverability (including branding, custom-domains, go, go-jwt-middleware, cli, universal-login, etc.).
  * Added a new plugin manifest to support the updated metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/agent-skills/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->