### PR TITLE
fix(auth0-nuxt): clarify runtimeConfig env var auto-population

### DIFF
--- a/plugins/auth0/skills/auth0-nuxt/SKILL.md
+++ b/plugins/auth0/skills/auth0-nuxt/SKILL.md
@@ -42,6 +42,7 @@ Server-side session authentication for Nuxt 3/4. NOT the same as @auth0/auth0-vu
 | Using `useUser()` for security checks | Use `useAuth0(event).getSession()` server-side |
 | Missing callback URLs in Auth0 Dashboard | Add `http://localhost:3000/auth/callback` |
 | Weak/missing session secret | Generate: `openssl rand -hex 64` |
+| Hardcoding credentials in `nuxt.config.ts` | Leave runtimeConfig values as empty strings; Nuxt auto-fills from `NUXT_AUTH0_*` env vars |
 
 ## Quick Setup
 
@@ -65,6 +66,8 @@ NUXT_AUTH0_AUDIENCE=https://your-api  # optional
 
 ```typescript
 // 4. nuxt.config.ts
+// Leave values as empty strings — Nuxt auto-fills them from NUXT_AUTH0_* env vars at runtime.
+// If you prefer explicit mapping, use: domain: process.env.NUXT_AUTH0_DOMAIN || ''
 export default defineNuxtConfig({
   modules: ['@auth0/auth0-nuxt'],
   runtimeConfig: {


### PR DESCRIPTION
### Description

Some Agents were hardcoding credentials directly in nuxt.config.ts because the empty string placeholders didn't explain Nuxt's automatic env var mapping. Added inline comment and a Critical Mistakes row.

### Testing

Verified this by running the necessary evals against the models in question.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
