### PR TITLE
feat(auth0): add Custom Token Exchange to unified skill

### DIFF
--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -98,12 +98,12 @@ rules:
   # and check_router_reachability.py, so its token budget is intentionally large
   # and can't be trimmed without dropping routes. Each intent adds a table row +
   # a Step 4 loader block, so the body grows as intents are added. Warn limit is
-  # 4100 (still catches real bloat) with the 6000 error ceiling unchanged. The
+  # 4300 (still catches real bloat) with the 6000 error ceiling unchanged. The
   # skill-description budget (200) is unchanged and enforced separately.
   context-budget:
     limits:
       skill:
-        warn: 4100
+        warn: 4300
         error: 6000
 
   # feature-audit.md and feature-healthcheck.md express Auth0 feature-gap severity

--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -87,6 +87,13 @@
       "expect_refs": ["feature-dpop/index.md", "tooling-cli/index.md", "framework-vue/index.md"]
     },
     {
+      "id": "feature-custom-token-exchange-nextjs",
+      "intent": "feature:custom-token-exchange",
+      "framework": "nextjs",
+      "tooling": "cli",
+      "expect_refs": ["feature-custom-token-exchange/index.md", "tooling-cli/index.md", "framework-nextjs/index.md"]
+    },
+    {
       "id": "guidance-token-handling",
       "intent": "guidance",
       "framework": null,

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -28,7 +28,7 @@ npx skills add auth0/agent-skills/plugins/auth0
 
 | Skill | Description | Documentation |
 |-------|-------------|---------------|
-| [auth0](skills/auth0) | Adds Auth0 authentication to any app. Covers 35+ frameworks (React, Next.js, Vue, Angular, Express, Flask, FastAPI, Spring Boot, Swift, Android, Flutter, Laravel, Go, PHP, .NET MAUI, ASP.NET Core, React Native, Expo, Ionic, and more), MFA, Organizations, custom domains, ACUL screen generation, branding, debugging auth errors, security best practices, running a tenant security & configuration audit (CheckMate), a plan-aware tenant health check, and migration from other providers. | [SKILL.md](skills/auth0/SKILL.md) |
+| [auth0](skills/auth0) | Adds Auth0 authentication to any app. Covers 35+ frameworks (React, Next.js, Vue, Angular, Express, Flask, FastAPI, Spring Boot, Swift, Android, Flutter, Laravel, Go, PHP, .NET MAUI, ASP.NET Core, React Native, Expo, Ionic, and more), MFA, Organizations, Custom Token Exchange, custom domains, ACUL screen generation, branding, debugging auth errors, security best practices, running a tenant security & configuration audit (CheckMate), a plan-aware tenant health check, and migration from other providers. | [SKILL.md](skills/auth0/SKILL.md) |
 
 ## Forcing the skill with `/auth0`
 

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -45,6 +45,7 @@ section heading (`### feature:mfa`) listing which reference files to load.
 | Build fully custom login/signup screens with your own code or framework, beyond what theme settings allow. *Auth0: Advanced Customization for Universal Login (ACUL).* | **feature:acul** |
 | Change how the login page looks — logo, colors, fonts, background, overall theme. *Auth0: branding, Universal Login customization.* | **feature:branding** |
 | Bind tokens to the client so a stolen or leaked token can't be reused/replayed from another machine. *Auth0: DPoP (Demonstrating Proof-of-Possession), sender-constrained tokens.* | **feature:dpop** |
+| Exchange a token from a legacy system or external identity provider for Auth0 tokens, or request Auth0 tokens for another API audience. *Auth0: Custom Token Exchange (CTE), RFC 8693.* | **feature:custom-token-exchange** |
 | Audit a tenant for security/config issues, report, then optionally fix findings. *Auth0: tenant audit, CheckMate.* | **audit** |
 | Check if a tenant is healthy and on the right plan — two scores + a recommendation. *Auth0: health check.* | **healthcheck** |
 | Ask for best practices, "is this secure?", how to handle tokens safely, "how should I do X". *Auth0: guidance / security.* | **guidance** |
@@ -313,6 +314,14 @@ Read: references/feature-dpop/index.md
 Read: references/tooling-{tooling}/index.md
 If a SPA framework is detected (vue/react/angular/spa-js): Read references/framework-{framework}/index.md
 DPoP is SPA-only (no SSR: Next.js/Nuxt) — feature-dpop/index.md states the exclusion.
+```
+
+### feature:custom-token-exchange
+```
+Read: references/feature-custom-token-exchange/index.md
+Read: references/tooling-{tooling}/index.md
+If framework detected: Read references/framework-{framework}/index.md
+CTE needs an application, deployed Action, and matching profile.
 ```
 
 ### guidance

--- a/plugins/auth0/skills/auth0/references/feature-custom-token-exchange/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-custom-token-exchange/index.md
@@ -1,0 +1,165 @@
+# Auth0 Custom Token Exchange (CTE)
+
+Use Custom Token Exchange (RFC 8693) when an application must exchange an
+existing external token for Auth0 access, ID, and refresh tokens: for example,
+a legacy-identity migration, an external identity-provider integration, or a
+request for a different API audience. CTE is Early Access and is available on
+B2B Professional and Enterprise plans.
+
+## Start with the security boundary
+
+CTE makes Auth0 issue tokens for the user represented by the supplied
+`subject_token`. That makes validation of the external token the security
+boundary:
+
+- Verify its signature, issuer, audience, expiry, and any application-specific
+  claims before mapping it to a user. Decoding a JWT is not validation.
+- Reject an invalid token with `api.access.rejectInvalidSubjectToken()` in the
+  CTE Action. This records the attempt for Suspicious IP Throttling.
+- Set exactly one user in the Action with either
+  `api.authentication.setUserById()` or
+  `api.authentication.setUserByConnection()` only after validation succeeds.
+- Treat the incoming token and the returned Auth0 tokens as credentials: do
+  not log them, return them to an untrusted caller, or persist them in browser
+  storage.
+
+CTE requires a first-party, OIDC-conformant application. The target API must
+allow skipping user consent because this is a non-interactive flow.
+
+## Configure the tenant and application
+
+### 1. Enable CTE on the application
+
+Confirm that the application is first-party and OIDC-conformant, then enable
+its `custom_authentication` profile type. Retrieve the active tenant and the
+application ID before making the change.
+
+```bash
+auth0 api PATCH /api/v2/clients/<client-id> \
+  --data '{
+    "token_exchange": {
+      "allow_any_profile_of_type": ["custom_authentication"]
+    }
+  }'
+```
+
+Enable the connection that the CTE Action will use for the application. A
+custom database connection with import mode enabled supports
+`setUserById()` but not `setUserByConnection()`.
+
+### 2. Create and deploy a CTE Action
+
+Create an Action with the **Custom Token Exchange** trigger. Its workflow is:
+
+1. Read `event.transaction.subject_token`.
+2. Verify the token against the external issuer's keys and required claims.
+3. Apply authorization policy for this exchange.
+4. Call `api.authentication.setUserById(auth0UserId)` for an existing Auth0
+   user, or `api.authentication.setUserByConnection(...)` when the validated
+   external identity should resolve or create a connection user.
+5. On an invalid token, call
+   `api.access.rejectInvalidSubjectToken("Invalid subject token")`; for an
+   authorization failure after successful validation, call
+   `api.access.deny(code, reason)`.
+6. Deploy the Action and record its Action ID.
+
+Do not use an Action that merely decodes an unverified JWT or trusts a user ID
+provided by the client. That lets an attacker exchange a forged token for a
+real user's Auth0 tokens.
+
+### 3. Create a profile
+
+A profile maps one `subject_token_type` to the deployed Action. The same string
+must be sent by the application for `subjectTokenType`.
+
+```bash
+auth0 api POST /api/v2/token-exchange-profiles \
+  --data '{
+    "name": "legacy-migration",
+    "subject_token_type": "urn:acme:legacy-token",
+    "action_id": "<deployed-action-id>",
+    "type": "custom_authentication"
+  }'
+```
+
+Use a unique URI for `subject_token_type`. It must be 10–100 characters and
+begin with `urn:`, `https://`, or `http://`. Do not use reserved Auth0, Okta,
+or IETF namespaces (`urn:auth0:`, `urn:okta:`, `urn:ietf:`, or their Auth0 and
+Okta HTTP(S) forms).
+
+## Exchange a token in Next.js
+
+`@auth0/nextjs-auth0` v4 provides `auth0.customTokenExchange()`. Invoke it in
+a Route Handler, Server Action, or other server-only code. A route that accepts
+a token from a browser must authenticate and authorize its caller before
+exchanging it; do not make it a public token-conversion endpoint.
+
+```ts
+// app/api/exchange-token/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { auth0 } from "@/lib/auth0";
+
+export async function POST(request: NextRequest) {
+  const session = await auth0.getSession();
+  if (!session) {
+    return NextResponse.json(
+      { code: "unauthenticated", message: "Sign in before requesting an exchange." },
+      { status: 401 }
+    );
+  }
+
+  const body = await request.json() as {
+    subjectToken?: string;
+    subjectTokenType?: string;
+  };
+  if (!body.subjectToken || !body.subjectTokenType) {
+    return NextResponse.json(
+      { code: "invalid_request", message: "subjectToken and subjectTokenType are required." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await auth0.customTokenExchange({
+      subjectToken: body.subjectToken,
+      subjectTokenType: body.subjectTokenType,
+      audience: "https://api.example.com",
+      scope: "read:data"
+    });
+
+    return NextResponse.json({ accessToken: result.accessToken });
+  } catch (error: unknown) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? String(error.code)
+        : "exchange_failed";
+
+    return NextResponse.json({ code, message: "Token exchange failed." }, { status: 400 });
+  }
+}
+```
+
+The SDK validates a missing subject token and malformed `subjectTokenType`
+before it sends the request. It throws `CustomTokenExchangeError` with codes
+including `missing_subject_token`, `invalid_subject_token_type`, and
+`exchange_failed`. Keep error details server-side; return a stable,
+non-sensitive error to the caller.
+
+The exchange does not create an Auth0 browser session. Use the returned tokens
+for the requested API; do not assume `auth0.getSession()` changes after the
+exchange.
+
+## Troubleshoot
+
+| Symptom | Check | Resolution |
+|---|---|---|
+| `exchange_failed` | Profile lookup | Confirm the client enables `custom_authentication` and the code's `subjectTokenType` exactly equals the profile's `subject_token_type`. |
+| `exchange_failed` after profile lookup | Action execution | Confirm the Action is deployed, validates the token, and calls exactly one user-setting method on successful validation. Inspect `fecte` tenant logs. |
+| `invalid_subject_token_type` | Type URI | Use a 10–100 character URI and avoid reserved IETF, Auth0, and Okta namespaces. |
+| `429 too_many_attempts` | Suspicious IP Throttling | Treat it as an attack-protection response; do not retry in a tight loop. Review the `pre-custom-token-exchange` throttle settings. |
+| No usable token after a successful call | API request | Supply the target API identifier as `audience` and request only scopes that API grants. |
+| No authenticated browser session | Expected CTE behavior | CTE returns tokens; perform a normal login flow when the application also needs a browser session. |
+
+Successful CTE transactions generate `secte` tenant logs; failed transactions
+generate `fecte` logs. Never include subject or Auth0 token values in log
+queries, application logs, or support tickets.


### PR DESCRIPTION
## Summary
- replace the obsolete standalone `auth0-custom-token-exchange` skill with the unified `feature-custom-token-exchange` reference
- route RFC 8693 / CTE requests through the `auth0` router and add a Next.js routing case
- cover application enablement, profile and Action requirements, validated subject-token handling, Next.js SDK usage, and tenant-log troubleshooting
- document Custom Token Exchange in the plugin catalog
- raise only the router context-budget warning from 4,100 to 4,300 tokens; each new router intent requires an intent row and a Step 4 block, while the 6,000-token error ceiling remains unchanged

## Router-change discipline
The existing Step 1/Step 2/Step 4 routing prose is unchanged. The `SKILL.md` diff contains only the CTE intent row and its matching CTE load block.

## Important constraints
- CTE is Early Access for B2B Professional and Enterprise.
- The feature reference follows the current Custom Token Exchange documentation: CTE Actions must validate subject tokens before setting a user, and the documented product limitation excludes specific delegation support.

## Validation
- `python3 -m json.tool evals/routing-cases.json`
- `uvx -q "skillsaw==0.16.0" --strict`
- `bash plugins/auth0/skills/auth0/scripts/validate-skill.sh`
- `python3 scripts/check_router_reachability.py plugins/auth0/skills/auth0`
- `python3 scripts/check_routing_evals.py plugins/auth0/skills/auth0`
- `git diff --check`
