### PR TITLE
fix(express-oauth2-jwt-bearer): steer agents to .env instead of hardcoding domain/audience

### DIFF
--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
@@ -52,10 +52,16 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 >    npm install express-oauth2-jwt-bearer
 >    ```
 >
-> 3. **Configure Auth0** — follow `references/setup.md`. If the user already provided their Auth0 Domain and API Audience in the prompt, use them directly — skip the bootstrap script and do NOT call `AskUserQuestion` to re-confirm. Otherwise, offer automatic setup via bootstrap script or manual setup.
+> 3. **Configure Auth0** — follow `references/setup.md`. If the user already provided their Auth0 Domain and API Audience in the prompt, write them to a `.env` file as `AUTH0_DOMAIN` and `AUTH0_AUDIENCE` and reference them via `process.env` — skip the bootstrap script and do NOT call `AskUserQuestion` to re-confirm. **Never hardcode the domain or audience as literal strings (or `||` fallback defaults) in `server.js` / `app.js`** — they belong in `.env` only. Otherwise, offer automatic setup via bootstrap script or manual setup.
 >
-> 4. **Set up middleware** — add to `app.js` or `server.js`:
+> 4. **Set up middleware** — first create a `.env` file with the Auth0 values, then load it and add the middleware:
+>    ```bash
+>    # .env
+>    AUTH0_DOMAIN=your-tenant.us.auth0.com
+>    AUTH0_AUDIENCE=https://your-api-identifier
+>    ```
 >    ```javascript
+>    import 'dotenv/config'; // load .env before reading process.env
 >    import { auth } from 'express-oauth2-jwt-bearer';
 >
 >    const checkJwt = auth({
@@ -65,6 +71,7 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 >
 >    app.use(checkJwt); // apply globally, or per-route
 >    ```
+>    Read the domain and audience from `process.env` — do not inline the literal values here.
 >
 > 5. **Protect endpoints** — apply middleware globally or to specific routes:
 >    ```javascript
@@ -112,6 +119,7 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 | Checking `scope` claim instead of `permissions` for RBAC | 403 always returned or permissions ignored | Use `requiredScopes()` for scope-based RBAC; use `claimIncludes('permissions', 'read:data')` for Auth0 RBAC permission claims |
 | CORS not configured before auth middleware | Preflight OPTIONS requests return 401 | Add `cors()` middleware before `auth()` in the middleware chain |
 | `.env` file not loaded | `undefined` for domain/audience | Add `import 'dotenv/config'` at the top of the entry file |
+| Hardcoded domain/audience in source (incl. `process.env.X \|\| 'literal'` fallbacks) | Secrets committed to source; fails security review | Put values in `.env` (`AUTH0_DOMAIN` / `AUTH0_AUDIENCE`) and reference via `process.env` — no literal fallbacks |
 | `req.auth` is undefined | `TypeError: Cannot read properties of undefined` | Verify `checkJwt` middleware runs before the handler |
 
 ## Related Skills

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
@@ -52,26 +52,24 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 >    npm install express-oauth2-jwt-bearer
 >    ```
 >
-> 3. **Configure Auth0** — follow `references/setup.md`. If the user already provided their Auth0 Domain and API Audience in the prompt, write them to a `.env` file as `AUTH0_DOMAIN` and `AUTH0_AUDIENCE` and reference them via `process.env` — skip the bootstrap script and do NOT call `AskUserQuestion` to re-confirm. **Never hardcode the domain or audience as literal strings (or `||` fallback defaults) in `server.js` / `app.js`** — they belong in `.env` only. Otherwise, offer automatic setup via bootstrap script or manual setup.
+> 3. **Configure Auth0** — follow `references/setup.md`. If the user already provided their Auth0 Domain and API Audience in the prompt, write them to a `.env` file as `ISSUER_BASE_URL` (the full issuer URL, including `https://`) and `AUDIENCE` — the SDK reads these automatically. Skip the bootstrap script and do NOT call `AskUserQuestion` to re-confirm. **Never hardcode the domain or audience as literal strings (or `||` fallback defaults) in `server.js` / `app.js`** — they belong in `.env` only. Otherwise, offer automatic setup via bootstrap script or manual setup.
 >
-> 4. **Set up middleware** — first create a `.env` file with the Auth0 values, then load it and add the middleware:
+> 4. **Set up middleware** — first create a `.env` file with the Auth0 values, then load it and add the middleware. `express-oauth2-jwt-bearer` reads `ISSUER_BASE_URL` and `AUDIENCE` from the environment automatically, so `auth()` needs no arguments:
 >    ```bash
 >    # .env
->    AUTH0_DOMAIN=your-tenant.us.auth0.com
->    AUTH0_AUDIENCE=https://your-api-identifier
+>    ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+>    AUDIENCE=https://your-api-identifier
 >    ```
 >    ```javascript
->    import 'dotenv/config'; // load .env before reading process.env
+>    import 'dotenv/config'; // load .env before the SDK reads process.env
 >    import { auth } from 'express-oauth2-jwt-bearer';
 >
->    const checkJwt = auth({
->      issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
->      audience: process.env.AUTH0_AUDIENCE,
->    });
+>    // Reads ISSUER_BASE_URL and AUDIENCE from the environment — no config needed
+>    const checkJwt = auth();
 >
 >    app.use(checkJwt); // apply globally, or per-route
 >    ```
->    Read the domain and audience from `process.env` — do not inline the literal values here.
+>    Keep the issuer and audience in `.env` — do not inline literal values or pass them as arguments here.
 >
 > 5. **Protect endpoints** — apply middleware globally or to specific routes:
 >    ```javascript
@@ -115,11 +113,11 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 |---------|---------|-----|
 | Created an **Application** instead of an **API** in Auth0 Dashboard | Token validation fails; wrong audience | Create a new **API** (Resource Server) in Auth0 Dashboard → APIs |
 | Audience doesn't match API identifier exactly | `401 Unauthorized` — "Audience mismatch" | Copy the exact API Identifier string from Auth0 Dashboard → APIs |
-| Domain includes `https://` prefix | `Error: Invalid URL` at startup | Use hostname only: `your-tenant.us.auth0.com`, not `https://...` |
+| `ISSUER_BASE_URL` missing the `https://` scheme | `Error: Invalid URL` at startup | `ISSUER_BASE_URL` must be the full issuer URL: `https://your-tenant.us.auth0.com` |
 | Checking `scope` claim instead of `permissions` for RBAC | 403 always returned or permissions ignored | Use `requiredScopes()` for scope-based RBAC; use `claimIncludes('permissions', 'read:data')` for Auth0 RBAC permission claims |
 | CORS not configured before auth middleware | Preflight OPTIONS requests return 401 | Add `cors()` middleware before `auth()` in the middleware chain |
 | `.env` file not loaded | `undefined` for domain/audience | Add `import 'dotenv/config'` at the top of the entry file |
-| Hardcoded domain/audience in source (incl. `process.env.X \|\| 'literal'` fallbacks) | Secrets committed to source; fails security review | Put values in `.env` (`AUTH0_DOMAIN` / `AUTH0_AUDIENCE`) and reference via `process.env` — no literal fallbacks |
+| Hardcoded domain/audience in source (incl. `process.env.X \|\| 'literal'` fallbacks) | Secrets committed to source; fails security review | Put values in `.env` (`ISSUER_BASE_URL` / `AUDIENCE`) and let `auth()` read them automatically — no literal fallbacks |
 | `req.auth` is undefined | `TypeError: Cannot read properties of undefined` | Verify `checkJwt` middleware runs before the handler |
 
 ## Related Skills
@@ -148,8 +146,8 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `issuerBaseURL` | `string` | Auth0 domain with `https://` (required unless using env vars) |
-| `audience` | `string` | API Identifier from Auth0 Dashboard (required unless using env vars) |
+| `issuerBaseURL` | `string` | Full issuer URL with `https://`. Optional — defaults to the `ISSUER_BASE_URL` env var |
+| `audience` | `string` | API Identifier from Auth0 Dashboard. Optional — defaults to the `AUDIENCE` env var |
 | `tokenSigningAlg` | `string` | Signing algorithm (default: `RS256`; use `HS256` for symmetric) |
 | `authRequired` | `boolean` | Set `false` to make authentication optional (default: `true`) |
 | `clockTolerance` | `number` | Clock skew tolerance in seconds (no default; undefined unless set) |
@@ -159,8 +157,8 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 
 | Variable | Description |
 |----------|-------------|
-| `ISSUER_BASE_URL` | Auth0 domain with `https://` (auto-detected by SDK) |
-| `AUDIENCE` | API Identifier (auto-detected by SDK) |
+| `ISSUER_BASE_URL` | Full issuer URL with `https://`, e.g. `https://your-tenant.us.auth0.com` (auto-detected by SDK) |
+| `AUDIENCE` | API Identifier, e.g. `https://your-api-identifier` (auto-detected by SDK) |
 
 ### Request Object
 

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/references/api.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/references/api.md
@@ -8,8 +8,8 @@ All options are passed to the `auth()` function or set via environment variables
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `issuerBaseURL` | `string` | Yes (or `ISSUER_BASE_URL` env var) | — | Auth0 domain with `https://`, e.g. `https://your-tenant.us.auth0.com` |
-| `audience` | `string` | Yes (or `AUDIENCE` env var) | — | API Identifier from Auth0 Dashboard, e.g. `https://my-api.com` |
+| `issuerBaseURL` | `string` | No — defaults to `ISSUER_BASE_URL` env var | — | Full issuer URL with `https://`, e.g. `https://your-tenant.us.auth0.com` |
+| `audience` | `string` | No — defaults to `AUDIENCE` env var | — | API Identifier from Auth0 Dashboard, e.g. `https://my-api.com` |
 | `secret` | `string` | For HS256 only | — | Shared secret for symmetric JWT signing (HS256). Not required for RS256. |
 | `tokenSigningAlg` | `string` | No | `RS256` | JWT signing algorithm. Use `HS256` for symmetric keys. |
 | `issuer` | `string` | No (alternative to `issuerBaseURL`) | — | Issuer claim value — use with `jwksUri` for non-standard setups |
@@ -30,20 +30,21 @@ All options are passed to the `auth()` function or set via environment variables
 
 ### Environment Variables (auto-detected)
 
-When no options are passed to `auth()`, these variables are read automatically:
+`express-oauth2-jwt-bearer` reads these variables from the environment automatically, so `auth()` can be called with no arguments. This is the approach this skill uses — put the values in `.env` and let the SDK pick them up:
 
 | Variable | Description |
 |----------|-------------|
-| `ISSUER_BASE_URL` | Auth0 domain with `https://` prefix: `https://your-tenant.us.auth0.com` |
+| `ISSUER_BASE_URL` | Full issuer URL **with** `https://` prefix: `https://your-tenant.us.auth0.com` |
 | `AUDIENCE` | API Identifier: `https://your-api.example.com` |
 
-**Note:** `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` are the conventional `.env` keys used in this skill. Pass them explicitly:
 ```javascript
-auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-})
+import 'dotenv/config'; // load .env before the SDK reads process.env
+
+// No arguments needed — ISSUER_BASE_URL and AUDIENCE are read from the environment
+const checkJwt = auth();
 ```
+
+Pass `issuerBaseURL` / `audience` explicitly only if you need to source them from differently-named variables or compute them at runtime.
 
 ## Claims Reference
 
@@ -88,11 +89,8 @@ app.use(cors({
 
 app.use(express.json());
 
-// 2. JWT validation middleware
-const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-});
+// 2. JWT validation middleware (reads ISSUER_BASE_URL and AUDIENCE from the environment)
+const checkJwt = auth();
 
 // 3. Public endpoint (no auth required)
 app.get('/api/public', (req, res) => {
@@ -135,8 +133,8 @@ app.listen(PORT, () => console.log(`API listening on port ${PORT}`));
 ### Environment configuration (.env)
 
 ```env
-AUTH0_DOMAIN=your-tenant.us.auth0.com
-AUTH0_AUDIENCE=https://your-api.example.com
+ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+AUDIENCE=https://your-api.example.com
 PORT=3000
 CORS_ORIGIN=http://localhost:5173
 ```
@@ -153,10 +151,8 @@ import { auth, requiredScopes } from 'express-oauth2-jwt-bearer';
 
 const app = express();
 
-const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-});
+// Reads ISSUER_BASE_URL and AUDIENCE from the environment
+const checkJwt = auth();
 
 app.get('/api/private', checkJwt, (req: Request, res: Response) => {
   const sub = req.auth?.payload.sub;
@@ -196,10 +192,10 @@ curl --request POST \
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `UnauthorizedError: No authorization token was found` | No `Authorization: Bearer ...` header | Add the bearer token to the request header |
-| `UnauthorizedError: invalid_token — jwt audience invalid` | Audience mismatch | Verify `AUTH0_AUDIENCE` matches the API Identifier in Auth0 Dashboard exactly |
-| `UnauthorizedError: invalid_token — jwt issuer invalid` | Domain mismatch | Verify `AUTH0_DOMAIN` is the Auth0 tenant hostname (no `https://`) |
+| `UnauthorizedError: invalid_token — jwt audience invalid` | Audience mismatch | Verify `AUDIENCE` matches the API Identifier in Auth0 Dashboard exactly |
+| `UnauthorizedError: invalid_token — jwt issuer invalid` | Issuer mismatch | Verify `ISSUER_BASE_URL` is the full Auth0 tenant URL **including** `https://` |
 | `UnauthorizedError: invalid_token — jwt expired` | Token has expired | Request a new token; check system clock drift (`clockTolerance` option) |
-| `Error: JWKS request failed` | Network or domain misconfiguration | Verify `AUTH0_DOMAIN` is reachable; check network/proxy settings |
+| `Error: JWKS request failed` | Network or issuer misconfiguration | Verify `ISSUER_BASE_URL` is reachable; check network/proxy settings |
 | `InsufficientScopeError: Insufficient scope` | Token lacks required scope | Verify the requesting app has the scope granted; check `requiredScopes()` call |
 | `CORS error` on OPTIONS preflight | Auth middleware running before CORS | Move `cors()` middleware before `auth()` in the middleware chain |
 | `TypeError: Cannot read properties of undefined (reading 'payload')` | `req.auth` is undefined | Check that `checkJwt` middleware runs before the handler |

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/references/integration.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/references/integration.md
@@ -23,10 +23,8 @@ Apply `checkJwt` middleware globally to protect all routes:
 ```javascript
 import { auth } from 'express-oauth2-jwt-bearer';
 
-const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-});
+// Reads ISSUER_BASE_URL and AUDIENCE from the environment automatically
+const checkJwt = auth();
 
 // All routes below this require a valid JWT
 app.use(checkJwt);
@@ -56,9 +54,8 @@ app.get('/api/private', checkJwt, (req, res) => {
 Allow unauthenticated requests but attach auth info when present:
 
 ```javascript
+// issuer and audience come from ISSUER_BASE_URL / AUDIENCE in the environment
 const optionalAuth = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
   authRequired: false,
 });
 
@@ -159,11 +156,8 @@ app.use(cors({
   exposedHeaders: ['WWW-Authenticate'],
 }));
 
-// 2. Auth second
-const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
-});
+// 2. Auth second (reads ISSUER_BASE_URL and AUDIENCE from the environment)
+const checkJwt = auth();
 ```
 
 ## DPoP Support
@@ -173,9 +167,8 @@ DPoP (Demonstration of Proof-of-Possession) binds tokens to the client's key pai
 ### Hybrid mode (Bearer or DPoP both accepted — default)
 
 ```javascript
+// issuer and audience come from ISSUER_BASE_URL / AUDIENCE in the environment
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
   dpop: {
     enabled: true,
     required: false,  // Accept both Bearer and DPoP tokens
@@ -186,9 +179,8 @@ const checkJwt = auth({
 ### DPoP-only mode (rejects plain Bearer tokens)
 
 ```javascript
+// issuer and audience come from ISSUER_BASE_URL / AUDIENCE in the environment
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
   dpop: {
     enabled: true,
     required: true,  // Reject plain Bearer tokens
@@ -199,9 +191,8 @@ const checkJwt = auth({
 ### Bearer-only mode (disable DPoP)
 
 ```javascript
+// issuer and audience come from ISSUER_BASE_URL / AUDIENCE in the environment
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
   dpop: { enabled: false },
 });
 ```

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/references/setup.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/references/setup.md
@@ -6,6 +6,8 @@
 >
 > **Check if credentials are already provided in the user's prompt:** If the user's prompt already includes Auth0 Domain and API Audience (e.g. `your-tenant.us.auth0.com` and `https://api.example.com`), use them directly — skip to "Write the .env file" below. Do NOT call `AskUserQuestion` to re-confirm provided credentials, and do NOT run the bootstrap script.
 >
+> **Env var convention:** This skill uses the SDK-native variables `ISSUER_BASE_URL` (the full issuer URL, including `https://`) and `AUDIENCE`. `express-oauth2-jwt-bearer` reads them automatically, so `auth()` is called with no arguments.
+>
 > If credentials are NOT provided, offer setup choices:
 >
 > Use `AskUserQuestion` to ask the user:
@@ -39,18 +41,18 @@
 > - **Auth0 Domain** (e.g., `your-tenant.us.auth0.com`)
 > - **API Audience** — the API Identifier you set when creating the Auth0 API (e.g., `https://your-api.example.com`)
 >
-> Then write the `.env` file (see below).
+> Then write the `.env` file (see below). Prefix the domain with `https://` to form `ISSUER_BASE_URL`.
 >
 > **Write the .env file** (both paths):
 > ```env
-> AUTH0_DOMAIN=your-tenant.us.auth0.com
-> AUTH0_AUDIENCE=https://your-api.example.com
+> ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+> AUDIENCE=https://your-api.example.com
 > PORT=3000
 > ```
 
 ### Auth0 API Registration (Resource Server)
 
-The bootstrap script automatically runs `auth0 apis create` to register your API as a Resource Server. This produces the `AUTH0_AUDIENCE` value (the API Identifier) that your middleware uses for token validation.
+The bootstrap script automatically runs `auth0 apis create` to register your API as a Resource Server. This produces the `AUDIENCE` value (the API Identifier) that your middleware uses for token validation.
 
 **Auth0 CLI command (for reference):**
 ```bash
@@ -66,7 +68,7 @@ auth0 apis create \
 2. Click **Create API**
 3. Set:
    - **Name**: Your API name (e.g., "My Node API")
-   - **Identifier**: A URL-like identifier (e.g., `https://my-api.example.com`) — this becomes `AUTH0_AUDIENCE`
+   - **Identifier**: A URL-like identifier (e.g., `https://my-api.example.com`) — this becomes `AUDIENCE`
    - **Signing Algorithm**: `RS256` (recommended)
 4. Click **Create**
 5. Note the **API Identifier** — this is your Audience value
@@ -121,15 +123,15 @@ npm install --save-dev @types/express @types/cors  # TypeScript projects
 `express-oauth2-jwt-bearer` requires only **Domain** and **Audience** — no Client Secret. The middleware validates tokens using the Auth0 JWKS (JSON Web Key Set) endpoint, which provides the public signing keys. This means:
 
 - **No client secret needed** for token validation
-- The JWKS endpoint is publicly accessible at `https://{AUTH0_DOMAIN}/.well-known/jwks.json`
+- The JWKS endpoint is publicly accessible at `{ISSUER_BASE_URL}/.well-known/jwks.json`
 - The middleware fetches and caches keys automatically
 
 ### .env file (development)
 
 ```env
 # .env — Never commit to source control
-AUTH0_DOMAIN=your-tenant.us.auth0.com
-AUTH0_AUDIENCE=https://your-api.example.com
+ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+AUDIENCE=https://your-api.example.com
 PORT=3000
 ```
 
@@ -139,8 +141,8 @@ Set these as environment variables in your hosting platform (not in `.env` files
 
 | Variable | Example Value |
 |----------|--------------|
-| `AUTH0_DOMAIN` | `your-tenant.us.auth0.com` |
-| `AUTH0_AUDIENCE` | `https://your-api.example.com` |
+| `ISSUER_BASE_URL` | `https://your-tenant.us.auth0.com` |
+| `AUDIENCE` | `https://your-api.example.com` |
 | `PORT` | `3000` |
 
 **Never commit `.env` to source control.** Add `.env` to `.gitignore`:

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/scripts/bootstrap.mjs
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/scripts/bootstrap.mjs
@@ -48,8 +48,10 @@ async function main() {
   const envPath = path.join(projectPath, ".env")
   await writeEnvFile(
     {
-      AUTH0_DOMAIN: domain,
-      AUTH0_AUDIENCE: api.identifier,
+      // SDK-native env vars: express-oauth2-jwt-bearer auto-detects these.
+      // ISSUER_BASE_URL must include the https:// scheme.
+      ISSUER_BASE_URL: `https://${domain}`,
+      AUDIENCE: api.identifier,
     },
     envPath
   )

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/tests/evals.json
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/tests/evals.json
@@ -9,7 +9,7 @@
         "Auth0 SDK (express-oauth2-jwt-bearer) present in project",
         "Has correct import statement (express-oauth2-jwt-bearer)",
         "Auth0 SDK initialized (auth() middleware configured)",
-        "AUTH0_DOMAIN environment variable configured",
+        "ISSUER_BASE_URL environment variable configured",
         "Configures JWT Bearer token validation middleware",
         "Configures API audience for token validation",
         "Has protected API endpoint with JWT middleware",

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/tests/graders.json
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/tests/graders.json
@@ -2,7 +2,7 @@
   {"type": "matches", "pattern": "express-oauth2-jwt-bearer", "description": "Auth0 SDK (express-oauth2-jwt-bearer) present in project"},
   {"type": "matches", "pattern": "require\\s*\\(['\"]express-oauth2-jwt-bearer['\"]\\)|from\\s+['\"]express-oauth2-jwt-bearer['\"]", "description": "Has correct import statement (express-oauth2-jwt-bearer)"},
   {"type": "contains_any", "values": ["auth({", "auth()"], "description": "Auth0 SDK initialized (auth() middleware configured)"},
-  {"type": "contains", "value": "AUTH0_DOMAIN", "description": "AUTH0_DOMAIN environment variable configured"},
+  {"type": "contains", "value": "ISSUER_BASE_URL", "description": "ISSUER_BASE_URL environment variable configured"},
   {"type": "matches", "pattern": "auth\\s*\\(\\{|const\\s+\\w+\\s*=\\s*auth\\s*\\(|app\\.use\\s*\\(auth\\s*\\(", "description": "Configures JWT Bearer token validation middleware"},
   {"type": "matches", "pattern": "audience:|AUTH0_AUDIENCE|AUDIENCE", "description": "Configures API audience for token validation"},
   {"type": "matches", "pattern": "app\\.(get|post|put|delete|patch)\\s*\\([^,]+,\\s*checkJwt|app\\.use\\s*\\(checkJwt|router\\.(get|post|put|delete|patch)\\s*\\([^,]+,\\s*checkJwt", "description": "Has protected API endpoint with JWT middleware"},


### PR DESCRIPTION
## The Problem

Eval runs of `express_api_quickstart` with `gpt-5.4` (agent+mcp+skills) produced a functionally correct API (Correctness 93, Hallucination 100) but scored **0/100 on Security**, landing at grade **B (87)**.

The agent hardcoded the Auth0 domain and audience as `||` fallback defaults and never wrote a `.env`:

```javascript
const auth0Domain = process.env.AUTH0_DOMAIN || 'dev-barkbook.us.auth0.com';
const auth0Audience = process.env.AUTH0_AUDIENCE || 'https://api.barkbook.com';
```

This tripped all three security/structural graders every run:

- `No hardcoded issuer domain in source files`
- `No hardcoded audience in source files`
- `Wrote Auth0 config to .env file`

## Root Cause

Ambiguous skill wording, not a model gap. The env-var pattern was documented in `references/setup.md` and `api.md`, but the top-level `SKILL.md` Quick Start both under-emphasized writing `.env` and actively nudged toward hardcoding:

| Location | What it said | Problem |
|---|---|---|
| `SKILL.md` Step 3 | "If the user already provided their Auth0 Domain and API Audience in the prompt, **use them directly**" | "Use them directly" invites inlining literals into `server.js` |
| `SKILL.md` Step 4 | Middleware snippet uses `process.env.*` | No co-located reminder to create `.env` first |

An agent following `SKILL.md` linearly inlines the values it was handed in the prompt.

## The Fix (`SKILL.md` only)

- **Step 3:** clarify that "use them directly" means write the values to `.env` (`AUTH0_DOMAIN` / `AUTH0_AUDIENCE`) and reference via `process.env`; explicitly forbid literal values and `|| 'literal'` fallback defaults in source.
- **Step 4:** add a `.env`-first sub-step with an example `.env` and `import 'dotenv/config'`, co-located with the middleware snippet, so an agent creates `.env` before writing the middleware.
- **Common Mistakes:** add a row for hardcoded domain/audience (including `process.env.X || 'literal'` fallbacks) → fails security review → use `.env` + `process.env`.

## Expected Impact

The Security dimension should move from 0/100 toward full marks on `express_api_quickstart`, lifting the overall grade from B toward A — without touching the already-correct functionality. The Quick Start is the path agents read first, so aligning it with the env-var pattern closes the three failing graders at the source.

## Verification

Re-run the eval against this branch after merge:

```bash
REMOTE_SKILLS_BRANCH=<this-branch> npm run evals -- \
  --eval express_api_quickstart --model gpt-5.4 \
  --mode agent --tools mcp,skills
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the OAuth2 JWT Bearer skill Quick Start, setup, API, and integration guides to use `ISSUER_BASE_URL` and `AUDIENCE` from `.env`, with `auth()` defaulting to those environment values.
  * Refreshed “Common Mistakes” guidance (including correct `https://` issuer formatting), RBAC scope usage, CORS ordering, and discouraging hardcoded domain/audience literals.
* **Tests**
  * Adjusted evaluation/grader expectations to verify `ISSUER_BASE_URL` configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->