### PR TITLE
fix(auth0): use `formula` for brew installs, not `package`

### DIFF
--- a/.skillsaw/rules.py
+++ b/.skillsaw/rules.py
@@ -665,13 +665,13 @@ class SkillOpenclawMetadataRule(Rule):
                         violations.append(
                             self.violation(
                                 f"metadata.openclaw.install[{i}] must be a mapping with "
-                                "'id', 'kind', 'package', 'bins', and 'label' fields.",
+                                "'id', 'kind', 'formula', 'bins', and 'label' fields.",
                                 file_path=skill_md
                             )
                         )
                         continue
                     missing = [
-                        k for k in ('id', 'kind', 'package', 'bins', 'label')
+                        k for k in ('id', 'kind', 'formula', 'bins', 'label')
                         if not entry.get(k)
                     ]
                     if missing:

--- a/plugins/auth0/skills/auth0-branding/SKILL.md
+++ b/plugins/auth0/skills/auth0-branding/SKILL.md
@@ -18,7 +18,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/auth0-cli/SKILL.md
+++ b/plugins/auth0/skills/auth0-cli/SKILL.md
@@ -18,7 +18,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/auth0-custom-domains/SKILL.md
+++ b/plugins/auth0/skills/auth0-custom-domains/SKILL.md
@@ -18,7 +18,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/auth0-dpop/SKILL.md
+++ b/plugins/auth0/skills/auth0-dpop/SKILL.md
@@ -17,7 +17,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/auth0-mfa/SKILL.md
+++ b/plugins/auth0/skills/auth0-mfa/SKILL.md
@@ -18,7 +18,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/auth0-migration/SKILL.md
+++ b/plugins/auth0/skills/auth0-migration/SKILL.md
@@ -18,7 +18,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/auth0-quickstart/SKILL.md
+++ b/plugins/auth0/skills/auth0-quickstart/SKILL.md
@@ -18,7 +18,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/auth0-react/SKILL.md
+++ b/plugins/auth0/skills/auth0-react/SKILL.md
@@ -20,7 +20,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/go-jwt-middleware/SKILL.md
+++ b/plugins/auth0/skills/go-jwt-middleware/SKILL.md
@@ -20,12 +20,12 @@ metadata:
     install:
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
       - id: brew
         kind: brew
-        package: gh
+        formula: gh
         bins: [gh]
         label: 'Install GitHub CLI (brew)'
 ---


### PR DESCRIPTION
## What

Renames `package` → `formula` in the Homebrew install entries of 9 skills under `plugins/auth0/skills/`. `package` is the field for `kind: node`/`uv` installs; `kind: brew` reads `formula` (or `cask`).

## Why it's a real bug (not cosmetic)

OpenClaw's skill installer parses a `kind: brew` entry by reading `formula`/`cask`; an entry with only `package` is missing its required field and is **silently dropped** — the brew installer never appears in `openclaw skills info`, so on a machine without the CLI already present these skills have **no working install path**.

### Verified in a container with Homebrew actually installed

OpenClaw 2026.6.11, Homebrew 4.6.20 present, using a minimal brew-only skill toggled between the two forms:

**As published (`kind: brew` + `package`):**
```
$ openclaw skills info <skill> --json   →   "install": []
$ openclaw skills info <skill>          →   (no Install options)
```
**After fix (`kind: brew` + `formula`):**
```
$ openclaw skills info <skill> --json   →   "install": [ { "id": "brew", "kind": "brew", ... } ]
$ openclaw skills info <skill>          →   Install options:
                                              → Install ... (brew)
```

The drop happens at parse time, so it fails **even with brew installed**.

## Scope

10 brew entries across 9 skills; the values (`auth0/auth0-cli/auth0`, `gh`) are already valid Homebrew tap/formula names, so only the key changes:

```diff
       - id: brew
         kind: brew
-        package: auth0/auth0-cli/auth0
+        formula: auth0/auth0-cli/auth0
```

Found with [skillsaw](https://skillsaw.org/rules/openclaw-metadata/)'s `openclaw-metadata` rule; the fixed tree lints clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated multiple plugin guides’ Homebrew install examples to use the `formula` format (instead of `package`) for the Auth0 CLI.
  * Ensured consistency across related setup instructions, including additional tooling where applicable.

* **Bug Fixes**
  * Adjusted metadata validation to accept the Homebrew `formula`-based install entries, aligning checks with the updated documentation format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->