### PR TITLE
Address snyk findings across skills

### DIFF
--- a/.github/workflows/snyk_agent_scan.yml
+++ b/.github/workflows/snyk_agent_scan.yml
@@ -38,8 +38,6 @@ jobs:
       if: ${{ !cancelled() }}
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        BASE_REF: ${{ github.base_ref }}
-        IS_PUSH: ${{ github.event_name == 'push' }}
       run: |
         set -euo pipefail
 
@@ -58,16 +56,8 @@ jobs:
             | tee "snyk-agent-scan-skill-${skill_name}.json"
         }
 
-        if [ "$IS_PUSH" = "true" ]; then
-          # On main: scan all skills
-          SKILL_DIRS=$(find plugins/*/skills -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)
-        else
-          # On PRs: scan only changed skills
-          git fetch origin "$BASE_REF" --depth=1
-          SKILL_DIRS=$(git diff --name-only "origin/$BASE_REF" -- 'plugins/*/skills/**' \
-            | cut -d/ -f1-4 \
-            | sort -u)
-        fi
+        # Scan all skills on both PRs and pushes to main
+        SKILL_DIRS=$(find plugins/*/skills -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)
 
         if [ -z "$SKILL_DIRS" ]; then
           echo "No skills to scan"

--- a/.snyk-agent-scan-ignore.json
+++ b/.snyk-agent-scan-ignore.json
@@ -29,8 +29,14 @@
   },
   {
     "code": "W012",
-    "url_pattern": "https://api\\.github\\.com/repos/auth0/[^/]+/releases/latest",
+    "url_pattern": "(https://api\\.github\\.com/)?repos/auth0/[^/]+/releases",
     "reason": "First-party Auth0 repo API call to fetch latest release version"
+  },
+  {
+    "code": "W012",
+    "skills": ["auth0-branding"],
+    "url_pattern": "https://api\\.brandfetch\\.io/v2/brands/",
+    "reason": "Brandfetch API is used to extract brand tokens (colors, logos, fonts) for theming Auth0 Universal Login"
   },
   {
     "code": "W012",

--- a/plugins/auth0/skills/auth0-android/SKILL.md
+++ b/plugins/auth0/skills/auth0-android/SKILL.md
@@ -56,6 +56,8 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
    >
    > Then follow [**Setup Guide**](references/setup.md) for the chosen path.
    > **Do NOT proceed to step 3 until Auth0 credentials are confirmed.**
+   >
+   > **Note:** For native Android apps, Domain and Client ID are public configuration (not secrets). No client secret is used. Write values directly to `strings.xml` without displaying them in conversation output.
 
 3. **Initialize**: Create an Auth0 account instance:
    ```kotlin

--- a/plugins/auth0/skills/auth0-android/references/setup.md
+++ b/plugins/auth0/skills/auth0-android/references/setup.md
@@ -172,17 +172,17 @@ with open(path, 'w') as f:
 PYEOF
 
 echo "✅ Auth0 credentials written to $STRINGS_FILE"
-echo "   Domain:       $DOMAIN"
-echo "   Client ID:    $CLIENT_ID"
-echo "   Package:      $PACKAGE_NAME"
-echo "   Callback URL: $CALLBACK_URL"
 ```
 
 After the script runs, proceed to **Post-Setup Steps** below.
 
 ### Manual Setup (User-Provided Credentials)
 
-> **Agent instruction:** Ask the user for their Auth0 **Client ID** and **Domain**. Then update `strings.xml` with the values they provide:
+> **Agent instruction:** Ask the user to provide their Auth0 **Client ID** and **Domain**.
+>
+> **Note:** For native Android applications, Domain and Client ID are public configuration values (compiled into the APK and visible to anyone who decompiles it). They are NOT secrets and do not grant access without the user's credentials. No client secret is used.
+>
+> Once the user provides values, write them directly to `strings.xml` without displaying them back in conversation output:
 > ```xml
 > <string name="com_auth0_client_id">USER_PROVIDED_CLIENT_ID</string>
 > <string name="com_auth0_domain">USER_PROVIDED_DOMAIN</string>

--- a/plugins/auth0/skills/auth0-fastify-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-fastify-api/SKILL.md
@@ -128,8 +128,9 @@ curl http://localhost:3001/api/public
 Test protected endpoint (requires access token):
 
 ```bash
+# First, obtain an access token (e.g. via Auth0 Dashboard > APIs > Test tab)
 curl http://localhost:3001/api/private \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+  -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
 ---

--- a/plugins/auth0/skills/auth0-flask/tests/evals.json
+++ b/plugins/auth0/skills/auth0-flask/tests/evals.json
@@ -3,7 +3,7 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Add Auth0 authentication to a Flask web application using the auth0-server-python SDK.\n\n**Auth0 Credentials:**\n- Domain: `dev-example.auth0.com`\n- Client ID: `abc123def456ghi789jkl012`\n- Client Secret: `secret_xyz789abc123def456ghi789jkl012mno345pqr678stu901vwx234yz`",
+      "prompt": "Add Auth0 authentication to a Flask web application using the auth0-server-python SDK.\n\n**Auth0 Credentials:**\n- Domain: `dev-example.auth0.com`\n- Client ID: `abc123def456ghi789jkl012`\n- Client Secret: `YOUR_AUTH0_CLIENT_SECRET`",
       "expected_output": "Working Flask web app with Auth0 session-based login, callback, profile, and logout routes",
       "expectations": [
         "Auth0 SDK (auth0-server-python) present in project",

--- a/plugins/auth0/skills/auth0-flask/tests/prompt.md
+++ b/plugins/auth0/skills/auth0-flask/tests/prompt.md
@@ -15,4 +15,4 @@ Add Auth0 authentication to a Flask web application using the auth0-server-pytho
 **Auth0 Credentials:**
 - Domain: `dev-example.auth0.com`
 - Client ID: `abc123def456ghi789jkl012`
-- Client Secret: `secret_xyz789abc123def456ghi789jkl012mno345pqr678stu901vwx234yz`
+- Client Secret: `YOUR_AUTH0_CLIENT_SECRET`


### PR DESCRIPTION
### Description

  #### 1. snyk-agent-scan-ignore.json

  - Broadened the GitHub API URL pattern from matching only `/releases/latest` to matching `/releases` - covers all release endpoint variants across Auth0 repos
  - Added a new allowlist entry for the `auth0-branding` skill to use `https://api.brandfetch.io/v2/brands/` (used to fetch brand colors/logos/fonts for theming Universal Login)

#### 2. auth0-android

Added clarification that for native Android apps, Domain and Client ID are public configuration (compiled into the APK, visible to anyone who decompiles it) - they are not secrets and no client secret is used

#### 3. auth0-fastify-api
Replaced the literal `YOUR_ACCESS_TOKEN` with a shell variable reference `$ACCESS_TOKEN`. 

#### 4. auth0-flask
Replaced a realistic looking secretwith an obvious placeholder `YOUR_AUTH0_CLIENT_SECRET` in both `tests/evals.json` and `tests/prompt.md` - still functional for eval purposes but no longer triggers secret-detection rules.

### References

Aims to fix the failing [action ](https://github.com/auth0/agent-skills/actions/runs/26568309185/job/78268596958)

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scan workflow to scan all skills on every run instead of only changed skills
  * Updated security scan ignore configuration for third-party API patterns

* **Documentation**
  * Enhanced Auth0 setup guidance for native Android applications, clarifying public configuration values
  * Updated Auth0 FastAPI setup documentation and testing examples
  * Improved Auth0 Flask test evaluation configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auth0/agent-skills/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->