### PR TITLE
fix(auth0-android): warn against Auth0.getInstance(clientId, domain) hardcoding credentials

### DIFF
--- a/plugins/auth0/skills/auth0-android/SKILL.md
+++ b/plugins/auth0/skills/auth0-android/SKILL.md
@@ -66,6 +66,8 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
    val account = Auth0.getInstance(context)
    ```
 
+   > **IMPORTANT:** `Auth0.getInstance(context)` auto-reads `com_auth0_client_id` and `com_auth0_domain` from `strings.xml`. **Never** pass `clientId` or `domain` as arguments (e.g. `Auth0.getInstance(clientId, domain)`) — that hardcodes credentials in source.
+
 4. **Add Auth UI**: Implement login and logout with Web Auth:
 
    > **Agent instruction:** Before adding new UI elements, search the project for existing click handlers for login, logout, sign-in, or sign-out buttons (e.g., `loginButton`, `signInButton`, `logoutButton`, `signOutButton`, or `setOnClickListener` with auth-related naming). If existing handlers are found, hook the Auth0 code into them without modifying the existing UI. Only create new buttons if no existing handlers are found.


### PR DESCRIPTION
## Description

Adds a 2-line `IMPORTANT` warning to the `auth0-android` skill reminding agents that `Auth0.getInstance(context)` already reads `com_auth0_client_id` and `com_auth0_domain` from `strings.xml` — and that passing `clientId`/`domain` as arguments hardcodes credentials directly in source code.

### Why this matters

Without this warning, agents tend to pass credentials as constructor arguments — a pattern that:

1. Hardcodes the Auth0 domain as a string literal in source code (security failure)
2. Bypasses `strings.xml`, breaking the project's configuration pattern

The warning also indirectly guides the model toward using `SecureCredentialsManager` + `SharedPreferencesStorage` for token persistence — by reading the `Auth0.getInstance(context)` pattern correctly, the model follows through to the full recommended credential storage setup.

## Eval story

Tested against the `android_quickstart` eval using `gpt-5.4-mini` with `--tools skills`. Three configurations compared:


**Without the skill**, the model stores tokens only in Compose `mutableStateOf` (in-memory, lost on process death).

**Skills on main** already has the correct `SecureCredentialsManager` pattern, but without the IMPORTANT warning the model falls back to `Auth0.getInstance(clientId, domain)` — introducing a hardcoded domain regression that makes it score _lower_ than no skill at all.

**This PR** closes the gap: the model follows `getInstance(context)` through correctly, sets up `SecureCredentialsManager` with `SharedPreferencesStorage`, and passes all 12 graders.

## References

- Auth0 Android SDK: https://github.com/auth0/Auth0.Android

## Testing

Eval run results above serve as the test. This is a documentation-only change to a skill file — no unit tests apply.

- [ ] This change adds test coverage for new/changed/fixed functionality

## Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used (`main`)
