### PR TITLE
fix(skills): optimize all skill descriptions per agentskills.io guide

### DIFF
--- a/plugins/auth0/skills/acul-screen-generator/SKILL.md
+++ b/plugins/auth0/skills/acul-screen-generator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: acul-screen-generator
-description: Generates complete, branded Auth0 Advanced Custom Universal Login (ACUL) screen implementations using the React or Vanilla JS SDK. Use when a developer asks to create, add, or modify ACUL login screens with custom branding, social login, theming, or specific authentication flows. Triggers on requests like "generate a custom login screen", "add a signup screen to my ACUL project", "customize my Auth0 Universal Login with our brand colors", "apply our theme to all ACUL screens", or any task involving Auth0 Universal Login customization with @auth0/auth0-acul-react or @auth0/auth0-acul-js.
+description: >
+  Use when building or customizing Auth0 Universal Login screens with full UI control — creating branded login, signup, or MFA screens using the ACUL React or Vanilla JS SDK. Use this even if the user says "custom login page", "style my Auth0 login", or "build my own Universal Login UI" without mentioning ACUL directly. Does not cover basic branding (colors/logo only) — use auth0-branding for that.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-android-major-migration/SKILL.md
+++ b/plugins/auth0/skills/auth0-android-major-migration/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-android-major-migration
-description: Use when upgrading the Auth0.Android SDK (com.auth0.android:auth0) to its next major version (v4) in a native Android app (Kotlin/Java). Optionally takes a target version as an argument; otherwise auto-resolves the latest v4 release. Detects the current version, checks prerequisites (minSdk 26, Java 17, Gradle/AGP/Kotlin), fetches the new SDK's actual source to confirm signatures, audits which Auth0 APIs the project actually uses, and applies only the breaking changes that affect real call sites — nothing else. Builds until green, then summarises what changed.
+description: >
+  Use when upgrading an Android app's Auth0 SDK (com.auth0.android:auth0) to the next major version. Detects the current version, checks prerequisites, and applies only the breaking changes that affect the project's real call sites. Use even if the user just says "update my Auth0 Android SDK" or "migrate to Auth0 Android v4".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-android/SKILL.md
+++ b/plugins/auth0/skills/auth0-android/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-android
-description: Use when adding authentication to Android applications (Kotlin/Java) with Web Auth, biometric-protected credentials, and MFA - integrates com.auth0.android:auth0 SDK for native Android apps
+description: >
+  Use when adding Auth0 login, logout, or credential management to an Android app in Kotlin or Java. Covers Web Auth, biometric-protected CredentialsManager, and MFA — even if the user just says "add login to my Android app" without mentioning Auth0. Integrates com.auth0.android:auth0.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-angular/SKILL.md
+++ b/plugins/auth0/skills/auth0-angular/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-angular
-description: Use when adding authentication to Angular applications with route guards and HTTP interceptors - integrates @auth0/auth0-angular SDK for SPAs
+description: >
+  Use when adding Auth0 login, logout, route guards, or HTTP interceptors to an Angular application. Integrates @auth0/auth0-angular for SPAs — use even if the user says "protect my Angular routes" or "add authentication to Angular" without naming the SDK.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-aspnetcore-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-aspnetcore-api/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-aspnetcore-api
-description: "Use when securing ASP.NET Core Web API endpoints with JWT Bearer token validation, scope/permission checks, or stateless auth - integrates Auth0.AspNetCore.Authentication.Api for REST APIs receiving access tokens from frontends or mobile apps. Also handles DPoP proof-of-possession token binding. Triggers on: AddAuth0ApiAuthentication, .NET Web API auth, JWT validation, UseAuthentication, UseAuthorization."
+description: >
+  Use when protecting ASP.NET Core Web API endpoints with JWT Bearer token validation, scope checks, or DPoP binding. Integrates Auth0.AspNetCore.Authentication.Api for stateless REST APIs receiving access tokens from frontends or mobile apps.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-aspnetcore-authentication/SKILL.md
+++ b/plugins/auth0/skills/auth0-aspnetcore-authentication/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-aspnetcore-authentication
-description: Use when adding login, logout, and user profile to an ASP.NET Core MVC, Razor Pages, or Blazor Server web application using cookie-based authentication - integrates Auth0.AspNetCore.Authentication for server-rendered apps with login/callback/profile/logout flows.
+description: >
+  Use when adding cookie-based login, logout, or user profile to an ASP.NET Core MVC, Razor Pages, or Blazor Server web app. Integrates Auth0.AspNetCore.Authentication — use even if the user says "add login to my .NET web app" without naming the package.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-branding/SKILL.md
+++ b/plugins/auth0/skills/auth0-branding/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-branding
-description: Use when you want to (1) brand an Auth0 tenant's Universal Login to match a website or brand assets (colors, logo, fonts, page layout, text); (2) manually update one or more branding values (logos, colors, fonts, borders, backgrounds, text strings, or the page template) without extraction; (3) rewrite login text to match a voice and tone; (4) reset branding to Auth0 defaults; or (5) check whether a tenant is set up for branding to take effect end-to-end. Does not cover Advanced Customizations for Universal Login (ACUL); use the `acul-screen-generator` skill for that.
+description: >
+  Use when customizing the look of Auth0 Universal Login to match a brand — changing colors, logo, fonts, page layout, or login text. Also use when resetting branding to defaults or checking if branding is wired up end-to-end. Does not cover full custom UI screens — use acul-screen-generator for that.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-cli/SKILL.md
+++ b/plugins/auth0/skills/auth0-cli/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-cli
-description: Reference for Auth0 CLI commands — apps, apis, users, roles, organizations, actions, logs, custom domains, universal-login, terraform, raw API mode, and --json output. Use this skill whenever you need to run Auth0 CLI commands to create or manage applications, APIs, users, roles, organizations, actions, log streams, custom domains, or Universal Login configuration, or when you need to call the Auth0 Management API directly. Trigger on prompts like "create an Auth0 app", "list my Auth0 users", "assign a role", "set up an organization", "deploy an action", "configure a custom domain", "generate Terraform for Auth0", "stream Auth0 logs", "call the Management API", or any task involving the auth0 CLI tool.
+description: >
+  Use when running Auth0 CLI commands to manage tenant resources — creating apps or APIs, managing users, roles, organizations, actions, log streams, custom domains, or Universal Login config. Also use when calling the Auth0 Management API directly via the CLI.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-custom-domains/SKILL.md
+++ b/plugins/auth0/skills/auth0-custom-domains/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-custom-domains
-description: Use when setting up, troubleshooting, managing, removing, or checking the health of an Auth0 custom authentication domain (e.g. login.example.com), OR when diagnosing an error (400/403/404/409/429) from the /custom-domains Management API — especially Free-tier 403s (credit card on file, not a plan upgrade), self-managed cert 403s, PATCH-type 400s, `operation_not_supported` on `relying_party_identifier`, and 409 domain-already-exists. Handles CNAME creation in the user's DNS provider (Cloudflare, AWS Route 53, Azure DNS automated; other registrars guided), verification polling, Multiple Custom Domains (MCD), default-domain selection, TLS policy, client-IP header, per-domain passkey relying party identifier, and domain metadata.
+description: >
+  Use when setting up, verifying, or troubleshooting a custom Auth0 login domain (e.g. login.example.com). Covers CNAME setup, verification, TLS policy, Multiple Custom Domains, and Management API errors — even if the user just says "use my own domain for Auth0 login".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-expo/SKILL.md
+++ b/plugins/auth0/skills/auth0-expo/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-expo
-description: Use when adding authentication to Expo (React Native) mobile apps — login, logout, user sessions, protected routes, biometrics, or token management. Integrates react-native-auth0 SDK with Expo Config Plugin for native iOS/Android builds. Trigger for any Expo project needing Auth0, including app.json plugin config, custom scheme setup, or credential management. Do NOT use for bare React Native CLI projects (use auth0-react-native), React web apps (use auth0-react), Next.js (use auth0-nextjs), or backend APIs.
+description: >
+  Use when adding Auth0 login, logout, or session management to an Expo app. Integrates react-native-auth0 with the Expo Config Plugin for native iOS/Android builds — use even if the user says "add login to my Expo app" without mentioning the SDK. Do not use for bare React Native CLI projects.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-express/SKILL.md
+++ b/plugins/auth0/skills/auth0-express/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-express
-description: Use when adding authentication (login, logout, protected routes) to Express.js web applications - integrates express-openid-connect for session-based auth.
+description: >
+  Use when adding session-based login, logout, or protected routes to an Express.js web application. Integrates express-openid-connect — use even if the user says "add login to my Express app" or "protect my Express routes".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-fastapi-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-fastapi-api/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-fastapi-api
-description: "Use when securing FastAPI API endpoints with JWT Bearer token validation, scope/permission checks, or stateless auth - integrates auth0-fastapi-api for REST APIs receiving access tokens from SPAs, mobile apps, or other clients. Also handles DPoP proof-of-possession token binding. Triggers on: Auth0FastAPI, FastAPI API auth, JWT validation, require_auth, DPoP."
+description: >
+  Use when protecting FastAPI endpoints with JWT Bearer token validation, scope checks, or DPoP binding. Integrates auth0-fastapi-api for stateless APIs receiving access tokens — use even if the user says "secure my FastAPI endpoints" or "validate tokens in FastAPI".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-fastify-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-fastify-api/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-fastify-api
-description: Use when securing Fastify API endpoints with JWT Bearer token validation, scope/permission checks, or stateless auth - integrates @auth0/auth0-fastify-api for REST APIs receiving access tokens from frontends or mobile apps.
+description: >
+  Use when protecting Fastify API endpoints with JWT Bearer token validation or scope checks. Integrates @auth0/auth0-fastify-api for stateless APIs receiving access tokens from frontends or mobile apps.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-fastify/SKILL.md
+++ b/plugins/auth0/skills/auth0-fastify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-fastify
-description: Use when adding authentication (login, logout, protected routes) to Fastify web applications - integrates @auth0/auth0-fastify for session-based auth. For stateless Fastify APIs use auth0-fastify-api instead.
+description: >
+  Use when adding session-based login, logout, or protected routes to a Fastify web application. Integrates @auth0/auth0-fastify — use even if the user says "add login to my Fastify app". For Fastify APIs validating Bearer tokens, use auth0-fastify-api instead.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-flask/SKILL.md
+++ b/plugins/auth0/skills/auth0-flask/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-flask
-description: Use when adding login, logout, and user profile to a Flask web application using session-based authentication - integrates auth0-server-python for server-rendered apps with login/callback/profile/logout flows.
+description: >
+  Use when adding session-based login, logout, or user profile to a Flask web application. Integrates auth0-server-python — use even if the user says "add login to my Flask app" or "protect my Flask routes".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-flutter-native/SKILL.md
+++ b/plugins/auth0/skills/auth0-flutter-native/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-flutter-native
-description: Use when adding Auth0 authentication to a Flutter mobile application (iOS/Android) — integrates the auth0_flutter SDK (native platform) for Web Auth login/logout via the system browser, with secure credential storage and biometric protection through the CredentialsManager.
+description: >
+  Use when adding Auth0 login, logout, or biometric-protected credential storage to a Flutter mobile app (iOS or Android). Integrates auth0_flutter on the native platform — use even if the user says "add login to my Flutter app".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-flutter-web/SKILL.md
+++ b/plugins/auth0/skills/auth0-flutter-web/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-flutter-web
-description: Use when adding Auth0 authentication to a Flutter web application — integrates the auth0_flutter SDK (web platform) for browser-based authentication using redirect login, popup login, and credential caching.
+description: >
+  Use when adding Auth0 login or logout to a Flutter web application. Integrates auth0_flutter on the web platform — use even if the user says "add login to my Flutter web app".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-ionic-angular/SKILL.md
+++ b/plugins/auth0/skills/auth0-ionic-angular/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-ionic-angular
-description: Use when adding Auth0 authentication to an Ionic Angular application with Capacitor — integrates @auth0/auth0-angular SDK with Capacitor Browser and App plugins for native iOS/Android deep linking, login, logout, and user profile display.
+description: >
+  Use when adding Auth0 login, logout, or deep linking to an Ionic Angular app with Capacitor. Integrates @auth0/auth0-angular with Capacitor Browser and App plugins for native iOS/Android.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-ionic-react/SKILL.md
+++ b/plugins/auth0/skills/auth0-ionic-react/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-ionic-react
-description: Use when adding Auth0 authentication to an Ionic React application with Capacitor — integrates @auth0/auth0-react SDK with Capacitor Browser and App plugins for native iOS/Android deep linking, login, logout, and user profile display.
+description: >
+  Use when adding Auth0 login, logout, or deep linking to an Ionic React app with Capacitor. Integrates @auth0/auth0-react with Capacitor Browser and App plugins for native iOS/Android.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-ionic-vue/SKILL.md
+++ b/plugins/auth0/skills/auth0-ionic-vue/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-ionic-vue
-description: Use when adding Auth0 authentication to an Ionic Vue application with Capacitor — integrates @auth0/auth0-vue SDK with Capacitor Browser and App plugins for native iOS/Android deep linking, login, logout, and user profile display.
+description: >
+  Use when adding Auth0 login, logout, or deep linking to an Ionic Vue app with Capacitor. Integrates @auth0/auth0-vue with Capacitor Browser and App plugins for native iOS/Android.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-java-mvc-common/SKILL.md
+++ b/plugins/auth0/skills/auth0-java-mvc-common/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-java-mvc-common
-description: Use when adding Auth0 login, logout, and callback handling to Java Servlet web applications - integrates com.auth0:mvc-auth-commons SDK for server-side Java apps using javax.servlet with session-based authentication. Triggers on AuthenticationController, AuthorizeUrl, Tokens, IdentityVerificationException, Java MVC auth.
+description: >
+  Use when adding Auth0 login, logout, or callback handling to a Java Servlet web application. Integrates com.auth0:mvc-auth-commons for server-side Java apps — use even if the user says "add login to my Java web app" without naming the library.
 license: MIT
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-laravel-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-laravel-api/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-laravel-api
-description: "Use when securing Laravel API endpoints with JWT Bearer token validation, scope/permission checks, or stateless auth - integrates auth0/login (laravel-auth0) with the AuthorizationGuard for REST APIs receiving access tokens from SPAs, mobile apps, or other clients. Triggers on: Laravel API auth, auth0.authorizer, AuthorizationGuard, Laravel JWT, stateless Bearer."
+description: >
+  Use when protecting Laravel API endpoints with JWT Bearer token validation or scope checks. Integrates auth0/login with the AuthorizationGuard for stateless APIs receiving access tokens.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-laravel/SKILL.md
+++ b/plugins/auth0/skills/auth0-laravel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-laravel
-description: Use when adding login, logout, and user profile to a Laravel web application using session-based authentication - integrates auth0/login (laravel-auth0) for guard-based auth with auto-registered routes.
+description: >
+  Use when adding session-based login, logout, or user profile to a Laravel web application. Integrates auth0/login (laravel-auth0) with guard-based auth — use even if the user says "add login to my Laravel app".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-maui/SKILL.md
+++ b/plugins/auth0/skills/auth0-maui/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-maui
-description: Use when adding Auth0 authentication to .NET MAUI cross-platform applications (iOS, Android, macOS, Windows) - integrates Auth0.OidcClient.MAUI NuGet package for native login, logout, token refresh, and user profile. Trigger on MAUI authentication, add login to MAUI, Auth0 MAUI, .NET MAUI auth, cross-platform mobile auth
+description: >
+  Use when adding Auth0 login, logout, or token management to a .NET MAUI cross-platform app (iOS, Android, macOS, or Windows). Integrates Auth0.OidcClient.MAUI — use even if the user says "add login to my MAUI app".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-mfa/SKILL.md
+++ b/plugins/auth0/skills/auth0-mfa/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-mfa
-description: Use when adding MFA, 2FA, TOTP, SMS codes, push notifications, passkeys, or when requiring step-up verification for sensitive operations or meeting compliance requirements (HIPAA, PCI-DSS) - covers adaptive and risk-based authentication with Auth0.
+description: >
+  Use when adding MFA or step-up authentication to an app — requiring users to verify with a second factor (TOTP, SMS, passkey, push) for login or before a sensitive action. Also use for adaptive/risk-based MFA or compliance requirements like HIPAA or PCI-DSS, even if the user just says "add two-factor auth" or "require MFA before this action".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-migration/SKILL.md
+++ b/plugins/auth0/skills/auth0-migration/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-migration
-description: Use when migrating or switching from an existing auth provider (Firebase, Cognito, Supabase, Clerk, custom auth) to Auth0 - covers bulk user import, gradual migration strategies, code migration patterns, and JWT validation updates.
+description: >
+  Use when migrating users or authentication from another provider (Firebase, Cognito, Supabase, Clerk, or custom auth) to Auth0. Covers bulk user import, gradual migration strategies, and updating JWT validation — use even if the user says "switch our auth to Auth0" or "move our users to Auth0".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-net-android/SKILL.md
+++ b/plugins/auth0/skills/auth0-net-android/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-net-android
-description: Use when adding Auth0 authentication to .NET Android applications - integrates Auth0.OidcClient.AndroidX NuGet package for native login, logout, token management, and user profile via system browser with PKCE. Trigger on .NET Android auth, .NET 8 Android auth, .NET 9 Android auth, add login to .NET Android, Auth0 Android C#, Xamarin Android auth, Auth0 OIDC Android, Chrome Custom Tabs login .NET, native Android C# authentication
+description: >
+  Use when adding Auth0 login or token management to a .NET Android application. Integrates Auth0.OidcClient.AndroidX — use even if the user says "add login to my .NET Android app" or references Xamarin Android.
 license: Apache-2.0
 metadata:
   author: Auth0 SDKs Team <auth0-sdk-cdt@okta.com>

--- a/plugins/auth0/skills/auth0-net-ios/SKILL.md
+++ b/plugins/auth0/skills/auth0-net-ios/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-net-ios
-description: Use when adding Auth0 authentication to .NET iOS applications - integrates Auth0.OidcClient.iOS NuGet package for native login, logout, token management, and user profile via ASWebAuthenticationSession with PKCE. Trigger on .NET iOS auth, .NET 8 iOS auth, .NET 9 iOS auth, add login to .NET iOS, Auth0 iOS C#, Xamarin iOS auth, Auth0 OIDC iOS, ASWebAuthenticationSession login .NET, native iOS C# authentication
+description: >
+  Use when adding Auth0 login or token management to a .NET iOS application. Integrates Auth0.OidcClient.iOS — use even if the user says "add login to my .NET iOS app" or references Xamarin iOS.
 license: Apache-2.0
 metadata:
   author: Auth0 SDKs Team <auth0-sdk-cdt@okta.com>

--- a/plugins/auth0/skills/auth0-nextjs/SKILL.md
+++ b/plugins/auth0/skills/auth0-nextjs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-nextjs
-description: Use when adding authentication to Next.js applications (login, logout, protected pages, middleware, server components) - supports App Router and Pages Router with @auth0/nextjs-auth0 SDK.
+description: >
+  Use when adding Auth0 login, logout, protected pages, or middleware to a Next.js application. Supports App Router and Pages Router with @auth0/nextjs-auth0 — use even if the user says "add login to my Next.js app" or "protect my Next.js routes".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-nuxt/SKILL.md
+++ b/plugins/auth0/skills/auth0-nuxt/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-nuxt
-description: Use when implementing Auth0 authentication in Nuxt 3/4 applications, configuring session management, protecting routes with middleware, or integrating API access tokens - provides setup patterns, composable usage, and security best practices for the @auth0/auth0-nuxt SDK
+description: >
+  Use when adding Auth0 login, logout, session management, or protected routes to a Nuxt 3 or Nuxt 4 application. Integrates @auth0/auth0-nuxt — use even if the user says "add login to my Nuxt app".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-php-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-php-api/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-php-api
-description: "Use when securing PHP API endpoints with JWT Bearer token validation, scope/permission checks, or stateless auth - integrates auth0/auth0-php SDK in API mode (STRATEGY_API) for REST APIs receiving access tokens from SPAs, mobile apps, or other clients. Triggers on: auth0-php API, PHP JWT validation, getBearerToken, STRATEGY_API, PHP Bearer auth."
+description: >
+  Use when protecting PHP API endpoints with JWT Bearer token validation or scope checks. Integrates auth0/auth0-php in API mode for stateless APIs receiving access tokens.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-php/SKILL.md
+++ b/plugins/auth0/skills/auth0-php/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-php
-description: Use when adding login, logout, and user profile to a PHP web application using session-based authentication - integrates auth0/auth0-php SDK for server-rendered apps with login/callback/profile/logout flows.
+description: >
+  Use when adding session-based login, logout, or user profile to a PHP web application. Integrates auth0/auth0-php — use even if the user says "add login to my PHP app".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-quickstart/SKILL.md
+++ b/plugins/auth0/skills/auth0-quickstart/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-quickstart
-description: Use when adding authentication or login to any app - detects your stack (React, Next.js, Vue, Nuxt, Angular, Express, Fastify, FastAPI, ASP.NET Core, React Native, Expo, Android, Swift), sets up an Auth0 account if needed, and routes to the correct SDK setup workflow.
+description: >
+  Use when adding Auth0 authentication to any app and unsure which SDK or skill to use. Detects the project's framework and routes to the right setup workflow — use this as the entry point even if the user just says "add login to my app" or "set up Auth0" without naming a framework.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-react-native/SKILL.md
+++ b/plugins/auth0/skills/auth0-react-native/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-react-native
-description: Use when adding authentication to React Native or Expo mobile apps (iOS/Android) with biometric support - integrates react-native-auth0 SDK with native deep linking
+description: >
+  Use when adding Auth0 login, logout, or biometric auth to a bare React Native app (not Expo). Integrates react-native-auth0 with native deep linking.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-react/SKILL.md
+++ b/plugins/auth0/skills/auth0-react/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-react
-description: Use when adding authentication to React applications (login, logout, user sessions, protected routes) - integrates @auth0/auth0-react SDK for SPAs with Vite or Create React App
+description: >
+  Use when adding Auth0 login, logout, protected routes, or user sessions to a React SPA. Integrates @auth0/auth0-react — use even if the user says "add login to my React app" or "protect my React routes" without naming the SDK.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-spa-js/SKILL.md
+++ b/plugins/auth0/skills/auth0-spa-js/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-spa-js
-description: Use when adding authentication to Vanilla JS, Svelte, or any framework-agnostic single-page applications - integrates @auth0/auth0-spa-js SDK for SPAs without framework-specific wrappers
+description: >
+  Use when adding Auth0 login or token management to a Vanilla JS, Svelte, or framework-agnostic SPA. Integrates @auth0/auth0-spa-js — use when there is no framework-specific Auth0 SDK available.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-springboot-api/SKILL.md
+++ b/plugins/auth0/skills/auth0-springboot-api/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-springboot-api
-description: Use when securing Spring Boot API endpoints with JWT Bearer token validation, scope-based authorization, or DPoP proof-of-possession - integrates com.auth0:auth0-springboot-api SDK for REST APIs receiving access tokens from frontends or mobile apps. Triggers on Auth0AuthenticationFilter, Spring Boot API auth, JWT validation, SecurityFilterChain, hasAuthority SCOPE.
+description: >
+  Use when protecting Spring Boot API endpoints with JWT Bearer token validation, scope-based authorization, or DPoP binding. Integrates com.auth0:auth0-springboot-api for REST APIs receiving access tokens.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-swift-major-migration/SKILL.md
+++ b/plugins/auth0/skills/auth0-swift-major-migration/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-swift-major-migration
-description: "Migrates Auth0.swift v2.x integrations to v3.x. Pass a target v3 tag as an argument (e.g. auth0-swift-major-migration 3.0.0-beta.2) to pin a specific version, or omit it to auto-resolve the latest v3 release. Detects the current version, fetches the new SDK's actual source to confirm signatures, audits which Auth0 APIs the project actually uses, and applies only the breaking changes that affect real call sites — nothing else. Builds until green, then summarises what changed."
+description: >
+  Use when upgrading an iOS or macOS app's Auth0.swift SDK from v2 to v3. Detects the current version, fetches the new SDK source to confirm API signatures, and applies only the breaking changes that affect real call sites — use even if the user says "update my Auth0 Swift SDK" or "migrate to Auth0.swift v3".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-swift/SKILL.md
+++ b/plugins/auth0/skills/auth0-swift/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-swift
-description: Use when adding Auth0 authentication to an iOS, macOS, tvOS, watchOS, or visionOS application — integrates the Auth0.swift SDK for native Apple platform authentication using Web Auth, CredentialsManager, and biometric protection.
+description: >
+  Use when adding Auth0 login, logout, or biometric-protected credential storage to an iOS, macOS, tvOS, watchOS, or visionOS app. Integrates Auth0.swift — use even if the user says "add login to my iOS app" or "add login to my Swift app".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-vue/SKILL.md
+++ b/plugins/auth0/skills/auth0-vue/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-vue
-description: Use when adding authentication to Vue.js 3 applications (login, logout, user sessions, protected routes) - integrates @auth0/auth0-vue SDK for SPAs with Vite or Vue CLI
+description: >
+  Use when adding Auth0 login, logout, protected routes, or user sessions to a Vue 3 SPA. Integrates @auth0/auth0-vue — use even if the user says "add login to my Vue app" or "protect my Vue routes" without naming the SDK.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/auth0-winforms/SKILL.md
+++ b/plugins/auth0/skills/auth0-winforms/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-winforms
-description: Use when adding Auth0 authentication to Windows Forms (WinForms) desktop applications - integrates Auth0.OidcClient.WinForms NuGet package for native login, logout, token refresh, and user profile. Trigger on WinForms authentication, add login to WinForms, Auth0 WinForms, .NET Windows Forms auth, Windows desktop auth
+description: >
+  Use when adding Auth0 login, logout, or token management to a Windows Forms (WinForms) desktop application. Integrates Auth0.OidcClient.WinForms — use even if the user says "add login to my WinForms app" or "add Auth0 to my Windows desktop app".
 license: Apache-2.0
 metadata:
   author: Auth0 SDKs Team <auth0-sdk-cdt@okta.com>

--- a/plugins/auth0/skills/auth0-wpf/SKILL.md
+++ b/plugins/auth0/skills/auth0-wpf/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auth0-wpf
-description: Use when adding Auth0 authentication to WPF (Windows Presentation Foundation) desktop applications - integrates Auth0.OidcClient.WPF NuGet package for native login, logout, token refresh, and user profile. Trigger on WPF authentication, add login to WPF, Auth0 WPF, .NET WPF auth, Windows desktop auth
+description: >
+  Use when adding Auth0 login, logout, or token management to a WPF desktop application. Integrates Auth0.OidcClient.WPF — use even if the user says "add login to my WPF app" or "add Auth0 to my Windows desktop app".
 license: Apache-2.0
 metadata:
   author: Auth0 SDKs Team <auth0-sdk-cdt@okta.com>

--- a/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
+++ b/plugins/auth0/skills/express-oauth2-jwt-bearer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: express-oauth2-jwt-bearer
-description: Use when adding Auth0 token validation to Express or Node.js APIs - integrates express-oauth2-jwt-bearer SDK to protect Node.js API endpoints with JWT Bearer authentication, scope-based RBAC, claim validation, and optional DPoP support
+description: >
+  Use when protecting Express or Node.js API endpoints with JWT Bearer token validation, scope-based access control, or DPoP binding. Integrates express-oauth2-jwt-bearer — use even if the user says "validate tokens in my Express API" or "protect my Node.js API endpoints".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>

--- a/plugins/auth0/skills/go-jwt-middleware/SKILL.md
+++ b/plugins/auth0/skills/go-jwt-middleware/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: go-jwt-middleware
-description: Use when securing Go HTTP API endpoints with JWT Bearer token validation, scope/permission checks, or stateless auth. Integrates github.com/auth0/go-jwt-middleware/v3 for REST APIs receiving access tokens from frontends or mobile apps. Also handles DPoP proof-of-possession token binding. Triggers on jwtmiddleware, go-jwt-middleware, Go API auth, JWT validation, CheckJWT.
+description: >
+  Use when protecting Go HTTP API endpoints with JWT Bearer token validation or scope checks. Integrates go-jwt-middleware/v3 — use even if the user says "validate tokens in my Go API" or "secure my Go HTTP endpoints".
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>


### PR DESCRIPTION
## Summary

Rewrites the `description` field in all 44 `SKILL.md` files following the [agentskills.io optimizing-descriptions guide](https://agentskills.io/skill-creation/optimizing-descriptions).

Key changes:
- **Imperative phrasing** — all descriptions now start with "Use when..." instead of describing what the skill does
- **User intent focus** — descriptions describe what the user is trying to achieve, not the skill's internal mechanics
- **Explicit scope hints** — added "use even if the user says X without mentioning Y" to improve triggering on indirect requests
- **No keyword lists** — removed all "Triggers on:", comma-separated keyword dumps, and "Also handles:" patterns
- **Under 1024 chars** — all descriptions within the spec limit

## Test plan

- [x] `uvx skillsaw --strict` passes with 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated skill descriptions across all Auth0 integrations to provide clearer guidance on when and how to use each skill, including explicit use cases, supported frameworks/platforms, and related SDKs. Enhanced descriptions now better distinguish between skills with overlapping scopes (e.g., `acul-screen-generator` vs. `auth0-branding`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->