### PR TITLE
Chore/snyk agent scan refactor

### DIFF
--- a/.snyk-agent-scan-ignore.json
+++ b/.snyk-agent-scan-ignore.json
@@ -1,7 +1,6 @@
 [
   {
     "code": "W012",
-    "skills": ["auth0-android", "auth0-angular", "auth0-aspnetcore-authentication", "auth0-express", "auth0-flask", "auth0-ionic-angular", "auth0-ionic-vue", "auth0-nextjs", "auth0-quickstart", "auth0-react", "auth0-spa-js", "auth0-vue"],
     "url": "https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh",
     "reason": "First-party Auth0 CLI install script from Auth0-owned repository"
   },
@@ -25,7 +24,6 @@
   },
   {
     "code": "W012",
-    "skills": ["auth0-java-mvc-common", "auth0-expo", "auth0-springboot-api", "express-oauth2-jwt-bearer", "go-jwt-middleware"],
     "url_pattern": "https://api\\.github\\.com/repos/auth0/[^/]+/releases/latest",
     "reason": "First-party Auth0 repo API call to fetch latest release version"
   }

--- a/.snyk-agent-scan-ignore.json
+++ b/.snyk-agent-scan-ignore.json
@@ -25,32 +25,8 @@
   },
   {
     "code": "W012",
-    "skills": ["auth0-java-mvc-common"],
-    "url": "https://api.github.com/repos/auth0/auth0-java-mvc-common/releases/latest",
-    "reason": "First-party Auth0 repo API call to fetch latest release version"
-  },
-  {
-    "code": "W012",
-    "skills": ["auth0-expo"],
-    "url": "https://api.github.com/repos/auth0/react-native-auth0/releases/latest",
-    "reason": "First-party Auth0 repo API call to fetch latest SDK version"
-  },
-  {
-    "code": "W012",
-    "skills": ["auth0-springboot-api"],
-    "url": "https://api.github.com/repos/auth0/auth0-auth-java/releases/latest",
-    "reason": "First-party Auth0 repo API call to fetch latest release version"
-  },
-  {
-    "code": "W012",
-    "skills": ["express-oauth2-jwt-bearer"],
-    "url": "https://api.github.com/repos/auth0/node-oauth2-jwt-bearer/releases/latest",
-    "reason": "First-party Auth0 repo API call to fetch latest release version"
-  },
-  {
-    "code": "W012",
-    "skills": ["go-jwt-middleware"],
-    "url": "https://api.github.com/repos/auth0/go-jwt-middleware/releases/latest",
+    "skills": ["auth0-java-mvc-common", "auth0-expo", "auth0-springboot-api", "express-oauth2-jwt-bearer", "go-jwt-middleware"],
+    "url_pattern": "https://api\\.github\\.com/repos/auth0/[^/]+/releases/latest",
     "reason": "First-party Auth0 repo API call to fetch latest release version"
   }
 ]

--- a/scripts/check_snyk_findings.py
+++ b/scripts/check_snyk_findings.py
@@ -22,7 +22,10 @@ def ignored_reason(code, message, ignores, skill=None):
         if entry_skills and skill and skill not in entry_skills:
             continue
         url = entry.get('url', '')
+        url_pattern = entry.get('url_pattern', '')
         if url and re.search(r'(?<![/\w])' + re.escape(url) + r'(?![a-zA-Z0-9_/\-])', message):
+            return entry.get('reason', 'no reason given')
+        if url_pattern and re.search(url_pattern, message):
             return entry.get('reason', 'no reason given')
     return None
 


### PR DESCRIPTION
### Description

This PR refactors the Snyk agent scan ignore configuration (`.snyk-agent-scan-ignore.json`) to reduce duplication and improve maintainability:


- **Drops the `skills` field from entries**: Removes skill-specific scoping from ignore entries so they apply globally to any skill, eliminating the need to update the list when new skills are added.
- **Updates `check_snyk_findings.py`** to support the new `url_pattern` field alongside the existing `url` field.

- **Consolidates GitHub Releases API entries**: Replaces 5 separate per-skill entries for `https://api.github.com/repos/auth0/*/releases/latest` with a single entry using `url_pattern` regex (`https://api\.github\.com/repos/auth0/[^/]+/releases/latest`). This ensures any future skill fetching a GitHub Releases endpoint is automatically covered.

### References

- No external references.

### Testing

N/A


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch