### PR TITLE
fix(auth0-swift): handle inline credentials and add user profile API

### DIFF
--- a/plugins/auth0/skills/auth0-swift/SKILL.md
+++ b/plugins/auth0/skills/auth0-swift/SKILL.md
@@ -61,13 +61,29 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 ### Step 2 — Configure Auth0
 
 > **Agent instruction:**
+> - **If Auth0 credentials (domain AND client ID) are already in the user's prompt:** Write `Auth0.plist` directly with those values — do NOT ask the user any questions, and do NOT hardcode them in Swift source files. Then proceed to Step 3.
 > - **If an `Auth0.plist` file already exists in the project:** Read it to extract `ClientId` and `Domain`, then proceed to Step 3.
-> - **If no `Auth0.plist` exists:** Ask the user via `AskUserQuestion`: _"How would you like to configure Auth0?"_
+> - **If no `Auth0.plist` exists and no credentials were provided:** Ask the user via `AskUserQuestion`: _"How would you like to configure Auth0?"_
 >   - **Automatic (Auth0 CLI)** — I'll create the application, set callback URLs, and configure everything using the Auth0 CLI.
 >   - **Manual** — You provide a pre-configured `Auth0.plist` file and I'll add it to your project.
 >
 > If the user chooses **automatic**: Follow [Setup Guide — Automated Setup via Auth0 CLI](./references/setup.md#automated-setup-via-auth0-cli).
 > If the user chooses **manual**: Follow [Setup Guide — Manual Setup](./references/setup.md#manual-setup-user-provided-auth0plist).
+>
+> **`Auth0.plist` format:**
+> ```xml
+> <?xml version="1.0" encoding="UTF-8"?>
+> <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+> <plist version="1.0">
+> <dict>
+>   <key>ClientId</key>
+>   <string>YOUR_CLIENT_ID</string>
+>   <key>Domain</key>
+>   <string>YOUR_DOMAIN</string>
+> </dict>
+> </plist>
+> ```
+> Place `Auth0.plist` in the same directory as the app's Swift source files so the SDK can find it automatically.
 
 ### Step 3 — Configure Callback URLs
 
@@ -155,9 +171,16 @@ import Combine
 
 class AuthenticationService: ObservableObject {
     @Published var isAuthenticated = false
+    @Published var userName: String?
+    @Published var userEmail: String?
     private let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
 
-    init() { isAuthenticated = credentialsManager.canRenew() }
+    init() {
+        isAuthenticated = credentialsManager.canRenew()
+        // credentialsManager.user is a UserInfo? decoded from the stored ID token
+        userName = credentialsManager.user?.name
+        userEmail = credentialsManager.user?.email
+    }
 
     func login() async {
         do {
@@ -167,7 +190,11 @@ class AuthenticationService: ObservableObject {
                 .scope("openid profile email offline_access")
                 .start()
             _ = credentialsManager.store(credentials: credentials)
-            await MainActor.run { isAuthenticated = true }
+            await MainActor.run {
+                isAuthenticated = true
+                userName = credentialsManager.user?.name
+                userEmail = credentialsManager.user?.email
+            }
         } catch WebAuthError.userCancelled { }
         catch { print("Login failed: \(error)") }
     }
@@ -176,7 +203,11 @@ class AuthenticationService: ObservableObject {
         do { try await Auth0.webAuth().useHTTPS().clearSession() }
         catch { print("Logout failed: \(error)") }
         _ = credentialsManager.clear()
-        await MainActor.run { isAuthenticated = false }
+        await MainActor.run {
+            isAuthenticated = false
+            userName = nil
+            userEmail = nil
+        }
     }
 }
 ```
@@ -205,6 +236,8 @@ class AuthenticationService {
     private let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
 
     var isAuthenticated: Bool { credentialsManager.canRenew() }
+    // credentialsManager.user is a UserInfo? decoded from the stored ID token
+    var user: UserInfo? { credentialsManager.user }
 
     func login() async throws {
         let credentials = try await Auth0
@@ -274,6 +307,8 @@ private let auth = AuthenticationService()
 | Opening `.xcodeproj` instead of `.xcworkspace` (CocoaPods) | Always open the `.xcworkspace` file after `pod install` |
 | Not calling `clearSession()` on logout | Always call `clearSession()` to remove the Auth0 session cookie from the browser |
 | Build error "No such module 'Auth0'" | Verify the package is added to the correct target; for CocoaPods, open `.xcworkspace` |
+| Hardcoding domain/clientId in Swift source when they're in the prompt | Write them into `Auth0.plist` and call `Auth0.webAuth()` with no arguments — the SDK reads the plist automatically |
+| Using `IDTokenClaimsValidation()` or similar to read user profile | Use `credentialsManager.user` — it returns a `UserInfo?` with `.name`, `.email`, `.picture`, etc., decoded from the stored ID token |
 
 ## Related Skills
 

--- a/plugins/auth0/skills/auth0-swift/SKILL.md
+++ b/plugins/auth0/skills/auth0-swift/SKILL.md
@@ -61,7 +61,7 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 ### Step 2 — Configure Auth0
 
 > **Agent instruction:**
-> - **If Auth0 credentials (domain AND client ID) are already in the user's prompt:** Write `Auth0.plist` directly with those values — do NOT ask the user any questions, and do NOT hardcode them in Swift source files. Then proceed to Step 3.
+> - **If Auth0 credentials (domain AND client ID) are already in the user's prompt:** Write `Auth0.plist` directly with those values — do NOT ask the user any questions, do NOT hardcode them in Swift source files, and do NOT pass them as arguments to `Auth0.webAuth()` or `Auth0.authentication()`. The SDK reads `Auth0.plist` automatically — always use the no-argument form `Auth0.webAuth()`. Then proceed to Step 3.
 > - **If an `Auth0.plist` file already exists in the project:** Read it to extract `ClientId` and `Domain`, then proceed to Step 3.
 > - **If no `Auth0.plist` exists and no credentials were provided:** Ask the user via `AskUserQuestion`: _"How would you like to configure Auth0?"_
 >   - **Automatic (Auth0 CLI)** — I'll create the application, set callback URLs, and configure everything using the Auth0 CLI.
@@ -159,6 +159,15 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 ### Step 4 — Implement Authentication
 
 > **Agent instruction:** Search the project for `@main struct` (SwiftUI) or `AppDelegate`/`UIViewController` (UIKit) to detect the UI framework. If ambiguous, ask via `AskUserQuestion`: _"Does your app use SwiftUI or UIKit?"_ Then follow **only** the matching path below.
+>
+> **IMPORTANT — Never pass credentials in code:** Do NOT pass `clientId` or `domain` as arguments to `Auth0.webAuth()`, `Auth0.authentication()`, or any other SDK call. The SDK reads these values automatically from `Auth0.plist`. Always use the no-argument forms:
+> ```swift
+> Auth0.webAuth()           // ✓ reads Auth0.plist automatically
+> Auth0.authentication()    // ✓ reads Auth0.plist automatically
+>
+> Auth0.webAuth(clientId: "...", domain: "...")      // ✗ never do this
+> Auth0.authentication(clientId: "...", domain: "...") // ✗ never do this
+> ```
 
 #### SwiftUI
 
@@ -171,16 +180,9 @@ import Combine
 
 class AuthenticationService: ObservableObject {
     @Published var isAuthenticated = false
-    @Published var userName: String?
-    @Published var userEmail: String?
     private let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
 
-    init() {
-        isAuthenticated = credentialsManager.canRenew()
-        // credentialsManager.user is a UserInfo? decoded from the stored ID token
-        userName = credentialsManager.user?.name
-        userEmail = credentialsManager.user?.email
-    }
+    init() { isAuthenticated = credentialsManager.canRenew() }
 
     func login() async {
         do {
@@ -190,11 +192,7 @@ class AuthenticationService: ObservableObject {
                 .scope("openid profile email offline_access")
                 .start()
             _ = credentialsManager.store(credentials: credentials)
-            await MainActor.run {
-                isAuthenticated = true
-                userName = credentialsManager.user?.name
-                userEmail = credentialsManager.user?.email
-            }
+            await MainActor.run { isAuthenticated = true }
         } catch WebAuthError.userCancelled { }
         catch { print("Login failed: \(error)") }
     }
@@ -203,11 +201,7 @@ class AuthenticationService: ObservableObject {
         do { try await Auth0.webAuth().useHTTPS().clearSession() }
         catch { print("Logout failed: \(error)") }
         _ = credentialsManager.clear()
-        await MainActor.run {
-            isAuthenticated = false
-            userName = nil
-            userEmail = nil
-        }
+        await MainActor.run { isAuthenticated = false }
     }
 }
 ```
@@ -236,8 +230,6 @@ class AuthenticationService {
     private let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
 
     var isAuthenticated: Bool { credentialsManager.canRenew() }
-    // credentialsManager.user is a UserInfo? decoded from the stored ID token
-    var user: UserInfo? { credentialsManager.user }
 
     func login() async throws {
         let credentials = try await Auth0
@@ -308,7 +300,6 @@ private let auth = AuthenticationService()
 | Not calling `clearSession()` on logout | Always call `clearSession()` to remove the Auth0 session cookie from the browser |
 | Build error "No such module 'Auth0'" | Verify the package is added to the correct target; for CocoaPods, open `.xcworkspace` |
 | Hardcoding domain/clientId in Swift source when they're in the prompt | Write them into `Auth0.plist` and call `Auth0.webAuth()` with no arguments — the SDK reads the plist automatically |
-| Using `IDTokenClaimsValidation()` or similar to read user profile | Use `credentialsManager.user` — it returns a `UserInfo?` with `.name`, `.email`, `.picture`, etc., decoded from the stored ID token |
 
 ## Related Skills
 


### PR DESCRIPTION
 ## Context                                                                                                                              
                                                                                    
  Two consistent L3 security grader failures were observed when running `swift_quickstart` evals                                          
  against `gpt-5.4-mini` in the `agent+skills` configuration. Even with the skill present, the
  agent was hardcoding `domain` and `clientId` directly in Swift source files instead of writing                                          
  `Auth0.plist`.                                                                                                                          
                                                                                                                                          
  ## Root cause                                                                                                                           
                                                                                                                                          
  Step 2's agent instruction had a branch for "credentials already in the prompt" but gave no                                             
  explicit directive to write `Auth0.plist` first and never mentioned that the SDK must be called
  without arguments. Without that constraint, the model defaulted to the path of least resistance —                                       
  inlining values directly into `Auth0.webAuth(clientId:domain:)` calls.                                                                  
                                                                                                                                          
  Step 4's implementation block also had no reminder, so even when Step 2 was followed correctly,                                         
  the model could still pass credentials as arguments at the call site.                                                                   
                                                                                                                                          
  ## Changes                                                                                                                              
                                                                                                                                          
  - **Step 2** — Strengthened the "credentials in prompt" branch to explicitly state: write                                               
    `Auth0.plist` directly, never hardcode in Swift source, never pass as arguments to       
    `Auth0.webAuth()` or `Auth0.authentication()`. Added the `Auth0.plist` XML template inline so                                         
    the agent has a concrete format to copy rather than inventing its own.                                                                
  - **Step 4** — Added an `IMPORTANT` block at the top of the implementation section with a                                               
    side-by-side correct/incorrect code example showing the no-argument forms vs. the argument                                            
    forms. This fires as a second enforcement point even if the agent skimmed Step 2.                                                     
  - **Common Mistakes table** — Added a row explicitly naming this failure pattern and its fix.                                           
                                                                                                                                          
  ## Eval results                                                                                                                         
                                                                                                                                          
  | Config | Score | Security | Grader pass rate |                                                                                        
  |---|---|---|---|                                                                          
  | `agent+skills` (before) | B (81.9) | F (0) | 75% |                                                                                    
  | `agent+skills` (after) | A (90.1) | A (100) | 83% |                                                                                   
                                                                                                                                          
  Security went from F → A. Both graders (`notContainsInSource` for client ID and domain in Swift                                         
  source files) now pass.                                                                                                                 
                                                                                                                                          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Auth0 Swift skill setup guidance with improved Step 2 credential-handling scenarios
  * Added support for automatic and manual `Auth0.plist` configuration options
  * Expanded "Common Mistakes" section with best practices for Auth0 integration
  * Updated code examples to surface user identity information through improved access patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/agent-skills/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->