### PR TITLE
fix: normalize skill license to Apache-2.0

### DIFF
--- a/plugins/auth0/skills/auth0-expo/SKILL.md
+++ b/plugins/auth0/skills/auth0-expo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth0-expo
 description: Use when adding authentication to Expo (React Native) mobile apps — login, logout, user sessions, protected routes, biometrics, or token management. Integrates react-native-auth0 SDK with Expo Config Plugin for native iOS/Android builds. Trigger for any Expo project needing Auth0, including app.json plugin config, custom scheme setup, or credential management. Do NOT use for bare React Native CLI projects (use auth0-react-native), React web apps (use auth0-react), Next.js (use auth0-nextjs), or backend APIs.
-license: Proprietary
+license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
   version: '1.0.0'

--- a/plugins/auth0/skills/auth0-ionic-angular/SKILL.md
+++ b/plugins/auth0/skills/auth0-ionic-angular/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth0-ionic-angular
 description: Use when adding Auth0 authentication to an Ionic Angular application with Capacitor — integrates @auth0/auth0-angular SDK with Capacitor Browser and App plugins for native iOS/Android deep linking, login, logout, and user profile display.
-license: Proprietary
+license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
   version: '1.0.0'

--- a/plugins/auth0/skills/auth0-ionic-react/SKILL.md
+++ b/plugins/auth0/skills/auth0-ionic-react/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth0-ionic-react
 description: Use when adding Auth0 authentication to an Ionic React application with Capacitor — integrates @auth0/auth0-react SDK with Capacitor Browser and App plugins for native iOS/Android deep linking, login, logout, and user profile display.
-license: Proprietary
+license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
   version: '1.0.0'

--- a/plugins/auth0/skills/auth0-ionic-vue/SKILL.md
+++ b/plugins/auth0/skills/auth0-ionic-vue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth0-ionic-vue
 description: Use when adding Auth0 authentication to an Ionic Vue application with Capacitor — integrates @auth0/auth0-vue SDK with Capacitor Browser and App plugins for native iOS/Android deep linking, login, logout, and user profile display.
-license: Proprietary
+license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
   version: '1.0.0'

--- a/plugins/auth0/skills/auth0-spa-js/SKILL.md
+++ b/plugins/auth0/skills/auth0-spa-js/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth0-spa-js
 description: Use when adding authentication to Vanilla JS, Svelte, or any framework-agnostic single-page applications - integrates @auth0/auth0-spa-js SDK for SPAs without framework-specific wrappers
-license: Proprietary
+license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
   version: '1.0.0'

--- a/plugins/auth0/skills/auth0-swift/SKILL.md
+++ b/plugins/auth0/skills/auth0-swift/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth0-swift
 description: Use when adding Auth0 authentication to an iOS, macOS, tvOS, watchOS, or visionOS application — integrates the Auth0.swift SDK for native Apple platform authentication using Web Auth, CredentialsManager, and biometric protection.
-license: Proprietary
+license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
   version: '1.0.0'

--- a/plugins/auth0/skills/auth0-winforms/SKILL.md
+++ b/plugins/auth0/skills/auth0-winforms/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth0-winforms
 description: Use when adding Auth0 authentication to Windows Forms (WinForms) desktop applications - integrates Auth0.OidcClient.WinForms NuGet package for native login, logout, token refresh, and user profile. Trigger on WinForms authentication, add login to WinForms, Auth0 WinForms, .NET Windows Forms auth, Windows desktop auth
-license: Proprietary
+license: Apache-2.0
 metadata:
   author: Auth0 SDKs Team <auth0-sdk-cdt@okta.com>
   openclaw:


### PR DESCRIPTION
## Description

  Seven skills were tagged `license: Proprietary` in their `SKILL.md` frontmatter while the repository's root `LICENSE` is Apache-2.0. This normalizes them to `Apache-2.0` so the per-skill
   license matches the repo license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license declarations across Auth0 skill packages (auth0-expo, auth0-ionic-angular, auth0-ionic-react, auth0-ionic-vue, auth0-spa-js, auth0-swift, and auth0-winforms) to Apache-2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->