### PR TITLE
fix(coderabbit): flag bad skill descriptions during PR review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,7 +16,13 @@ reviews:
 
         Frontmatter:
         - `name` (required): max 64 chars, lowercase letters/numbers/hyphens only, must not start/end with hyphen, no consecutive hyphens, must match the parent directory name.
-        - `description` (required): max 1024 chars, must describe what the skill does AND when to use it. Flag vague descriptions.
+        - `description` (required): max 1024 chars. Flag any description that:
+            - Does NOT start with imperative phrasing ("Use when...", "Use this skill when...", "Use to...")
+            - Starts with a noun phrase or passive form ("This skill...", "Handles...", "Provides...")
+            - Contains keyword-dump patterns: "Triggers on:", "Also handles:", or comma-separated keyword lists
+            - Describes internal mechanics rather than user intent (what the user is trying to achieve)
+            - Missing scope hints for indirect invocation (e.g. "even if the user doesn't mention Auth0 explicitly")
+            - Exceeds 1024 characters
         - `license`: should be "Apache-2.0" for this repo.
         - `metadata.author`: should be present (e.g. "Auth0 <support@auth0.com>").
         - `metadata.version`: should be a semver string.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,10 +19,9 @@ reviews:
         - `description` (required): max 1024 chars. Flag any description that:
             - Does NOT start with imperative phrasing ("Use when...", "Use this skill when...", "Use to...")
             - Starts with a noun phrase or passive form ("This skill...", "Handles...", "Provides...")
-            - Contains keyword-dump patterns: "Triggers on:", "Also handles:", or comma-separated keyword lists
+            - Contains keyword-dump patterns: "Triggers on:", "Also handles:", or bare enumeration labels
             - Describes internal mechanics rather than user intent (what the user is trying to achieve)
             - Missing scope hints for indirect invocation (e.g. "even if the user doesn't mention Auth0 explicitly")
-            - Exceeds 1024 characters
         - `license`: should be "Apache-2.0" for this repo.
         - `metadata.author`: should be present (e.g. "Auth0 <support@auth0.com>").
         - `metadata.version`: should be a semver string.


### PR DESCRIPTION
## Summary

Extends `.coderabbit.yaml` path instructions for `plugins/**/SKILL.md` so CodeRabbit flags poor `description` fields automatically on every PR.

CodeRabbit will now flag descriptions that:
- Don't open with imperative phrasing (`Use when...`, `Use this skill when...`)
- Use passive/noun openers (`This skill...`, `Handles...`, `Provides...`)
- Contain keyword-dump patterns (`Triggers on:`, `Also handles:`, comma-separated keyword lists)
- Describe internal mechanics instead of user intent
- Are missing scope hints for indirect invocation
- Exceed 1024 characters

#### We are adding guardrails at PR review level

## Motivation

PR #133 had to manually rewrite all 44 skill descriptions because no automated gate caught the pattern drift. This change closes that gap so regressions are caught at review time.

## Test plan

- [x] `.coderabbit.yaml` is valid YAML
- [x] Rules align with the [agentskills.io optimizing-descriptions guide](https://agentskills.io/skill-creation/optimizing-descriptions)