### PR TITLE
fix(express-oauth2-jwt-bearer): use SDK-native env vars

### DIFF
--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
@@ -54,14 +54,11 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 >
 > 3. **Configure Auth0** — follow `references/setup.md`. If the user already provided their Auth0 Domain and API Audience in the prompt, use them directly — skip the bootstrap script and do NOT call `AskUserQuestion` to re-confirm. Otherwise, offer automatic setup via bootstrap script or manual setup.
 >
-> 4. **Set up middleware** — add to `app.js` or `server.js`:
+> 4. **Set up middleware** — add to `app.js` or `server.js`. The SDK reads `ISSUER_BASE_URL` and `AUDIENCE` from the environment automatically, so `auth()` needs no arguments:
 >    ```javascript
 >    import { auth } from 'express-oauth2-jwt-bearer';
 >
->    const checkJwt = auth({
->      issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
->      audience: process.env.AUTH0_AUDIENCE,
->    });
+>    const checkJwt = auth(); // reads ISSUER_BASE_URL + AUDIENCE from env
 >
 >    app.use(checkJwt); // apply globally, or per-route
 >    ```
@@ -108,10 +105,10 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 |---------|---------|-----|
 | Created an **Application** instead of an **API** in Auth0 Dashboard | Token validation fails; wrong audience | Create a new **API** (Resource Server) in Auth0 Dashboard → APIs |
 | Audience doesn't match API identifier exactly | `401 Unauthorized` — "Audience mismatch" | Copy the exact API Identifier string from Auth0 Dashboard → APIs |
-| Domain includes `https://` prefix | `Error: Invalid URL` at startup | Use hostname only: `your-tenant.us.auth0.com`, not `https://...` |
+| `ISSUER_BASE_URL` missing the `https://` prefix | `Error: Invalid URL` at startup | `ISSUER_BASE_URL` is a full URL — use `https://your-tenant.us.auth0.com`, not the bare hostname |
 | Checking `scope` claim instead of `permissions` for RBAC | 403 always returned or permissions ignored | Use `requiredScopes()` for scope-based RBAC; use `claimIncludes('permissions', 'read:data')` for Auth0 RBAC permission claims |
 | CORS not configured before auth middleware | Preflight OPTIONS requests return 401 | Add `cors()` middleware before `auth()` in the middleware chain |
-| `.env` file not loaded | `undefined` for domain/audience | Add `import 'dotenv/config'` at the top of the entry file |
+| `.env` file not loaded | `auth()` throws "issuerBaseURL ... required" at startup | Add `import 'dotenv/config'` at the top of the entry file, before calling `auth()` |
 | `req.auth` is undefined | `TypeError: Cannot read properties of undefined` | Verify `checkJwt` middleware runs before the handler |
 
 ## Related Skills
@@ -140,8 +137,8 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `issuerBaseURL` | `string` | Auth0 domain with `https://` (required unless using env vars) |
-| `audience` | `string` | API Identifier from Auth0 Dashboard (required unless using env vars) |
+| `issuerBaseURL` | `string` | Auth0 domain with `https://` (defaults to `ISSUER_BASE_URL` env var) |
+| `audience` | `string` | API Identifier from Auth0 Dashboard (defaults to `AUDIENCE` env var) |
 | `tokenSigningAlg` | `string` | Signing algorithm (default: `RS256`; use `HS256` for symmetric) |
 | `authRequired` | `boolean` | Set `false` to make authentication optional (default: `true`) |
 | `clockTolerance` | `number` | Clock skew tolerance in seconds (no default; undefined unless set) |
@@ -149,10 +146,12 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 
 ### Environment Variables
 
+The SDK auto-detects these when no arguments are passed to `auth()`:
+
 | Variable | Description |
 |----------|-------------|
-| `ISSUER_BASE_URL` | Auth0 domain with `https://` (auto-detected by SDK) |
-| `AUDIENCE` | API Identifier (auto-detected by SDK) |
+| `ISSUER_BASE_URL` | Auth0 domain as a **full URL** with `https://` (e.g. `https://your-tenant.us.auth0.com`) |
+| `AUDIENCE` | API Identifier from Auth0 Dashboard (e.g. `https://my-api.example.com`) |
 
 ### Request Object
 

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
@@ -47,15 +47,16 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 >
 > 1. **Fetch latest version** (see instruction above).
 >
-> 2. **Install the SDK:**
+> 2. **Install the SDK** (and `dotenv` to load `.env`):
 >    ```bash
->    npm install express-oauth2-jwt-bearer
+>    npm install express-oauth2-jwt-bearer dotenv
 >    ```
 >
 > 3. **Configure Auth0** — follow `references/setup.md`. If the user already provided their Auth0 Domain and API Audience in the prompt, use them directly — skip the bootstrap script and do NOT call `AskUserQuestion` to re-confirm. Otherwise, offer automatic setup via bootstrap script or manual setup.
 >
-> 4. **Set up middleware** — add to `app.js` or `server.js`. The SDK reads `ISSUER_BASE_URL` and `AUDIENCE` from the environment automatically, so `auth()` needs no arguments:
+> 4. **Set up middleware** — add to `app.js` or `server.js`. The SDK reads `ISSUER_BASE_URL` and `AUDIENCE` from the environment automatically, so `auth()` needs no arguments. Load `.env` with `dotenv` **before** calling `auth()`:
 >    ```javascript
+>    import 'dotenv/config'; // must come before auth() — or: require('dotenv').config();
 >    import { auth } from 'express-oauth2-jwt-bearer';
 >
 >    const checkJwt = auth(); // reads ISSUER_BASE_URL + AUDIENCE from env

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
@@ -63,6 +63,8 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 >    app.use(checkJwt); // apply globally, or per-route
 >    ```
 >
+>    > **IMPORTANT:** `auth()` auto-reads `ISSUER_BASE_URL` and `AUDIENCE` from the environment. **Never** hardcode the domain or audience as string literals (e.g. `auth({ issuerBaseURL: 'https://your-tenant.us.auth0.com', audience: '...' })`) — that bakes per-environment config into source. Set them in `.env`/your platform's env vars and let the SDK read them.
+>
 > 5. **Protect endpoints** — apply middleware globally or to specific routes:
 >    ```javascript
 >    // Global protection

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/references/api.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/references/api.md
@@ -8,8 +8,8 @@ All options are passed to the `auth()` function or set via environment variables
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `issuerBaseURL` | `string` | Yes (or `ISSUER_BASE_URL` env var) | — | Auth0 domain with `https://`, e.g. `https://your-tenant.us.auth0.com` |
-| `audience` | `string` | Yes (or `AUDIENCE` env var) | — | API Identifier from Auth0 Dashboard, e.g. `https://my-api.com` |
+| `issuerBaseURL` | `string` | Yes (or `ISSUER_BASE_URL` env var) | `process.env.ISSUER_BASE_URL` | Auth0 domain with `https://`, e.g. `https://your-tenant.us.auth0.com` |
+| `audience` | `string` | Yes (or `AUDIENCE` env var) | `process.env.AUDIENCE` | API Identifier from Auth0 Dashboard, e.g. `https://my-api.com` |
 | `secret` | `string` | For HS256 only | — | Shared secret for symmetric JWT signing (HS256). Not required for RS256. |
 | `tokenSigningAlg` | `string` | No | `RS256` | JWT signing algorithm. Use `HS256` for symmetric keys. |
 | `issuer` | `string` | No (alternative to `issuerBaseURL`) | — | Issuer claim value — use with `jwksUri` for non-standard setups |
@@ -34,15 +34,15 @@ When no options are passed to `auth()`, these variables are read automatically:
 
 | Variable | Description |
 |----------|-------------|
-| `ISSUER_BASE_URL` | Auth0 domain with `https://` prefix: `https://your-tenant.us.auth0.com` |
+| `ISSUER_BASE_URL` | Auth0 domain as a **full URL** with `https://` prefix: `https://your-tenant.us.auth0.com` |
 | `AUDIENCE` | API Identifier: `https://your-api.example.com` |
 
-**Note:** `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` are the conventional `.env` keys used in this skill. Pass them explicitly:
+This is the convention this skill uses — set them in `.env` and call `auth()` with no arguments:
 ```javascript
-auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-})
+import 'dotenv/config';
+import { auth } from 'express-oauth2-jwt-bearer';
+
+const checkJwt = auth(); // reads ISSUER_BASE_URL + AUDIENCE from env
 ```
 
 ## Claims Reference
@@ -89,9 +89,9 @@ app.use(cors({
 app.use(express.json());
 
 // 2. JWT validation middleware
+//    issuerBaseURL + audience are read from ISSUER_BASE_URL / AUDIENCE env vars.
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  clockTolerance: 5, // seconds of allowed clock skew
 });
 
 // 3. Public endpoint (no auth required)
@@ -135,8 +135,8 @@ app.listen(PORT, () => console.log(`API listening on port ${PORT}`));
 ### Environment configuration (.env)
 
 ```env
-AUTH0_DOMAIN=your-tenant.us.auth0.com
-AUTH0_AUDIENCE=https://your-api.example.com
+ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+AUDIENCE=https://your-api.example.com
 PORT=3000
 CORS_ORIGIN=http://localhost:5173
 ```
@@ -153,10 +153,7 @@ import { auth, requiredScopes } from 'express-oauth2-jwt-bearer';
 
 const app = express();
 
-const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-});
+const checkJwt = auth(); // reads ISSUER_BASE_URL + AUDIENCE from env
 
 app.get('/api/private', checkJwt, (req: Request, res: Response) => {
   const sub = req.auth?.payload.sub;
@@ -196,10 +193,10 @@ curl --request POST \
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `UnauthorizedError: No authorization token was found` | No `Authorization: Bearer ...` header | Add the bearer token to the request header |
-| `UnauthorizedError: invalid_token — jwt audience invalid` | Audience mismatch | Verify `AUTH0_AUDIENCE` matches the API Identifier in Auth0 Dashboard exactly |
-| `UnauthorizedError: invalid_token — jwt issuer invalid` | Domain mismatch | Verify `AUTH0_DOMAIN` is the Auth0 tenant hostname (no `https://`) |
+| `UnauthorizedError: invalid_token — jwt audience invalid` | Audience mismatch | Verify `AUDIENCE` matches the API Identifier in Auth0 Dashboard exactly |
+| `UnauthorizedError: invalid_token — jwt issuer invalid` | Issuer mismatch | Verify `ISSUER_BASE_URL` is the full Auth0 tenant URL with `https://` |
 | `UnauthorizedError: invalid_token — jwt expired` | Token has expired | Request a new token; check system clock drift (`clockTolerance` option) |
-| `Error: JWKS request failed` | Network or domain misconfiguration | Verify `AUTH0_DOMAIN` is reachable; check network/proxy settings |
+| `Error: JWKS request failed` | Network or issuer misconfiguration | Verify `ISSUER_BASE_URL` is reachable; check network/proxy settings |
 | `InsufficientScopeError: Insufficient scope` | Token lacks required scope | Verify the requesting app has the scope granted; check `requiredScopes()` call |
 | `CORS error` on OPTIONS preflight | Auth middleware running before CORS | Move `cors()` middleware before `auth()` in the middleware chain |
 | `TypeError: Cannot read properties of undefined (reading 'payload')` | `req.auth` is undefined | Check that `checkJwt` middleware runs before the handler |

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/references/integration.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/references/integration.md
@@ -23,10 +23,8 @@ Apply `checkJwt` middleware globally to protect all routes:
 ```javascript
 import { auth } from 'express-oauth2-jwt-bearer';
 
-const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-});
+// Reads ISSUER_BASE_URL + AUDIENCE from env
+const checkJwt = auth();
 
 // All routes below this require a valid JWT
 app.use(checkJwt);
@@ -57,9 +55,7 @@ Allow unauthenticated requests but attach auth info when present:
 
 ```javascript
 const optionalAuth = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-  authRequired: false,
+  authRequired: false, // issuerBaseURL + audience read from env
 });
 
 app.get('/api/profile', optionalAuth, (req, res) => {
@@ -159,11 +155,8 @@ app.use(cors({
   exposedHeaders: ['WWW-Authenticate'],
 }));
 
-// 2. Auth second
-const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-});
+// 2. Auth second (reads ISSUER_BASE_URL + AUDIENCE from env)
+const checkJwt = auth();
 ```
 
 ## DPoP Support
@@ -174,8 +167,7 @@ DPoP (Demonstration of Proof-of-Possession) binds tokens to the client's key pai
 
 ```javascript
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  // issuerBaseURL + audience read from ISSUER_BASE_URL / AUDIENCE env vars
   dpop: {
     enabled: true,
     required: false,  // Accept both Bearer and DPoP tokens
@@ -187,8 +179,7 @@ const checkJwt = auth({
 
 ```javascript
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  // issuerBaseURL + audience read from ISSUER_BASE_URL / AUDIENCE env vars
   dpop: {
     enabled: true,
     required: true,  // Reject plain Bearer tokens
@@ -200,8 +191,7 @@ const checkJwt = auth({
 
 ```javascript
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  // issuerBaseURL + audience read from ISSUER_BASE_URL / AUDIENCE env vars
   dpop: { enabled: false },
 });
 ```

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/references/setup.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/references/setup.md
@@ -41,16 +41,16 @@
 >
 > Then write the `.env` file (see below).
 >
-> **Write the .env file** (both paths):
+> **Write the .env file** (both paths). The SDK reads `ISSUER_BASE_URL` (a full URL, including `https://`) and `AUDIENCE` automatically:
 > ```env
-> AUTH0_DOMAIN=your-tenant.us.auth0.com
-> AUTH0_AUDIENCE=https://your-api.example.com
+> ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+> AUDIENCE=https://your-api.example.com
 > PORT=3000
 > ```
 
 ### Auth0 API Registration (Resource Server)
 
-The bootstrap script automatically runs `auth0 apis create` to register your API as a Resource Server. This produces the `AUTH0_AUDIENCE` value (the API Identifier) that your middleware uses for token validation.
+The bootstrap script automatically runs `auth0 apis create` to register your API as a Resource Server. This produces the `AUDIENCE` value (the API Identifier) that your middleware uses for token validation.
 
 **Auth0 CLI command (for reference):**
 ```bash
@@ -66,7 +66,7 @@ auth0 apis create \
 2. Click **Create API**
 3. Set:
    - **Name**: Your API name (e.g., "My Node API")
-   - **Identifier**: A URL-like identifier (e.g., `https://my-api.example.com`) — this becomes `AUTH0_AUDIENCE`
+   - **Identifier**: A URL-like identifier (e.g., `https://my-api.example.com`) — this becomes `AUDIENCE`
    - **Signing Algorithm**: `RS256` (recommended)
 4. Click **Create**
 5. Note the **API Identifier** — this is your Audience value
@@ -85,7 +85,7 @@ To use `claimIncludes('permissions', 'read:data')` with Auth0 RBAC:
 
 After running the bootstrap script or manual setup:
 
-1. **Verify domain and audience** are correct in `.env`
+1. **Verify `ISSUER_BASE_URL` and `AUDIENCE`** are correct in `.env`
 2. **Test the API is reachable**: `auth0 apis list --json --no-input | grep your-api`
 3. **Confirm CORS is configured** before auth middleware in your server file (see integration.md)
 4. **Request a test token** using M2M credentials or the Auth0 Dashboard test feature:
@@ -121,15 +121,15 @@ npm install --save-dev @types/express @types/cors  # TypeScript projects
 `express-oauth2-jwt-bearer` requires only **Domain** and **Audience** — no Client Secret. The middleware validates tokens using the Auth0 JWKS (JSON Web Key Set) endpoint, which provides the public signing keys. This means:
 
 - **No client secret needed** for token validation
-- The JWKS endpoint is publicly accessible at `https://{AUTH0_DOMAIN}/.well-known/jwks.json`
+- The JWKS endpoint is publicly accessible at `{ISSUER_BASE_URL}/.well-known/jwks.json`
 - The middleware fetches and caches keys automatically
 
 ### .env file (development)
 
 ```env
 # .env — Never commit to source control
-AUTH0_DOMAIN=your-tenant.us.auth0.com
-AUTH0_AUDIENCE=https://your-api.example.com
+ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+AUDIENCE=https://your-api.example.com
 PORT=3000
 ```
 
@@ -139,8 +139,8 @@ Set these as environment variables in your hosting platform (not in `.env` files
 
 | Variable | Example Value |
 |----------|--------------|
-| `AUTH0_DOMAIN` | `your-tenant.us.auth0.com` |
-| `AUTH0_AUDIENCE` | `https://your-api.example.com` |
+| `ISSUER_BASE_URL` | `https://your-tenant.us.auth0.com` |
+| `AUDIENCE` | `https://your-api.example.com` |
 | `PORT` | `3000` |
 
 **Never commit `.env` to source control.** Add `.env` to `.gitignore`:

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/scripts/bootstrap.mjs
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/scripts/bootstrap.mjs
@@ -48,8 +48,8 @@ async function main() {
   const envPath = path.join(projectPath, ".env")
   await writeEnvFile(
     {
-      AUTH0_DOMAIN: domain,
-      AUTH0_AUDIENCE: api.identifier,
+      ISSUER_BASE_URL: `https://${domain}`,
+      AUDIENCE: api.identifier,
     },
     envPath
   )

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/tests/evals.json
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/tests/evals.json
@@ -9,7 +9,7 @@
         "Auth0 SDK (express-oauth2-jwt-bearer) present in project",
         "Has correct import statement (express-oauth2-jwt-bearer)",
         "Auth0 SDK initialized (auth() middleware configured)",
-        "AUTH0_DOMAIN environment variable configured",
+        "ISSUER_BASE_URL environment variable configured",
         "Configures JWT Bearer token validation middleware",
         "Configures API audience for token validation",
         "Has protected API endpoint with JWT middleware",

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/tests/graders.json
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/tests/graders.json
@@ -2,9 +2,9 @@
   {"type": "matches", "pattern": "express-oauth2-jwt-bearer", "description": "Auth0 SDK (express-oauth2-jwt-bearer) present in project"},
   {"type": "matches", "pattern": "require\\s*\\(['\"]express-oauth2-jwt-bearer['\"]\\)|from\\s+['\"]express-oauth2-jwt-bearer['\"]", "description": "Has correct import statement (express-oauth2-jwt-bearer)"},
   {"type": "contains_any", "values": ["auth({", "auth()"], "description": "Auth0 SDK initialized (auth() middleware configured)"},
-  {"type": "contains", "value": "AUTH0_DOMAIN", "description": "AUTH0_DOMAIN environment variable configured"},
+  {"type": "contains", "value": "ISSUER_BASE_URL", "description": "ISSUER_BASE_URL environment variable configured"},
   {"type": "matches", "pattern": "auth\\s*\\(\\{|const\\s+\\w+\\s*=\\s*auth\\s*\\(|app\\.use\\s*\\(auth\\s*\\(", "description": "Configures JWT Bearer token validation middleware"},
-  {"type": "matches", "pattern": "audience:|AUTH0_AUDIENCE|AUDIENCE", "description": "Configures API audience for token validation"},
+  {"type": "matches", "pattern": "audience:|AUDIENCE", "description": "Configures API audience for token validation"},
   {"type": "matches", "pattern": "app\\.(get|post|put|delete|patch)\\s*\\([^,]+,\\s*checkJwt|app\\.use\\s*\\(checkJwt|router\\.(get|post|put|delete|patch)\\s*\\([^,]+,\\s*checkJwt", "description": "Has protected API endpoint with JWT middleware"},
   {"type": "matches", "pattern": "cors\\s*\\(|require\\s*\\(['\"]cors['\"]\\)|from\\s+['\"]cors['\"]", "description": "Configures CORS middleware"},
 


### PR DESCRIPTION
## Summary
- Switch the `express-oauth2-jwt-bearer` skill from the Auth0-flavored `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` env vars to the SDK's own `ISSUER_BASE_URL` / `AUDIENCE` vars, which `auth()` reads from the environment automatically.
- Code examples now call `auth()` with no arguments (no `process.env` plumbing). Option-bearing examples (`authRequired`, `dpop`, `clockTolerance`) keep only their options.
- `ISSUER_BASE_URL` is a **full URL** including `https://` — the opposite of the old hostname-only `AUTH0_DOMAIN`. Updated the "Common Mistakes" and "Common Issues" rows that previously warned *against* the `https://` prefix.

## Why
The package is a generic RFC 6750 OAuth2 middleware, not an Auth0-specific SDK. `ISSUER_BASE_URL` / `AUDIENCE` are its native convention (`access-token-jwt`'s `jwt-verifier.ts` defaults `issuerBaseURL = process.env.ISSUER_BASE_URL` and `audience = process.env.AUDIENCE`). Using them means less boilerplate and removes the `https://`-prefix footgun.

## Files changed
- `SKILL.md`, `references/setup.md`, `references/api.md`, `references/integration.md`
- `scripts/bootstrap.mjs` — writes `ISSUER_BASE_URL=https://<domain>` and `AUDIENCE`
- `tests/graders.json`, `tests/evals.json` — assert on `ISSUER_BASE_URL`

## Note
This intentionally diverges from the `AUTH0_*` naming used by other Auth0 skills, since this SDK is provider-neutral. A `clockTolerance` option is kept in the complete example so the skill still demonstrates advanced `auth()` configuration.

## Test plan
- [ ] Run the skill eval (`tests/evals.json`) and confirm graders pass with the new env var names
- [ ] Verify a generated app starts with `ISSUER_BASE_URL` + `AUDIENCE` in `.env` and validates a token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication configuration guides to use `ISSUER_BASE_URL` and `AUDIENCE` environment variables with automatic detection.
  * Revised setup instructions, examples, and integration guides to reflect simplified configuration approach.
  * Clarified environment variable handling and common configuration scenarios.

* **Chores**
  * Updated bootstrap process to generate new environment variable names during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->