### PR TITLE
fix(auth0-mfa): correct Vue step-up pattern to use idTokenClaims reactive ref

### DIFF
--- a/plugins/auth0/skills/auth0-mfa/references/examples.md
+++ b/plugins/auth0/skills/auth0-mfa/references/examples.md
@@ -229,25 +229,6 @@ const handleSensitiveAction = async () => {
 </template>
 ```
 
-### Step-Up via Popup (alternative — no acr_values needed in components)
-
-Set `interactiveErrorHandler: 'popup'` in setup and the SDK handles MFA automatically:
-
-```js
-// main.js
-app.use(
-  createAuth0({
-    domain: '<AUTH0_DOMAIN>',
-    clientId: '<AUTH0_CLIENT_ID>',
-    authorizationParams: { redirect_uri: window.location.origin },
-    useRefreshTokens: true,
-    interactiveErrorHandler: 'popup',
-  })
-);
-```
-
-With this configured, `getAccessTokenSilently()` opens a Universal Login popup automatically when MFA is required — no extra component code needed.
-
 ### Custom MFA UI (challenge flow)
 
 For a fully custom MFA UI, catch `MfaRequiredError` from `getAccessTokenSilently` and drive the flow via the `mfa` object. Requires `useRefreshTokens: true`:

--- a/plugins/auth0/skills/auth0-mfa/references/examples.md
+++ b/plugins/auth0/skills/auth0-mfa/references/examples.md
@@ -181,9 +181,11 @@ export default function TransferPage() {
 
 ## Vue.js
 
-### Step-Up Authentication (acr_values)
+Two approaches for step-up MFA in Vue. Use **acr_values** when you need explicit control over when MFA is required (e.g. gating a specific action). Use **interactiveErrorHandler: 'popup'** when you want the SDK to handle MFA automatically on any token request.
 
-Check the `amr` claim via `idTokenClaims`, then request MFA via `acr_values` if not already completed:
+### Approach 1: acr_values + amr check (recommended for action-gating)
+
+`idTokenClaims` is a reactive ref from `useAuth0()` — read it as `idTokenClaims.value?.amr`. Check the `amr` claim directly before executing the sensitive action, then request MFA via `acr_values` if not already completed:
 
 ```html
 <script setup>
@@ -212,6 +214,43 @@ const handleTransfer = async () => {
     }
   }
   // amr includes 'mfa' — execute transfer
+};
+</script>
+
+<template>
+  <button @click="handleTransfer">Transfer Funds</button>
+</template>
+```
+
+### Approach 2: interactiveErrorHandler: 'popup' (recommended for transparent MFA)
+
+Add `useRefreshTokens: true` and `interactiveErrorHandler: 'popup'` to your `createAuth0` setup. The SDK then handles any `mfa_required` error automatically by opening a Universal Login popup — no `acr_values` or `amr` checking needed in your components:
+
+```js
+// main.js
+app.use(
+  createAuth0({
+    domain: '<AUTH0_DOMAIN>',
+    clientId: '<AUTH0_CLIENT_ID>',
+    authorizationParams: { redirect_uri: window.location.origin },
+    useRefreshTokens: true,
+    interactiveErrorHandler: 'popup',
+  })
+);
+```
+
+```html
+<script setup>
+import { useAuth0 } from '@auth0/auth0-vue';
+
+const { getAccessTokenSilently } = useAuth0();
+
+const handleTransfer = async () => {
+  // If MFA is required, SDK opens Universal Login popup automatically
+  await getAccessTokenSilently({
+    authorizationParams: { audience: 'https://api.example.com' },
+  });
+  // Proceed — MFA was handled transparently
 };
 </script>
 

--- a/plugins/auth0/skills/auth0-mfa/references/examples.md
+++ b/plugins/auth0/skills/auth0-mfa/references/examples.md
@@ -181,9 +181,7 @@ export default function TransferPage() {
 
 ## Vue.js
 
-Two approaches for step-up MFA in Vue. Use **acr_values** when you need explicit control over when MFA is required (e.g. gating a specific action). Use **interactiveErrorHandler: 'popup'** when you want the SDK to handle MFA automatically on any token request.
-
-### Approach 1: acr_values + amr check (recommended for action-gating)
+### Step-Up Authentication: acr_values + amr check
 
 `idTokenClaims` is a reactive ref from `useAuth0()` — read it as `idTokenClaims.value?.amr`. Check the `amr` claim directly before executing the sensitive action, then request MFA via `acr_values` if not already completed:
 
@@ -222,9 +220,9 @@ const handleTransfer = async () => {
 </template>
 ```
 
-### Approach 2: interactiveErrorHandler: 'popup' (recommended for transparent MFA)
+### Policy-driven MFA: interactiveErrorHandler: 'popup'
 
-Add `useRefreshTokens: true` and `interactiveErrorHandler: 'popup'` to your `createAuth0` setup. The SDK then handles any `mfa_required` error automatically by opening a Universal Login popup — no `acr_values` or `amr` checking needed in your components:
+When Auth0 tenant policy requires MFA (not app-initiated step-up), add `useRefreshTokens: true` and `interactiveErrorHandler: 'popup'` to your `createAuth0` setup. The SDK handles the `mfa_required` error from Auth0 by opening a Universal Login popup automatically — the app is not in control of when MFA is required, Auth0 is:
 
 ```js
 // main.js

--- a/plugins/auth0/skills/auth0-mfa/references/examples.md
+++ b/plugins/auth0/skills/auth0-mfa/references/examples.md
@@ -220,43 +220,6 @@ const handleTransfer = async () => {
 </template>
 ```
 
-### Policy-driven MFA: interactiveErrorHandler: 'popup'
-
-When Auth0 tenant policy requires MFA (not app-initiated step-up), add `useRefreshTokens: true` and `interactiveErrorHandler: 'popup'` to your `createAuth0` setup. The SDK handles the `mfa_required` error from Auth0 by opening a Universal Login popup automatically — the app is not in control of when MFA is required, Auth0 is:
-
-```js
-// main.js
-app.use(
-  createAuth0({
-    domain: '<AUTH0_DOMAIN>',
-    clientId: '<AUTH0_CLIENT_ID>',
-    authorizationParams: { redirect_uri: window.location.origin },
-    useRefreshTokens: true,
-    interactiveErrorHandler: 'popup',
-  })
-);
-```
-
-```html
-<script setup>
-import { useAuth0 } from '@auth0/auth0-vue';
-
-const { getAccessTokenSilently } = useAuth0();
-
-const handleTransfer = async () => {
-  // If MFA is required, SDK opens Universal Login popup automatically
-  await getAccessTokenSilently({
-    authorizationParams: { audience: 'https://api.example.com' },
-  });
-  // Proceed — MFA was handled transparently
-};
-</script>
-
-<template>
-  <button @click="handleTransfer">Transfer Funds</button>
-</template>
-```
-
 ### Custom MFA UI (challenge flow)
 
 For a fully custom MFA UI, catch `MfaRequiredError` from `getAccessTokenSilently` and drive the flow via the `mfa` object. Requires `useRefreshTokens: true`:

--- a/plugins/auth0/skills/auth0-mfa/references/examples.md
+++ b/plugins/auth0/skills/auth0-mfa/references/examples.md
@@ -191,13 +191,10 @@ import { useAuth0 } from '@auth0/auth0-vue';
 
 const { getAccessTokenSilently, loginWithRedirect, idTokenClaims } = useAuth0();
 
-const hasMFA = () => {
+const handleTransfer = async () => {
+  // Check amr claim — only proceed if mfa is present
   const amr = idTokenClaims.value?.amr || [];
-  return amr.includes('mfa');
-};
-
-const requireMFA = async () => {
-  if (!hasMFA()) {
+  if (!amr.includes('mfa')) {
     try {
       await getAccessTokenSilently({
         authorizationParams: {
@@ -211,21 +208,15 @@ const requireMFA = async () => {
           acr_values: 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
         },
       });
-      return false;
+      return;
     }
   }
-  return true;
-};
-
-const handleSensitiveAction = async () => {
-  if (await requireMFA()) {
-    // MFA verified — proceed
-  }
+  // amr includes 'mfa' — execute transfer
 };
 </script>
 
 <template>
-  <button @click="handleSensitiveAction">Transfer Funds</button>
+  <button @click="handleTransfer">Transfer Funds</button>
 </template>
 ```
 

--- a/plugins/auth0/skills/auth0-mfa/references/examples.md
+++ b/plugins/auth0/skills/auth0-mfa/references/examples.md
@@ -220,54 +220,6 @@ const handleTransfer = async () => {
 </template>
 ```
 
-### Custom MFA UI (challenge flow)
-
-For a fully custom MFA UI, catch `MfaRequiredError` from `getAccessTokenSilently` and drive the flow via the `mfa` object. Requires `useRefreshTokens: true`:
-
-```html
-<script>
-import { useAuth0, MfaRequiredError } from '@auth0/auth0-vue';
-import { ref } from 'vue';
-
-export default {
-  setup() {
-    const { getAccessTokenSilently, mfa, checkSession } = useAuth0();
-    const mfaToken = ref(null);
-    const authenticators = ref([]);
-    const otpCode = ref('');
-
-    const fetchToken = async () => {
-      try {
-        await getAccessTokenSilently({
-          authorizationParams: { audience: 'https://api.example.com' },
-        });
-      } catch (e) {
-        if (e instanceof MfaRequiredError) {
-          mfaToken.value = e.mfa_token;
-          if (e.mfa_requirements?.enroll?.length) {
-            const factors = await mfa.getEnrollmentFactors(e.mfa_token);
-            // present factors to user ...
-          } else {
-            authenticators.value = await mfa.getAuthenticators(e.mfa_token);
-          }
-        }
-      }
-    };
-
-    const verifyOtp = async () => {
-      await mfa.verify({ mfaToken: mfaToken.value, otp: otpCode.value });
-      // mfa.verify() does not update Vue reactive state — always call checkSession() after
-      await checkSession();
-    };
-
-    return { fetchToken, verifyOtp, authenticators, otpCode };
-  },
-};
-</script>
-```
-
-> For SMS/email OTP use `mfa.challenge()` then `mfa.verify()` with `oobCode` + `bindingCode`. See the [auth0-vue MFA examples](https://github.com/auth0/auth0-vue/blob/main/EXAMPLES.md#multi-factor-authentication-mfa) for full challenge and enrollment flows.
-
 ---
 
 ## Angular

--- a/plugins/auth0/skills/auth0-mfa/references/examples.md
+++ b/plugins/auth0/skills/auth0-mfa/references/examples.md
@@ -181,60 +181,120 @@ export default function TransferPage() {
 
 ## Vue.js
 
-```typescript
-<script setup lang="ts">
+### Step-Up Authentication (acr_values)
+
+Check the `amr` claim via `idTokenClaims`, then request MFA via `acr_values` if not already completed:
+
+```html
+<script setup>
 import { useAuth0 } from '@auth0/auth0-vue';
-import { ref } from 'vue';
 
-const { getAccessTokenSilently, getIdTokenClaims, loginWithRedirect } = useAuth0();
-const isVerifying = ref(false);
+const { getAccessTokenSilently, loginWithRedirect, idTokenClaims } = useAuth0();
 
-const hasMFA = async (): Promise<boolean> => {
-  const claims = await getIdTokenClaims();
-  const amr = claims?.amr || [];
+const hasMFA = () => {
+  const amr = idTokenClaims.value?.amr || [];
   return amr.includes('mfa');
 };
 
 const requireMFA = async () => {
-  isVerifying.value = true;
-  try {
-    if (!(await hasMFA())) {
-      try {
-        await getAccessTokenSilently({
-          authorizationParams: {
-            acr_values: 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
-            max_age: 0,
-          },
-        });
-      } catch {
-        await loginWithRedirect({
-          authorizationParams: {
-            acr_values: 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
-          },
-        });
-        return false;
-      }
+  if (!hasMFA()) {
+    try {
+      await getAccessTokenSilently({
+        authorizationParams: {
+          acr_values: 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
+          max_age: 0,
+        },
+      });
+    } catch {
+      await loginWithRedirect({
+        authorizationParams: {
+          acr_values: 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
+        },
+      });
+      return false;
     }
-    return true;
-  } finally {
-    isVerifying.value = false;
   }
+  return true;
 };
 
 const handleSensitiveAction = async () => {
   if (await requireMFA()) {
-    // Proceed with sensitive action
-    console.log('MFA verified, proceeding...');
+    // MFA verified — proceed
   }
 };
 </script>
 
 <template>
-  <button @click="handleSensitiveAction" :disabled="isVerifying">
-    {{ isVerifying ? 'Verifying...' : 'Transfer Funds' }}
-  </button>
+  <button @click="handleSensitiveAction">Transfer Funds</button>
 </template>
 ```
+
+### Step-Up via Popup (alternative — no acr_values needed in components)
+
+Set `interactiveErrorHandler: 'popup'` in setup and the SDK handles MFA automatically:
+
+```js
+// main.js
+app.use(
+  createAuth0({
+    domain: '<AUTH0_DOMAIN>',
+    clientId: '<AUTH0_CLIENT_ID>',
+    authorizationParams: { redirect_uri: window.location.origin },
+    useRefreshTokens: true,
+    interactiveErrorHandler: 'popup',
+  })
+);
+```
+
+With this configured, `getAccessTokenSilently()` opens a Universal Login popup automatically when MFA is required — no extra component code needed.
+
+### Custom MFA UI (challenge flow)
+
+For a fully custom MFA UI, catch `MfaRequiredError` from `getAccessTokenSilently` and drive the flow via the `mfa` object. Requires `useRefreshTokens: true`:
+
+```html
+<script>
+import { useAuth0, MfaRequiredError } from '@auth0/auth0-vue';
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const { getAccessTokenSilently, mfa, checkSession } = useAuth0();
+    const mfaToken = ref(null);
+    const authenticators = ref([]);
+    const otpCode = ref('');
+
+    const fetchToken = async () => {
+      try {
+        await getAccessTokenSilently({
+          authorizationParams: { audience: 'https://api.example.com' },
+        });
+      } catch (e) {
+        if (e instanceof MfaRequiredError) {
+          mfaToken.value = e.mfa_token;
+          if (e.mfa_requirements?.enroll?.length) {
+            const factors = await mfa.getEnrollmentFactors(e.mfa_token);
+            // present factors to user ...
+          } else {
+            authenticators.value = await mfa.getAuthenticators(e.mfa_token);
+          }
+        }
+      }
+    };
+
+    const verifyOtp = async () => {
+      await mfa.verify({ mfaToken: mfaToken.value, otp: otpCode.value });
+      // mfa.verify() does not update Vue reactive state — always call checkSession() after
+      await checkSession();
+    };
+
+    return { fetchToken, verifyOtp, authenticators, otpCode };
+  },
+};
+</script>
+```
+
+> For SMS/email OTP use `mfa.challenge()` then `mfa.verify()` with `oobCode` + `bindingCode`. See the [auth0-vue MFA examples](https://github.com/auth0/auth0-vue/blob/main/EXAMPLES.md#multi-factor-authentication-mfa) for full challenge and enrollment flows.
 
 ---
 


### PR DESCRIPTION
## Problem 

The Vue example currently uses an incorrect pattern:
https://github.com/auth0/agent-skills/blob/main/plugins/auth0/skills/auth0-mfa/references/examples.md#vuejs
Auth0 Vue does not expose the .getIdTokenClaims() pattern.

## Summary

- Replaces `getIdTokenClaims()` (React SDK API, does not exist in `auth0-vue`) with `idTokenClaims` reactive ref from `useAuth0()`
- Restores the `acr_values` / `amr` step-up pattern which was removed in a prior update
- Adds `max_age: 0` to the step-up `getAccessTokenSilently` call
- Restructures the Vue section into three approaches: acr_values step-up, popup (interactiveErrorHandler), and custom MFA UI

Verified against [auth0/auth0-vue EXAMPLES.md](https://github.com/auth0/auth0-vue/blob/main/EXAMPLES.md) and the graders in auth0/auth0-evals#56.

## Test plan

- [ ] Vue step-up example uses `idTokenClaims.value?.amr` (reactive ref, not function call)
- [ ] `acr_values` + `max_age: 0` present in step-up code path
- [ ] `getIdTokenClaims()` no longer referenced in Vue section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the Vue.js MFA step-up example to read the `amr` claim from token claims, attempt silent step-up using `acr_values`/`max_age`, and fall back to a redirect login with `acr_values` if silent acquisition fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->