### PR TITLE
feat(auth0): add tenant security audit with gated remediation

### DIFF
--- a/evals/behavioral/README.md
+++ b/evals/behavioral/README.md
@@ -30,8 +30,8 @@ behavioral/
 └── cases/
     ├── flask.json        # { slug, origin_skill, evals[], graders[] }
     ├── express-jwt.json
-    └── ...               # 17 cases; 13 have machine graders,
-                          # 4 (branding, custom-domains, cli, acul) are
+    └── ...               # 18 cases; 13 have machine graders,
+                          # 5 (branding, custom-domains, cli, acul, audit) are
                           # expectations-only → manual transcript review
 ```
 
@@ -98,3 +98,34 @@ end of the reply, so a judge that reasons before concluding is read correctly).
 Don't hardcode a specific SDK version in a grader — the references deliberately
 teach "use the current version," so a `"^1.7.4"`-style pin tests removed advice
 and rots on every release. Match "a version is present" only if you must.
+
+### Why the tenant-workflow cases have no machine graders
+
+The `audit` case is expectations-only because it **can't run unattended**: it needs
+`auth0 login` against a real tenant plus a live CheckMate scan, so it mutates real
+infrastructure and consumes Management API rate limit rather than working in a temp
+dir. Grade it by reading the transcript against the `assertions` list.
+
+The pre-migration `auth0-checkmate` skill did carry a `tests/graders.json`, but it
+was never executable: that skill shipped no `run-evals.mjs` (only 5 of the ~44
+skills did), and no `prompt.md` / `benchmark-config.json`, which the old runner
+required. Its grader set also had no `judge` grader, which that runner's own
+validation gate demanded. So nothing was regressed by not porting it — there was
+no passing baseline to preserve.
+
+Two things to fix first if you do port it:
+
+- The workspace scan won't see the deliverable by default. Reports land in
+  `$HOME/Documents/auth0_checkmate_reports` and state in `~/.auth0-checkmate/state/`,
+  both outside `workspaceDir`, and `.md` is not in `SOURCE_EXTENSIONS` — so the
+  markdown brief is invisible even when the path lines up. With no positive grader
+  passing, the empty-workspace guard then demotes every `not_contains` to FAIL.
+  Either have the eval prompt write the report into the cwd (grading the `.html`
+  copy works today) or teach the engine about the artifact directory and `.md`.
+- Two of the original eight graders fail a *spec-correct* run. `not_contains:
+  "fit score"` false-positives on the legitimate `a4aa_fit_score` and "Capability
+  Fit Score" the report is supposed to contain — use `not_matches` on
+  `sales fit score|firmographic` instead. And `matches: "<tenant_domain>|..."` is
+  backwards: it asserts placeholder tokens are still present, while the audit
+  reference's own final lint requires zero placeholders remain, so it only passes
+  when the skill misbehaves. Drop it.

--- a/evals/behavioral/cases/audit.json
+++ b/evals/behavioral/cases/audit.json
@@ -1,7 +1,7 @@
 {
   "slug": "audit",
-  "origin_skill": "auth0-checkmate",
-  "skill_name": "auth0-checkmate",
+  "origin_skill": "auth0",
+  "skill_name": "auth0",
   "evals": [
     {
       "id": 1,
@@ -17,7 +17,7 @@
         "Gathers lightweight company context for acmecorp.io (business model, products, auth surfaces)",
         "Produces a findings list with severity, title, and personalized remediation notes",
         "Triages findings into Immediate Actions (current plan) vs After Upgrading (requires upgrade)",
-        "Emits a plan recommendation with exact cost from the pricing reference",
+        "Emits a plan recommendation with plan name only and no price",
         "Saves report as auth0checkmate_<tenant>_<timestamp>.{md,html,pdf}",
         "State written to ~/.auth0-checkmate/state/ (not ~/.claude/skills/)",
         "Does not include sales fit scores or firmographic data in the report"

--- a/evals/behavioral/cases/audit.json
+++ b/evals/behavioral/cases/audit.json
@@ -1,0 +1,40 @@
+{
+  "slug": "audit",
+  "origin_skill": "auth0-checkmate",
+  "skill_name": "auth0-checkmate",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run an Auth0 CheckMate tenant audit for the company acmecorp.io. The Auth0 tenant is acmecorp.us.auth0.com. Generate a personalized security/configuration report as a PDF.",
+      "expected_output": "Phased CheckMate audit producing a personalized Auth0 Platform Development Review with triaged findings, immediate vs. post-upgrade action lists, and a plan recommendation. Report saved as markdown, HTML, and PDF.",
+      "files": [],
+      "assertions": [
+        "Bootstraps the Auth0 CLI (auth0 login or verifies existing session)",
+        "Creates or reuses a dedicated CheckMate M2M application in the tenant",
+        "Writes credentials to ~/.auth0-checkmate.env with mode 600 (chmod 600)",
+        "Substitutes <tenant_domain>, <client_id>, and <client_secret> before writing the env file",
+        "Runs the CheckMate audit tool against the tenant",
+        "Gathers lightweight company context for acmecorp.io (business model, products, auth surfaces)",
+        "Produces a findings list with severity, title, and personalized remediation notes",
+        "Triages findings into Immediate Actions (current plan) vs After Upgrading (requires upgrade)",
+        "Emits a plan recommendation with exact cost from the pricing reference",
+        "Saves report as auth0checkmate_<tenant>_<timestamp>.{md,html,pdf}",
+        "State written to ~/.auth0-checkmate/state/ (not ~/.claude/skills/)",
+        "Does not include sales fit scores or firmographic data in the report"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I already have my Auth0 tenant set up and the M2M app created. Just run CheckMate and give me the findings — skip the bootstrap steps.",
+      "expected_output": "CheckMate audit skipping Phase 1/2 bootstrap if credentials exist, producing findings and a report.",
+      "files": [],
+      "assertions": [
+        "Reads existing credentials from ~/.auth0-checkmate.env or ~/.auth0-checkmate/state/setup.json",
+        "Skips M2M app creation if client_id is already cached",
+        "Runs the CheckMate audit and parses data.report.summary[]",
+        "Produces a report with triaged findings"
+      ]
+    }
+  ],
+  "graders": null
+}

--- a/evals/behavioral/cases/audit.json
+++ b/evals/behavioral/cases/audit.json
@@ -1,6 +1,6 @@
 {
   "slug": "audit",
-  "origin_skill": "auth0",
+  "origin_skill": "auth0-checkmate",
   "skill_name": "auth0",
   "evals": [
     {

--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -129,6 +129,13 @@
       "framework": "nextjs",
       "tooling": "terraform",
       "expect_refs": ["feature-migration.md", "tooling-terraform.md", "framework-nextjs.md"]
+    },
+    {
+      "id": "audit-tenant",
+      "intent": "audit",
+      "framework": null,
+      "tooling": "cli",
+      "expect_refs": ["feature-audit.md", "feature-audit-pricing.md", "feature-audit-remediation.md", "tooling-cli.md"]
     }
   ]
 }

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -28,7 +28,7 @@ npx skills add auth0/agent-skills/plugins/auth0
 
 | Skill | Description | Documentation |
 |-------|-------------|---------------|
-| [auth0](skills/auth0) | Adds Auth0 authentication to any app. Covers 35+ frameworks (React, Next.js, Vue, Angular, Express, Flask, FastAPI, Spring Boot, Swift, Android, Flutter, Laravel, Go, PHP, .NET MAUI, ASP.NET Core, React Native, Expo, Ionic, and more), MFA, Organizations, custom domains, ACUL screen generation, branding, debugging auth errors, security best practices, and migration from other providers. | [SKILL.md](skills/auth0/SKILL.md) |
+| [auth0](skills/auth0) | Adds Auth0 authentication to any app. Covers 35+ frameworks (React, Next.js, Vue, Angular, Express, Flask, FastAPI, Spring Boot, Swift, Android, Flutter, Laravel, Go, PHP, .NET MAUI, ASP.NET Core, React Native, Expo, Ionic, and more), MFA, Organizations, custom domains, ACUL screen generation, branding, debugging auth errors, security best practices, running a tenant security & configuration audit (CheckMate), and migration from other providers. | [SKILL.md](skills/auth0/SKILL.md) |
 
 ## Forcing the skill with `/auth0`
 

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auth0
-description: Use when adding, fixing, or improving authentication in any app — login, logout, signup, route protection, JWT/access token validation, refresh token rotation, MFA, passkeys, step-up auth, SSO, RBAC, Organizations for B2B multi-tenant SaaS, custom login domains, ACUL, or Universal Login branding. Use even if Auth0 isn't mentioned — any time a developer asks how to authenticate users, secure an API, debug a 401, CORS error, callback URL mismatch, redirect loop, or 429 rate limit, or migrate from Clerk, NextAuth.js, Firebase Auth, Supabase, Cognito, or Passport.js. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, FastAPI, Spring Boot, Go, Swift, Android, Flutter, PHP, Laravel, ASP.NET Core, React Native, Expo, Ionic, and all Auth0 SDKs.
+description: Use when adding, fixing, or improving authentication in any app — login, logout, signup, route protection, JWT/access token validation, refresh token rotation, MFA, passkeys, step-up auth, SSO, RBAC, Organizations for B2B multi-tenant SaaS, custom login domains, ACUL, or Universal Login branding. Use to audit a tenant (CheckMate) or fix findings. Use even if Auth0 isn't mentioned — any time a developer asks how to authenticate users, secure an API, debug a 401, CORS error, callback URL mismatch, redirect loop, or 429 rate limit, or migrate from Clerk, NextAuth.js, Firebase, Supabase, Cognito, or Passport.js. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, FastAPI, Spring Boot, Go, Swift, Android, Flutter, PHP, Laravel, ASP.NET Core, React Native, Expo, Ionic, and all Auth0 SDKs.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
@@ -45,6 +45,7 @@ section heading (`### feature:mfa`) listing which reference files to load.
 | Build fully custom login/signup screens with your own code or framework, beyond what theme settings allow. *Auth0: Advanced Customization for Universal Login (ACUL).* | **feature:acul** |
 | Change how the login page looks — logo, colors, fonts, background, overall theme. *Auth0: branding, Universal Login customization.* | **feature:branding** |
 | Bind tokens to the client so a stolen or leaked token can't be reused/replayed from another machine. *Auth0: DPoP (Demonstrating Proof-of-Possession), sender-constrained tokens.* | **feature:dpop** |
+| Audit an existing Auth0 tenant for security & configuration issues and produce a report — run CheckMate, get a tenant configuration / platform development review, then optionally fix findings via the CLI. *Auth0: tenant audit, CheckMate.* | **audit** |
 | Ask for best practices, "is this secure?", how to handle tokens safely, "how should I do X". *Auth0: guidance / security.* | **guidance** |
 | Hit an error: 401 Unauthorized, 403 Forbidden, CORS, callback URL mismatch, redirect loop. *Auth0: debugging.* | **debug** |
 | Hit rate limiting: 429 Too Many Requests, quota exceeded. *Auth0: rate limits.* | **debug:rate-limit** |
@@ -337,6 +338,15 @@ Read: references/pattern-rate-limiting.md
 Read: references/feature-migration.md
 Read: references/tooling-{tooling}.md
 If framework detected: Read references/framework-{framework}.md
+```
+
+### audit
+```
+Read: references/feature-audit.md
+Read: references/feature-audit-pricing.md
+Read: references/feature-audit-remediation.md
+Read: references/tooling-{tooling}.md
+Apply findings only with per-command confirmation; verify each change by re-fetch.
 ```
 
 ### upgrade-sdk

--- a/plugins/auth0/skills/auth0/assets/audit/report-template.html
+++ b/plugins/auth0/skills/auth0/assets/audit/report-template.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<!--
+  Locked HTML report template for the audit workflow (feature-audit reference).
+  Phase 5 (report generation) substitutes every placeholder token with the same data feeding report-template.md.
+  Visual design models the "Auth0 Platform Development Review" reference layout (orange brand accent, severity-coded chips, four-section structure).
+  Render to PDF with scripts/render_pdf.sh (Chrome headless).
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Auth0 Platform Development Review — {{customer_name}}</title>
+<style>
+  :root {
+    --orange: #E94B1F;
+    --orange-soft: #FCE9E2;
+    --ink: #1A1A2E;
+    --ink-soft: #4F4F66;
+    --line: #E6E6EE;
+    --bg: #FFFFFF;
+    --severity-high: #C8260A;
+    --severity-moderate: #C46B1D;
+    --severity-low: #1F6FB5;
+    --severity-pass: #1F8A4C;
+  }
+  @page {
+    size: Letter;
+    margin: 0.6in 0.7in 0.7in 0.7in;
+    @bottom-right {
+      content: "{{review_month_year}}";
+      font: 9pt -apple-system, "Segoe UI", sans-serif;
+      color: var(--ink-soft);
+    }
+    @bottom-left {
+      content: "Confidential · Auth0 tenant configuration review for {{customer_name}}";
+      font: 9pt -apple-system, "Segoe UI", sans-serif;
+      color: var(--ink-soft);
+    }
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    padding: 0;
+    color: var(--ink);
+    background: var(--bg);
+    font-family: -apple-system, "Inter", "Segoe UI", system-ui, sans-serif;
+    font-size: 10.5pt;
+    line-height: 1.45;
+  }
+  .header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding-bottom: 14pt;
+    border-bottom: 3pt solid var(--orange);
+    margin-bottom: 18pt;
+  }
+  .header h1 {
+    font-size: 24pt;
+    font-weight: 700;
+    margin: 0 0 4pt 0;
+    line-height: 1.15;
+  }
+  .header .subtitle {
+    color: var(--ink-soft);
+    font-size: 11pt;
+  }
+  .plan-badge {
+    border: 1.5pt solid var(--orange);
+    color: var(--orange);
+    border-radius: 18pt;
+    padding: 4pt 12pt;
+    font-size: 10pt;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .header-right {
+    text-align: right;
+    font-size: 10pt;
+    color: var(--ink-soft);
+    line-height: 1.5;
+  }
+  .header-right .plan-badge {
+    display: inline-block;
+    margin-bottom: 6pt;
+  }
+  .header-right .meta-line {
+    display: block;
+    color: var(--ink);
+  }
+  .meta-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 12pt 0 24pt 0;
+  }
+  .meta-table th, .meta-table td {
+    text-align: left;
+    padding: 10pt 12pt;
+    border-bottom: 1pt solid var(--line);
+    font-size: 10.5pt;
+  }
+  .meta-table th {
+    width: 38%;
+    color: var(--ink-soft);
+    font-weight: 500;
+  }
+  .meta-table td {
+    color: var(--ink);
+    font-weight: 600;
+  }
+  h2.section {
+    color: var(--orange);
+    text-transform: uppercase;
+    font-size: 11pt;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    margin: 22pt 0 12pt 0;
+  }
+  table.data {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 8pt 0 18pt 0;
+  }
+  table.data th {
+    text-align: left;
+    text-transform: uppercase;
+    font-size: 8.5pt;
+    letter-spacing: 0.05em;
+    color: var(--ink-soft);
+    font-weight: 600;
+    padding: 8pt 12pt;
+    border-bottom: 1pt solid var(--line);
+  }
+  table.data td {
+    padding: 11pt 12pt;
+    border-bottom: 1pt solid var(--line);
+    vertical-align: top;
+  }
+  table.data td.label {
+    font-weight: 600;
+  }
+  .severity {
+    display: inline-block;
+    margin-right: 18pt;
+    font-weight: 600;
+  }
+  .severity.high { color: var(--severity-high); }
+  .severity.moderate { color: var(--severity-moderate); }
+  .severity.low { color: var(--severity-low); }
+  .severity.pass { color: var(--severity-pass); }
+  .gap {
+    border-left: 3pt solid var(--orange);
+    padding: 4pt 0 4pt 14pt;
+    margin: 12pt 0;
+  }
+  .gap .gap-name {
+    font-weight: 700;
+    margin-bottom: 4pt;
+  }
+  .gap p { margin: 0; }
+  .opportunities th, .opportunities td {
+    vertical-align: top;
+  }
+  .opportunities .feature { font-weight: 700; width: 18%; }
+  .opportunities .challenge { width: 36%; color: var(--ink); }
+  .opportunities .solution { width: 18%; color: var(--orange); font-weight: 600; }
+  .opportunities .impact { width: 28%; color: var(--ink-soft); }
+  .roadmap-banner {
+    font-weight: 700;
+    margin: 4pt 0 12pt 0;
+  }
+  .roadmap-banner em { color: var(--orange); font-style: normal; font-weight: 700; }
+  .roadmap p { margin: 6pt 0; }
+  .actions {
+    list-style: none;
+    counter-reset: action;
+    padding: 0;
+    margin: 6pt 0 16pt 0;
+  }
+  .actions li {
+    counter-increment: action;
+    display: flex;
+    align-items: flex-start;
+    margin: 6pt 0;
+  }
+  .actions li::before {
+    content: counter(action);
+    color: var(--ink-soft);
+    font-weight: 600;
+    width: 22pt;
+    flex: 0 0 22pt;
+    text-align: left;
+  }
+  .docs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8pt 12pt;
+    margin: 8pt 0 0 0;
+  }
+  .docs a {
+    display: block;
+    padding: 10pt 14pt;
+    border: 1pt solid var(--line);
+    border-radius: 6pt;
+    color: var(--orange);
+    font-weight: 600;
+    text-decoration: none;
+    font-size: 10pt;
+  }
+  hr.section-divider {
+    border: 0;
+    border-top: 1pt solid var(--line);
+    margin: 18pt 0;
+  }
+  .small { font-size: 9pt; color: var(--ink-soft); }
+</style>
+</head>
+<body>
+
+<header class="header">
+  <div>
+    <h1>Auth0 Platform<br>Development Review</h1>
+    {{subtitle_html}}  <!-- a subtitle div reading "Prepared by <org>" if reviewer_org is non-empty; emit empty string otherwise -->
+  </div>
+  <div class="header-right">
+    <span class="plan-badge">{{plan_tag}}</span>
+    <span class="meta-line">{{customer_name}} · {{tenant_domain}}</span>
+    <span class="meta-line">{{review_date_long}}</span>
+  </div>
+</header>
+
+<table class="meta-table">
+  <tr><th>Prepared by</th><td>{{reviewer_name}}</td></tr>
+  <tr><th>Date of Review</th><td>{{review_date_long}}</td></tr>
+  <tr><th>Customer Account</th><td>{{customer_name}} ({{tenant_domain}})</td></tr>
+  <tr><th>Current Auth0 Tier</th><td>{{tier}}</td></tr>
+  <tr><th>Use Case Diagnosis</th><td>{{business_model}} — {{product_summary_short}}</td></tr>
+  <tr><th>Recommended Plan</th><td>{{recommended_plan}} · Auth for AI Agents: {{a4aa_yes_no}}</td></tr>
+</table>
+
+<h2 class="section">1. Account Health</h2>
+
+<table class="data">
+  <thead>
+    <tr><th>Metric</th><th>Status</th></tr>
+  </thead>
+  <tbody>
+    <tr><td class="label">Applications Registered</td><td>{{apps_count}}</td></tr>
+    <tr><td class="label">Login Activity</td><td>{{login_activity}}</td></tr>
+    <tr>
+      <td class="label">Security Findings</td>
+      <td>
+        <span class="severity high">{{findings_high_count}} High</span>
+        <span class="severity moderate">{{findings_moderate_count}} Moderate</span>
+        <span class="severity low">{{findings_low_count}} Low / Info</span>
+        <span class="severity pass">{{findings_passing_count}} Passing</span>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- gaps_html: rendered from the included gap callouts. Each block is a gap div with a
+     gap-name heading and a one-line body paragraph. Only include gaps the data supports. -->
+{{gaps_html}}
+
+<h2 class="section">2. Executive Summary</h2>
+
+<p>{{exec_summary_paragraph}}</p>
+
+<p><strong>Configuration Posture at a Glance</strong></p>
+
+<table class="data">
+  <thead>
+    <tr><th>Severity</th><th>Count</th><th>Key Examples</th></tr>
+  </thead>
+  <tbody>
+    <tr><td class="label" style="color:var(--severity-high)">High</td><td>{{findings_high_count}}</td><td>{{findings_high_examples}}</td></tr>
+    <tr><td class="label" style="color:var(--severity-moderate)">Moderate</td><td>{{findings_moderate_count}}</td><td>{{findings_moderate_examples}}</td></tr>
+    <tr><td class="label" style="color:var(--severity-low)">Low / Info</td><td>{{findings_low_count}}</td><td>{{findings_low_examples}}</td></tr>
+    <tr><td class="label" style="color:var(--severity-pass)">Passing</td><td>{{findings_passing_count}} of {{findings_total_count}}</td><td>{{findings_passing_examples}}</td></tr>
+  </tbody>
+</table>
+
+<h2 class="section">3. Strategic Opportunities &amp; Action Plan</h2>
+
+<table class="data opportunities">
+  <thead>
+    <tr><th>Feature Area</th><th>The Enterprise Challenge</th><th>The Solution</th><th>Strategic Impact</th></tr>
+  </thead>
+  <tbody>
+    <!-- opportunities_rows: one table row per included row — feature area, a personalized
+         challenge cell, the solution label, and the strategic impact. Every challenge cell
+         MUST name a specific product, segment, or capability from the company context. -->
+    {{opportunities_rows}}
+  </tbody>
+</table>
+
+<h2 class="section">4. Recommended Roadmap &amp; Next Steps</h2>
+
+<p class="roadmap-banner">Recommended Plan: <em>{{recommended_plan}}{{a4aa_addon_suffix}}</em></p>
+
+<div class="roadmap">
+  {{plan_recommendation_paragraphs_html}}
+</div>
+
+<p><strong>Immediate Actions — Available Today (Free)</strong></p>
+<ol class="actions">
+  <!-- immediate_actions_html: one list item per item. Each must name affected apps/connections explicitly. -->
+  {{immediate_actions_html}}
+</ol>
+
+<p><strong>After Upgrading</strong></p>
+<ol class="actions">
+  <!-- after_upgrading_html: one list item per item. -->
+  {{after_upgrading_html}}
+</ol>
+
+<p><strong>Key Documentation</strong></p>
+<div class="docs">
+  <!-- docs_html: one anchor link per included row. Match Section 3 rows. -->
+  {{docs_html}}
+</div>
+
+</body>
+</html>

--- a/plugins/auth0/skills/auth0/assets/audit/report-template.md
+++ b/plugins/auth0/skills/auth0/assets/audit/report-template.md
@@ -1,0 +1,156 @@
+# Locked report skeleton (Auth0 Platform Development Review)
+
+This is the structural contract the audit workflow reference (Phase 5, report generation) follows for the markdown brief. The HTML/PDF render uses the parallel template at [report-template.html](report-template.html) — same data, same sections, different presentation. Replace every placeholder token with values from the CheckMate report, the lightweight company context (Phase 3), and tenant facts. Visual design models the "Auth0 Platform Development Review" reference layout (orange brand accent, severity-coded chips, four-section structure).
+
+Source-of-truth reminders (see the audit workflow reference, Phase 5) — placeholder → source:
+- tenant_domain → `state/setup.json.tenant_domain` (from `auth0 tenants list --json`); never from the company context
+- customer_name, product_*, business_model, ai_use_case, integrations_* → the company context (Phase 3; sanitized — no fit scores, no firmographics)
+- recommended_plan, a4aa_yes_no → DERIVED in Phase 4 from the use case + the findings + the co-loaded pricing reference (never a company score)
+- reviewer_name, reviewer_org → `state/operator.json.reviewer_name` / `.reviewer_org`
+- plan_tag, tier → `auth0 api get tenants/settings` (fallback "Free Plan")
+- apps_count, apps_* → `auth0 apps list --json`
+- login_activity → derived from `auth0 logs list --number 50`
+- custom_domains_present, log_streams_present, mfa_configured, etc. → tenant facts from Phase 4.4
+- findings_*_count, findings_*_examples → the CheckMate report (a flat array of finding objects), grouped by severity
+
+---
+
+# Auth0 Platform Development Review
+
+{{prepared_by_line}}  <!-- the "Prepared by <org>" line if reviewer_org is non-empty; OMIT this line entirely otherwise -->
+
+> **{{plan_tag}}** · {{customer_name}} · {{tenant_domain}} · {{review_date_long}}
+
+| | |
+|---|---|
+| **Prepared by** | {{reviewer_name}} |
+| **Date of Review** | {{review_date_long}} |
+| **Customer Account** | {{customer_name}} ({{tenant_domain}}) |
+| **Current Auth0 Tier** | {{tier}} |
+| **Use Case Diagnosis** | {{business_model}} — {{product_summary_short}} |
+| **Recommended Plan** | {{recommended_plan}} · Auth for AI Agents: {{a4aa_yes_no}} |
+
+---
+
+## 1. ACCOUNT HEALTH
+
+| METRIC | STATUS |
+|---|---|
+| **Applications Registered** | {{apps_count}} |
+| **Login Activity** | {{login_activity}} |
+| **Security Findings** | **{{findings_high_count}} High** &nbsp;&nbsp; **{{findings_moderate_count}} Moderate** &nbsp;&nbsp; **{{findings_low_count}} Low / Info** &nbsp;&nbsp; **{{findings_passing_count}} Passing** |
+
+> **The Branding Gap**
+> Authentication is served from the default Auth0 domain (`{{tenant_domain}}`). {{customer_user_type_short}} accessing {{product_1}} and {{product_2}} are redirected off-brand during login — undermining trust at a critical moment in the user journey.
+>
+> *(Include only if `custom_domains` is empty.)*
+
+> **The Security Gap**
+> No MFA is configured on any application. For {{customer_user_type_short}} handling {{data_sensitivity_descriptor}}, this is a material risk and a common enterprise procurement blocker.
+>
+> *(Include only if MFA is disabled per tenant facts.)*
+
+> **The Production Readiness Gap**
+> Development URLs (`{{dev_url_example}}`) remain active in production configurations across callbacks, web origins, and logout URLs for {{app_with_dev_urls}}.
+>
+> *(Include only if CheckMate flagged dev URLs / implicit grant types — name offending app from `apps_list`.)*
+
+> **The Compliance Gap** *(optional — include when log streams empty AND regulated industry / EU tenant)*
+> No log streaming is configured. {{customer_name}} operates in {{regulated_context}} and requires {{compliance_framework}} audit trails — currently limited to Auth0's default retention window.
+
+> **The Observability Gap** *(generic version when Compliance Gap doesn't apply)*
+> No log streaming is configured. Without it, diagnosing auth issues or security incidents is limited to Auth0's default retention window.
+
+---
+
+## 2. EXECUTIVE SUMMARY
+
+{{customer_name}} has built a structured Auth0 environment supporting {{products_inline_list}} — with {{apps_count}} registered applications and {{login_activity_descriptor}} login activity.
+
+The current challenge is graduating from a working setup to a **production-grade, enterprise-ready** authentication platform. A CheckMate security audit surfaced **{{findings_high_count}} High** and **{{findings_moderate_count}} Moderate** configuration gaps across security, branding, and observability. The core architecture is solid — these gaps are directly addressable with the right plan.
+
+### Configuration Posture at a Glance
+
+| SEVERITY | COUNT | KEY EXAMPLES |
+|---|---|---|
+| **High** | {{findings_high_count}} | {{findings_high_examples}} |
+| **Moderate** | {{findings_moderate_count}} | {{findings_moderate_examples}} |
+| **Low / Info** | {{findings_low_count}} | {{findings_low_examples}} |
+| **Passing** | {{findings_passing_count}} of {{findings_total_count}} | {{findings_passing_examples}} |
+
+Examples are dot-separated finding titles (top 3-5 per row), e.g. "No custom domain · Localhost URLs in production · Implicit grant types on 4 apps".
+
+---
+
+## 3. STRATEGIC OPPORTUNITIES & ACTION PLAN
+
+| FEATURE AREA | THE ENTERPRISE CHALLENGE | THE SOLUTION | STRATEGIC IMPACT |
+|---|---|---|---|
+| **Brand Trust & UX** | Enterprise clients authenticate through `{{tenant_domain}}` — a generic Auth0 domain — breaking the {{customer_name}} brand at login and invitation acceptance. | **Custom Domains** | Keep enterprise users entirely within your brand. Critical for sales credibility and user trust. |
+| **Per-Organization Management** | {{product_1}} and {{product_2}} serve distinct enterprise accounts with no way to isolate branding, members, or access per customer on the current plan. | **Auth0 Organizations** | Onboard enterprise clients cleanly with per-org branding, member management, and connection settings — scales with your go-to-market. |
+| **Enterprise SSO** | {{customer_name}}'s enterprise clients — {{customer_user_segments}} — already have corporate identity providers (Azure AD, Okta, Google Workspace). Currently they must create separate credentials to access {{product_suite_short}}, adding friction that blocks enterprise procurement. | **Enterprise Connections (SAML / OIDC)** | Let enterprise clients log in with their existing corporate credentials. Removes a common procurement blocker and eliminates the need for a separate set of credentials for your platform. |
+| **Account Security** | No MFA is configured on any application. Enterprise procurement increasingly requires it as a baseline, especially for platforms handling {{data_sensitivity_descriptor}}. | **MFA (WebAuthn / Authenticator App)** | Reduces account takeover risk significantly. Addresses common enterprise procurement requirements{{gdpr_clause}}. |
+| **Observability** | No log streaming is configured. Without it, diagnosing auth issues or security incidents is limited to Auth0's default retention window. | **Log Streaming** | Enables SIEM integration, enterprise audit trails, and the observability required for compliance and incident response. |
+| **AI Agent Security** *(only if `ai_use_case` ∈ AI-Native/AI-Differentiated)* | {{ai_product_1}} and {{ai_product_2}} use AI to interact with third-party {{integration_domain}} services. Managing OAuth tokens for these integrations manually creates security risk and developer overhead. | **Token Vault (A4AA)** | Securely store and rotate OAuth tokens for AI agent integrations — no re-authentication required, no secrets in code. |
+| **Human-in-the-Loop AI** *(only if autonomous-action workflows in enrichment)* | High-stakes {{ai_action_domain}} actions ({{ai_action_example_1}}, {{ai_action_example_2}}) may require explicit user approval before an AI agent executes them. | **CIBA (A4AA)** | Enable async human approval for sensitive AI-driven actions from any device, without disrupting the user experience. |
+
+Include only the rows whose triggers are met. Rewrite the cell text to reference the actual customer's products / segments / data — never leave generic placeholders in the rendered output.
+
+---
+
+## 4. RECOMMENDED ROADMAP & NEXT STEPS
+
+### Recommended Plan: **{{recommended_plan}}**{{a4aa_addon_suffix}}
+
+{{plan_recommendation_paragraph}}
+
+> Example: "**B2B Essentials** unlocks Custom Domains, Organizations, Enterprise Connections, and enhanced MFA — the four highest-impact changes for {{customer_name}}'s enterprise go-to-market.
+>
+> **A4AA Add-on** directly addresses the identity challenges in AI-assisted {{ai_workflow_descriptor}} workflows via Token Vault and CIBA."
+
+### Immediate Actions — Available Today (Free)
+
+> Numbered list of CheckMate findings actionable on the **current** plan. Triage rule: if the fix can be applied with the current tier's feature set per the feature→plan matrix in the co-loaded pricing reference (source of truth — read it, don't guess), it goes here. Each item must name the affected app/connection. These items feed the remediation reference's Loop A.
+
+1. {{immediate_action_1}}
+2. {{immediate_action_2}}
+3. {{immediate_action_3}}
+<!-- continue numbering for each remaining action -->
+
+> Illustrative shape (dummy data — replace every name with the actual tenant's apps):
+> 1. Remove `http://localhost:3000` from web origins, callbacks, and logout URLs in `Customer Portal Web`
+> 2. Disable the implicit grant type on `Default App, Admin Console Web, Customer Portal Web, Mobile App` — migrate to Authorization Code + PKCE
+> 3. Enable rotating refresh tokens on `Default App, Admin Console Web`
+> 4. Configure a Custom Domain — included free (1, credit-card verification required); keeps logins on-brand without an upgrade
+
+### After Upgrading
+
+> Numbered list of fixes requiring the recommended plan. Each item describes the outcome, not the dashboard click path. These items feed the remediation reference's Loop B (gated on user confirming the upgrade).
+
+1. {{after_upgrade_action_1}}
+2. {{after_upgrade_action_2}}
+<!-- continue numbering for each remaining action -->
+
+> Example items from the reference sample (Custom Domains is NOT here — it's free; see Immediate Actions):
+> 1. Set up Auth0 Organizations + Enterprise Connections (SAML / OIDC) for your first enterprise clients (Essentials)
+> 2. Enable WebAuthn or Authenticator App MFA across enterprise user flows (Essentials — Pro MFA Factors)
+> 3. Configure an email provider and branded email templates (Essentials — Email Workflow)
+> 4. Stream logs to your observability platform (Essentials — 1 log stream)
+> 5. Switch Breached Password Detection to blocking + Enhanced Password Protection (Professional)
+> 6. Implement Token Vault / CIBA for AI agent OAuth token management (A4AA add-on)
+
+### Key Documentation
+
+| | |
+|---|---|
+| [B2B Best Practices](https://auth0.com/docs/manage-users/organizations) | [Auth0 Organizations](https://auth0.com/docs/manage-users/organizations) |
+| [Custom Domains](https://auth0.com/docs/customize/custom-domains) | [Enterprise Connections](https://auth0.com/docs/authenticate/identity-providers/enterprise-identity-providers) |
+| [Configure WebAuthn as MFA](https://auth0.com/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/webauthn) | [Log Streaming](https://auth0.com/docs/customize/log-streams) |
+| [Token Vault (A4AA)](https://auth0.com/ai/docs/get-tokens-for-tools) | [CIBA (A4AA)](https://auth0.com/ai/docs/asynchronous-authorization) |
+| [Authorization Code + PKCE](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce) | |
+
+> Include only the rows whose corresponding Section 3 row is included.
+
+---
+
+*Confidential · Auth0 tenant configuration review for {{customer_name}} · {{review_month_year}}*

--- a/plugins/auth0/skills/auth0/references/feature-audit-pricing.md
+++ b/plugins/auth0/skills/auth0/references/feature-audit-pricing.md
@@ -1,0 +1,588 @@
+# Auth0 Pricing
+
+Source: https://auth0.com/pricing
+
+Auth0 offers flexible authentication and authorization plans for both B2C (consumer-facing) and B2B (business-facing) applications. The Free plan is identical regardless of use case. Paid plans are priced by Monthly Active Users (MAUs) and differ between B2C and B2B. Yearly billing is 11× the monthly price (equivalent to 1 month free).
+
+---
+
+## How to Use This Document
+
+To quote pricing for a customer, follow these steps in order:
+
+1. **Determine use case:** B2C (consumer-facing) or B2B (business-facing).
+2. **Identify their MAU tier:** Find the tier that meets or exceeds their expected monthly active users. If usage falls between tiers, use the next tier up.
+3. **Select the plan:** Match required features against the Feature Comparison tables to determine the minimum plan (Free, Essentials, Professional, or Enterprise).
+4. **Look up the base price:** Use the appropriate B2C or B2B base price table (monthly or yearly).
+5. **Add any add-ons:** Check if the customer needs AI Agents, additional M2M tokens, Enterprise SSO connections, or Enterprise MFA. Look up each add-on price from the explicit tables.
+6. **Calculate total cost:** Total = Base Price + sum of all applicable add-on prices.
+7. **Enterprise or "Contact us" tiers:** If any component shows "Contact us", direct the customer to Auth0 sales for a custom quote.
+
+---
+
+## Key Definitions
+
+- **Monthly Active Users (MAUs):** Any non-internal (non-employee) user that authenticated during a given month for a given tenant.
+- **Organizations:** Represent their business customers and partners in Auth0 and manage their membership.
+- **Enterprise Connections:** Enterprise IdPs supporting protocols like AD, LDAP, or SAML to authenticate your users.
+
+---
+
+## Plans Overview
+
+Auth0 has four tiers: **Free**, **Essentials**, **Professional**, and **Enterprise**. Pricing differs between B2C and B2B use cases.
+
+| Plan | B2C Starting Price | B2B Starting Price | MAUs at Starting Price |
+|---|---|---|---|
+| Free | $0/month | $0/month | Up to 25,000 |
+| Essentials | $35/month | $150/month | 500 MAUs |
+| Professional | $240/month | $800/month | 500 MAUs |
+| Enterprise | Contact us | Contact us | Custom |
+
+---
+
+## Free Plan
+
+**Free — $0/month** (same for B2C and B2B)
+
+No credit card needed to sign up.
+
+- Up to 25,000 monthly active users
+- 1 Custom Domain*
+- Secure Agentic AI workflows
+- Passwordless Authentication
+- Unlimited Social Connections**
+- 5 Organizations
+- Brand Customization
+- Basic Attack Protection
+- Community Support
+- 1 Enterprise Connection (NEW)
+- Self-Service SSO (NEW)
+- SCIM (NEW)
+
+---
+
+## B2C Pricing
+
+### Plan Highlights
+
+**Essentials — from $35/month**
+- Everything in Free, plus:
+- Higher Auth, API limits, and feature limits
+- Pro Multi-Factor Authentication
+- Role-based Access Control Per Organization
+- 10 Organizations (How we model your customers)
+- Stream Auth0 Audit Logs to Datadog, Splunk, AWS, Azure, etc.
+- Separate Production & Development Environments
+- Standard Support
+- Add-ons: Enterprise MFA, Enterprise SSO Connections, M2M Tokens
+
+**Professional — from $240/month**
+- Everything in Essentials, plus:
+- Enhanced Attack Protection
+- Use your existing User Database for Logins
+- Enterprise Multi-Factor Authentication
+- Add-ons: M2M Tokens
+
+**Enterprise — Contact us**
+- Everything in Professional, plus:
+- Custom User & SSO Tiers
+- 99.99% SLA
+- Enterprise Rate Limits
+- Enterprise Administration & Support
+- Add-ons: Advanced Security Features, Private Deployment
+
+*Pricing is available only at the listed MAU tiers. If your usage falls between tiers, you are billed at the next tier up.*
+
+### B2C Base Price by MAUs (monthly)
+
+| MAUs | Essentials | Professional |
+|------|-----------|--------------|
+| 500 | $35 | $240 |
+| 1,000 | $70 | $240 |
+| 2,500 | $175 | $545 |
+| 5,000 | $350 | $1,000 |
+| 7,500 | $525 | $1,200 |
+| 10,000 | $700 | $1,600 |
+| 20,000 | $1,400 | $3,200 |
+| 30,000 | $2,100 | Contact us |
+| 40,000 | $2,800 | Not available |
+| 50,000 | $3,500 | Not available |
+
+### B2C Base Price by MAUs (yearly)
+
+| MAUs | Essentials | Professional |
+|------|-----------|--------------|
+| 500 | $385 | $2,640 |
+| 1,000 | $770 | $2,640 |
+| 2,500 | $1,925 | $5,995 |
+| 5,000 | $3,850 | $11,000 |
+| 7,500 | $5,775 | $13,200 |
+| 10,000 | $7,700 | $17,600 |
+| 20,000 | $15,400 | $35,200 |
+| 30,000 | $23,100 | Contact us |
+| 40,000 | $30,800 | Not available |
+| 50,000 | $38,500 | Not available |
+
+### B2C Add-ons
+
+**Auth0 for AI Agents**
+- Adds 50% to the base price (rounded up to the dollar)
+- Unlimited Token Vault
+- All forms of CIBA
+
+*B2C AI Agents Add-On Price by MAUs (monthly)*
+
+| MAUs | Essentials | Professional |
+|------|-----------|--------------|
+| 500 | $18 | $120 |
+| 1,000 | $35 | $120 |
+| 2,500 | $88 | $273 |
+| 5,000 | $175 | $500 |
+| 7,500 | $263 | $600 |
+| 10,000 | $350 | $800 |
+| 20,000 | $700 | $1,600 |
+| 30,000 | $1,050 | Contact us |
+| 40,000 | $1,400 | Not available |
+| 50,000 | $1,750 | Not available |
+
+*B2C AI Agents Add-On Price by MAUs (yearly — 11× monthly)*
+
+| MAUs | Essentials | Professional |
+|------|-----------|--------------|
+| 500 | $198 | $1,320 |
+| 1,000 | $385 | $1,320 |
+| 2,500 | $968 | $3,003 |
+| 5,000 | $1,925 | $5,500 |
+| 7,500 | $2,893 | $6,600 |
+| 10,000 | $3,850 | $8,800 |
+| 20,000 | $7,700 | $17,600 |
+| 30,000 | $11,550 | Contact us |
+| 40,000 | $15,400 | Not available |
+| 50,000 | $19,250 | Not available |
+
+
+**M2M Token Add-On Tier Pricing** (Professional plan only; 5,000 included)
+
+*B2C M2M Token Add-On (monthly)*
+
+| M2M Tokens | Price/month |
+|-----------|-------------|
+| 5,000 | Included |
+| 7,500 | $30 |
+| 10,000 | $40 |
+| 20,000 | $80 |
+| 30,000 | $120 |
+| 40,000 | $160 |
+| 50,000 | $200 |
+| 60,000 | $240 |
+| 70,000 | $280 |
+| 80,000 | $320 |
+| 90,000 | $360 |
+| 100,000 | $400 |
+| 125,000 | $500 |
+| 150,000 | $600 |
+| 175,000 | $700 |
+| 200,000 | $800 |
+| 250,000 | $1,000 |
+| 300,000 | $1,200 |
+
+*B2C M2M Token Add-On (yearly — 11× monthly)*
+
+| M2M Tokens | Price/year |
+|-----------|------------|
+| 5,000 | Included |
+| 7,500 | $330 |
+| 10,000 | $440 |
+| 20,000 | $880 |
+| 30,000 | $1,320 |
+| 40,000 | $1,760 |
+| 50,000 | $2,200 |
+| 60,000 | $2,640 |
+| 70,000 | $3,080 |
+| 80,000 | $3,520 |
+| 90,000 | $3,960 |
+| 100,000 | $4,400 |
+| 125,000 | $5,500 |
+| 150,000 | $6,600 |
+| 175,000 | $7,700 |
+| 200,000 | $8,800 |
+| 250,000 | $11,000 |
+| 300,000 | $13,200 |
+
+---
+
+## B2B Pricing
+
+### Plan Highlights
+
+**Essentials — from $150/month**
+- Everything in Free, plus:
+- Unlimited** Organizations
+- 3 SSO Enterprise Connections
+- Role-based Access Control
+- Higher Auth and API limits
+- Pro Multi-Factor Authentication
+- Stream Auth0 Audit Logs
+- Dev & Prod tenant configuration
+- Standard Support
+- Add-ons: Enterprise MFA, Enterprise SSO Connections, M2M Tokens
+
+**Professional — from $800/month**
+- Everything in Essentials, plus:
+- Enhanced Attack Protection
+- Use your existing User Database for Logins
+- Enterprise Multi-Factor Authentication
+- Custom Token Exchange
+- Security Center
+- Additional Enterprise Connections
+- Add-ons: Enterprise SSO Connections, M2M Tokens
+
+**Enterprise — Contact us**
+- Everything in Professional, plus:
+- Custom User & SSO Tiers
+- 99.99% SLA
+- Enterprise Rate Limits
+- Enterprise Administration & Support
+- Add-ons: Advanced Security Features, Private Deployment
+
+### B2B Base Price by MAUs (monthly)
+
+| MAUs | Essentials | Professional |
+|------|-----------|--------------|
+| 500 | $150 | $800 |
+| 1,000 | $300 | $800 |
+| 2,500 | $700 | $1,200 |
+| 5,000 | $1,300 | $1,500 |
+| 7,500 | $1,725 | $1,800 |
+| 10,000 | $2,100 | $2,400 |
+| 20,000 | $3,800 | Contact us |
+| 30,000+ | Contact us | Contact us |
+
+### B2B Base Price by MAUs (yearly)
+
+| MAUs | Essentials | Professional |
+|------|-----------|--------------|
+| 500 | $1,650 | $8,800 |
+| 1,000 | $3,300 | $8,800 |
+| 2,500 | $7,700 | $13,200 |
+| 5,000 | $14,300 | $16,500 |
+| 7,500 | $18,975 | $19,800 |
+| 10,000 | $23,100 | $26,400 |
+| 20,000 | $41,800 | Contact us |
+| 30,000+ | Contact us | Contact us |
+
+### B2B Add-ons
+
+**Auth0 for AI Agents**
+- Adds 50% to the base price (rounded up to the dollar)
+- Unlimited Token Vault
+- All forms of CIBA
+
+*B2B AI Agents Add-On Price by MAUs (monthly)*
+
+| MAUs | Essentials | Professional |
+|------|-----------|--------------|
+| 500 | $75 | $400 |
+| 1,000 | $150 | $400 |
+| 2,500 | $350 | $600 |
+| 5,000 | $650 | $750 |
+| 7,500 | $863 | $900 |
+| 10,000 | $1,050 | $1,200 |
+| 20,000 | $1,900 | Contact us |
+| 30,000+ | Contact us | Contact us |
+
+*B2B AI Agents Add-On Price by MAUs (yearly — 11× monthly)*
+
+| MAUs | Essentials | Professional |
+|------|-----------|--------------|
+| 500 | $825 | $4,400 |
+| 1,000 | $1,650 | $4,400 |
+| 2,500 | $3,850 | $6,600 |
+| 5,000 | $7,150 | $8,250 |
+| 7,500 | $9,493 | $9,900 |
+| 10,000 | $11,550 | $13,200 |
+| 20,000 | $20,900 | Contact us |
+| 30,000+ | Contact us | Contact us |
+
+**M2M Tokens — Essentials and Professional plan** (Professional plan 5,000 included)
+
+*B2B M2M Token Add-On (monthly)*
+
+| M2M Tokens | Price/month |
+|-----------|-------------|
+| 2,500 | $10 |
+| 5,000 | $20 |
+| 7,500 | $30 |
+| 10,000 | $40 |
+| 20,000 | $80 |
+| 30,000 | $120 |
+| 40,000 | $160 |
+| 50,000 | $200 |
+| 60,000 | $240 |
+| 70,000 | $280 |
+| 80,000 | $320 |
+| 90,000 | $360 |
+| 100,000 | $400 |
+| 125,000 | $500 |
+| 150,000 | $600 |
+| 175,000 | $700 |
+| 200,000 | $800 |
+| 250,000 | $1,000 |
+| 300,000 | $1,200 |
+
+*B2B M2M Token Add-On (yearly — 11× monthly)*
+
+| M2M Tokens | Price/year |
+|-----------|------------|
+| 2,500 | $110 |
+| 5,000 | $220 |
+| 7,500 | $330 |
+| 10,000 | $440 |
+| 20,000 | $880 |
+| 30,000 | $1,320 |
+| 40,000 | $1,760 |
+| 50,000 | $2,200 |
+| 60,000 | $2,640 |
+| 70,000 | $3,080 |
+| 80,000 | $3,520 |
+| 90,000 | $3,960 |
+| 100,000 | $4,400 |
+| 125,000 | $5,500 |
+| 150,000 | $6,600 |
+| 175,000 | $7,700 |
+| 200,000 | $8,800 |
+| 250,000 | $11,000 |
+| 300,000 | $13,200 |
+
+
+**Enterprise SSO Connections**
+- Essentials: 3 included. $100/month ($1,100/year) per additional connection (max 30 total)
+- Professional: 5 included. $100/month ($1,100/year) per additional connection (max 30 total)
+
+**Enterprise MFA**
+- Essentials: $100/month ($1,100/year)
+- Professional: Included
+
+---
+
+## Feature Comparison
+
+> ADD-ON = available as paid add-on
+> * credit card verification required for custom domains
+> ** subject to system limitations
+> The Free column is identical for B2C and B2B.
+
+### B2C Feature Comparison
+
+#### Authentication
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| External Active Users | Up to 25,000 | Custom Tiers | Custom Tiers | Custom Tiers |
+| Machine-to-Machine Authentication | 1,000 | 1,000 | 5,000 | 5,000 |
+| M2M Add-on | No | No | Yes | Yes |
+| Passwordless | Included | Included | Included | Included |
+| Social Connections | Unlimited** | Unlimited** | Unlimited** | Unlimited** |
+| Custom Social Connections | Included | Included | Included | Included |
+| Passkeys | Included | Included | Included | Included |
+| Auth0 Database Connection | Included | Included | Included | Included |
+| Custom Database Connections | Not available | Not available | Included | Included |
+| Cross APP SSO | Not available | Not available | Included | Included |
+| Enterprise Connections | 1 | Not available | Not available | Custom Tiers |
+| Inbound SCIM | Included | Included | Included | Included |
+| Okta Connections | Unlimited** | Unlimited** | Unlimited** | Unlimited** |
+| Express Configuration | Included | Included | Included | Included |
+| Organizations | 5 | 10 | 10 | Custom Tiers |
+| Self-Service SSO | Included | Not available | Not available | Select Enterprise Plans |
+| M2M Access for Organizations | Not available | Not available | Not available | Select Enterprise Plans |
+| Home Realm Discovery | Not available | Not available | Not available | Included |
+| Long Lived Sessions | Not available | Not available | Not available | Included |
+
+#### AI
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| CIBA | Not available | ADD-ON | ADD-ON | Included + ADD-ON |
+| Token Vault | 2 | 3 + ADD-ON | 3 + ADD-ON | 4 + ADD-ON |
+
+#### Branding
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| Configurable Login Experience | Included | Included | Included | Included |
+| Accessibility | Included | Included | Included | Included |
+| Custom Domains* | 1 | Included | Included | Included |
+| Email Workflow | Not available | Included | Included | Included |
+| Customize Signup & Login | Not available | Included | Included | Included |
+
+#### Extensibility
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| Actions + Forms | 5 | 10 | 15 | 30 + ADD-ON |
+| The Actions Library | Included | Included | Included | Included |
+| Marketplace | Included | Included | Included | Included |
+| Pro Forms | Not available | Not available | Included | Included |
+
+#### Security & Compliance
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| Brute Force Protection | Included | Included | Included | Included |
+| Suspicious IP Throttling | Included | Included | Included | Included |
+| Enhanced Password Protection | Not available | Not available | Included | Included |
+| Basic Breached Password Detection | Not available | Not available | Included | Included |
+| Credential Guard | Not available | Not available | Not available | ADD-ON |
+| Bot Detection | Not available | Not available | Not available | ADD-ON |
+| Tenant Access Control List (ACL) | Not available | Not available | Not available | 1 + ADD-ON |
+| Integration with Okta Universal Logout | Included | Included | Included | Included |
+| Pro MFA Factors | Not available | Included | Included | Included |
+| Enterprise MFA Factors | Not available | Included | Included | Included |
+| Adaptive MFA | Not available | Not available | Not available | ADD-ON |
+| Security Center | Not available | Not available | Included | Included |
+| Continuous Session Protection | Not available | Not available | Not available | Included |
+| FAPI certified Security Profile | Not available | Not available | Not available | ADD-ON |
+| Compliance Certifications | Included | Included | Included | Included |
+| HIPAA/BAA | Not available | Not available | Not available | ADD-ON |
+| Prioritized Security Log Streams | Not available | Not available | Not available | Included |
+| Private Key JWT | Not available | Not available | Not available | Included |
+| OIDC Back-Channel Logout | Not available | Not available | Not available | Included |
+
+#### User Management
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| User Import | Included | Included | Included | Included |
+| Custom Attributes | Included | Included | Included | Included |
+| Role Management | Not available | Included | Included | Included |
+| Account Linking | Not available | Included | Included | Included |
+
+#### Platform
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| Number of Tenants Included | 1 | 3 | 12 | Unlimited** |
+| Number of Admin/Contributors | 3 | Unlimited** | Unlimited** | Unlimited** |
+| Admin Access Controls | Admin | Admin and Viewer | Admin, Viewer and Editor | Admin, Viewer and Editor |
+| Auth0 Dashboard SSO | Not available | Not available | Not available | Included |
+| Log Retention | 1 Day | 5 Days | 10 Days | 30 Days |
+| Log Streaming | Not available | 1 Log Stream | 2 Log Streams | 2 Log Streams |
+| Private Deployment | Not available | Not available | Not available | ADD-ON |
+| SLA | Not available | Not available | Not available | 99.99% |
+| Community Support | Included | Included | Included | Included |
+| Standard Support | Not available | Included | Included | Included |
+| Premier Support | Not available | Not available | Not available | Premier Success Options |
+
+---
+
+### B2B Feature Comparison
+
+#### Authentication
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| External Active Users | Up to 25,000 | Custom Tiers | Custom Tiers | Custom Tiers |
+| Machine-to-Machine Authentication | 1,000 | 1,000 | 5,000 | 5,000 |
+| M2M Add-on | No | No | Yes | Yes |
+| Passwordless | Included | Included | Included | Included |
+| Social Connections | Unlimited** | Unlimited** | Unlimited** | Unlimited** |
+| Custom Social Connections | Included | Included | Included | Included |
+| Passkeys | Included | Included | Included | Included |
+| Auth0 Database Connection | Included | Included | Included | Included |
+| Custom Database Connections | Not available | Not available | Included | Included |
+| Cross APP SSO | Not available | Not available | Included | Included |
+| Enterprise Connections | 1 | 3 + ADD-ON | 5 + ADD-ON | Custom Tiers |
+| Inbound SCIM | Included | Included | Included | Included |
+| Okta Connections | Unlimited** | Unlimited** | Unlimited** | Unlimited** |
+| Express Configuration | Included | Included | Included | Included |
+| Organizations | 5 | Unlimited** | Unlimited** | Custom Tiers |
+| Self-Service SSO | Included | Included | Included | Select Enterprise Plans |
+| M2M Access for Organizations | Not available | Not available | Included | Select Enterprise Plans |
+| Home Realm Discovery | Not available | Included | Included | Included |
+| Long Lived Sessions | Not available | Not available | Not available | Included |
+
+#### AI
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| CIBA | Not available | ADD-ON | ADD-ON | Included + ADD-ON |
+| Token Vault | 2 | 3 + ADD-ON | 3 + ADD-ON | 4 + ADD-ON |
+
+#### Branding
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| Configurable Login Experience | Included | Included | Included | Included |
+| Accessibility | Included | Included | Included | Included |
+| Custom Domains* | 1 | Included | Included | Included |
+| Email Workflow | Not available | Included | Included | Included |
+| Customize Signup & Login | Not available | Included | Included | Included |
+
+#### Extensibility
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| Actions + Forms | 5 | 10 | 15 | 30 + ADD-ON |
+| The Actions Library | Included | Included | Included | Included |
+| Marketplace | Included | Included | Included | Included |
+| Pro Forms | Not available | Not available | Included | Included |
+
+#### Security & Compliance
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| Brute Force Protection | Included | Included | Included | Included |
+| Suspicious IP Throttling | Included | Included | Included | Included |
+| Enhanced Password Protection | Not available | Not available | Included | Included |
+| Basic Breached Password Detection | Not available | Not available | Included | Included |
+| Credential Guard | Not available | Not available | Not available | ADD-ON |
+| Bot Detection | Not available | Not available | Not available | ADD-ON |
+| Tenant Access Control List (ACL) | Not available | Not available | Not available | 1 + ADD-ON |
+| Integration with Okta Universal Logout | Included | Included | Included | Included |
+| Pro MFA Factors | Not available | Included | Included | Included |
+| Enterprise MFA Factors | Not available | ADD-ON | Included | Included |
+| Adaptive MFA | Not available | Not available | Not available | ADD-ON |
+| Security Center | Not available | Not available | Not available | Included |
+| Continuous Session Protection | Not available | Not available | Not available | Included |
+| FAPI certified Security Profile | Not available | Not available | Not available | ADD-ON |
+| Compliance Certifications | Included | Included | Included | Included |
+| HIPAA/BAA | Not available | Not available | Not available | ADD-ON |
+| Prioritized Security Log Streams | Not available | Not available | Not available | Included |
+| Private Key JWT | Not available | Not available | Not available | Included |
+| OIDC Back-Channel Logout | Not available | Not available | Not available | Included |
+
+#### User Management
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| User Import | Included | Included | Included | Included |
+| Custom Attributes | Included | Included | Included | Included |
+| Role Management | Not available | Included | Included | Included |
+| Account Linking | Not available | Included | Included | Included |
+
+#### Platform
+
+| Feature | Free | Essentials | Professional | Enterprise |
+|---|---|---|---|---|
+| Number of Tenants Included | 1 | 3 | 12 | Unlimited** |
+| Number of Admin/Contributors | 3 | Unlimited** | Unlimited** | Unlimited** |
+| Admin Access Controls | Admin | Admin and Viewer | Admin, Viewer and Editor | Admin, Viewer and Editor |
+| Auth0 Dashboard SSO | Not available | Not available | Not available | Included |
+| Log Retention | 1 Day | 5 Days | 10 Days | 30 Days |
+| Log Streaming | Not available | 1 Log Stream | 2 Log Streams | 2 Log Streams |
+| Private Deployment | Not available | Not available | Not available | ADD-ON |
+| SLA | Not available | Not available | Not available | 99.99% |
+| Community Support | Included | Included | Included | Included |
+| Standard Support | Not available | Included | Included | Included |
+| Premier Support | Not available | Not available | Not available | Premier Success Options |
+
+---
+
+## Notes
+
+- Yearly billing = 11× the monthly price (equivalent to 1 month free)
+- * Custom domains require credit card verification
+- ** Subject to system limitations
+- Enterprise plan pricing is custom; contact Auth0 sales
+- The Free plan is identical for B2C and B2B: up to 25,000 MAUs, no credit card required

--- a/plugins/auth0/skills/auth0/references/feature-audit-pricing.md
+++ b/plugins/auth0/skills/auth0/references/feature-audit-pricing.md
@@ -1,8 +1,9 @@
 # Auth0 Pricing
 
-Source: https://auth0.com/pricing
+`https://auth0.com/pricing.md` holds the up-to-date prices — retrieve it before quoting any
+figure. The feature→plan matrix below is local; read it from here.
 
-Auth0 offers flexible authentication and authorization plans for both B2C (consumer-facing) and B2B (business-facing) applications. The Free plan is identical regardless of use case. Paid plans are priced by Monthly Active Users (MAUs) and differ between B2C and B2B. Yearly billing is 11× the monthly price (equivalent to 1 month free).
+Auth0 offers flexible authentication and authorization plans for both B2C (consumer-facing) and B2B (business-facing) applications. The Free plan is identical regardless of use case. Paid plans are priced by Monthly Active Users (MAUs) and differ between B2C and B2B.
 
 ---
 
@@ -10,13 +11,17 @@ Auth0 offers flexible authentication and authorization plans for both B2C (consu
 
 To quote pricing for a customer, follow these steps in order:
 
-1. **Determine use case:** B2C (consumer-facing) or B2B (business-facing).
-2. **Identify their MAU tier:** Find the tier that meets or exceeds their expected monthly active users. If usage falls between tiers, use the next tier up.
-3. **Select the plan:** Match required features against the Feature Comparison tables to determine the minimum plan (Free, Essentials, Professional, or Enterprise).
-4. **Look up the base price:** Use the appropriate B2C or B2B base price table (monthly or yearly).
-5. **Add any add-ons:** Check if the customer needs AI Agents, additional M2M tokens, Enterprise SSO connections, or Enterprise MFA. Look up each add-on price from the explicit tables.
-6. **Calculate total cost:** Total = Base Price + sum of all applicable add-on prices.
-7. **Enterprise or "Contact us" tiers:** If any component shows "Contact us", direct the customer to Auth0 sales for a custom quote.
+1. **Fetch `https://auth0.com/pricing.md` first.** Do this before quoting any figure. It carries
+   the B2C and B2B base-price tables (monthly and yearly), every add-on table (Auth for AI
+   Agents, M2M tokens, Enterprise SSO connections, Enterprise MFA), and the current MAU tiers.
+   If it can't be fetched, give the plan name without a figure — never a price from memory.
+2. **Determine use case:** B2C (consumer-facing) or B2B (business-facing).
+3. **Identify their MAU tier:** Find the tier that meets or exceeds their expected monthly active users. If usage falls between tiers, use the next tier up.
+4. **Select the plan:** Match required features against the Feature Comparison tables below to determine the minimum plan (Free, Essentials, Professional, or Enterprise).
+5. **Look up the base price** in the fetched page, using the appropriate B2C or B2B table.
+6. **Add any add-ons:** Check whether the customer needs AI Agents, additional M2M tokens, Enterprise SSO connections, or Enterprise MFA, and take each add-on price from the fetched page.
+7. **Calculate total cost:** Total = Base Price + sum of all applicable add-on prices.
+8. **"Contact us" or "Not available" components:** If any component reads "Contact us", direct the customer to Auth0 sales for a custom quote. If it reads "Not available", that plan or add-on does not exist at their MAU tier — do not recommend it and do not total it; move up a plan or send them to sales.
 
 ---
 
@@ -30,20 +35,17 @@ To quote pricing for a customer, follow these steps in order:
 
 ## Plans Overview
 
-Auth0 has four tiers: **Free**, **Essentials**, **Professional**, and **Enterprise**. Pricing differs between B2C and B2B use cases.
-
-| Plan | B2C Starting Price | B2B Starting Price | MAUs at Starting Price |
-|---|---|---|---|
-| Free | $0/month | $0/month | Up to 25,000 |
-| Essentials | $35/month | $150/month | 500 MAUs |
-| Professional | $240/month | $800/month | 500 MAUs |
-| Enterprise | Contact us | Contact us | Custom |
+Auth0 has four tiers: **Free**, **Essentials**, **Professional**, and **Enterprise**. Free is
+identical for B2C and B2B; the paid tiers are priced separately for each. Starting prices, the
+MAU tier they apply at, and how Enterprise is sold are in the fetched pricing page — read
+Enterprise off that page rather than assuming, and never quote or estimate an Enterprise price
+yourself.
 
 ---
 
 ## Free Plan
 
-**Free — $0/month** (same for B2C and B2B)
+**Free** (same for B2C and B2B)
 
 No credit card needed to sign up.
 
@@ -66,7 +68,7 @@ No credit card needed to sign up.
 
 ### Plan Highlights
 
-**Essentials — from $35/month**
+**Essentials**
 - Everything in Free, plus:
 - Higher Auth, API limits, and feature limits
 - Pro Multi-Factor Authentication
@@ -77,7 +79,7 @@ No credit card needed to sign up.
 - Standard Support
 - Add-ons: Enterprise MFA, Enterprise SSO Connections, M2M Tokens
 
-**Professional — from $240/month**
+**Professional**
 - Everything in Essentials, plus:
 - Enhanced Attack Protection
 - Use your existing User Database for Logins
@@ -94,121 +96,12 @@ No credit card needed to sign up.
 
 *Pricing is available only at the listed MAU tiers. If your usage falls between tiers, you are billed at the next tier up.*
 
-### B2C Base Price by MAUs (monthly)
+### B2C Prices
 
-| MAUs | Essentials | Professional |
-|------|-----------|--------------|
-| 500 | $35 | $240 |
-| 1,000 | $70 | $240 |
-| 2,500 | $175 | $545 |
-| 5,000 | $350 | $1,000 |
-| 7,500 | $525 | $1,200 |
-| 10,000 | $700 | $1,600 |
-| 20,000 | $1,400 | $3,200 |
-| 30,000 | $2,100 | Contact us |
-| 40,000 | $2,800 | Not available |
-| 50,000 | $3,500 | Not available |
-
-### B2C Base Price by MAUs (yearly)
-
-| MAUs | Essentials | Professional |
-|------|-----------|--------------|
-| 500 | $385 | $2,640 |
-| 1,000 | $770 | $2,640 |
-| 2,500 | $1,925 | $5,995 |
-| 5,000 | $3,850 | $11,000 |
-| 7,500 | $5,775 | $13,200 |
-| 10,000 | $7,700 | $17,600 |
-| 20,000 | $15,400 | $35,200 |
-| 30,000 | $23,100 | Contact us |
-| 40,000 | $30,800 | Not available |
-| 50,000 | $38,500 | Not available |
-
-### B2C Add-ons
-
-**Auth0 for AI Agents**
-- Adds 50% to the base price (rounded up to the dollar)
-- Unlimited Token Vault
-- All forms of CIBA
-
-*B2C AI Agents Add-On Price by MAUs (monthly)*
-
-| MAUs | Essentials | Professional |
-|------|-----------|--------------|
-| 500 | $18 | $120 |
-| 1,000 | $35 | $120 |
-| 2,500 | $88 | $273 |
-| 5,000 | $175 | $500 |
-| 7,500 | $263 | $600 |
-| 10,000 | $350 | $800 |
-| 20,000 | $700 | $1,600 |
-| 30,000 | $1,050 | Contact us |
-| 40,000 | $1,400 | Not available |
-| 50,000 | $1,750 | Not available |
-
-*B2C AI Agents Add-On Price by MAUs (yearly — 11× monthly)*
-
-| MAUs | Essentials | Professional |
-|------|-----------|--------------|
-| 500 | $198 | $1,320 |
-| 1,000 | $385 | $1,320 |
-| 2,500 | $968 | $3,003 |
-| 5,000 | $1,925 | $5,500 |
-| 7,500 | $2,893 | $6,600 |
-| 10,000 | $3,850 | $8,800 |
-| 20,000 | $7,700 | $17,600 |
-| 30,000 | $11,550 | Contact us |
-| 40,000 | $15,400 | Not available |
-| 50,000 | $19,250 | Not available |
-
-
-**M2M Token Add-On Tier Pricing** (Professional plan only; 5,000 included)
-
-*B2C M2M Token Add-On (monthly)*
-
-| M2M Tokens | Price/month |
-|-----------|-------------|
-| 5,000 | Included |
-| 7,500 | $30 |
-| 10,000 | $40 |
-| 20,000 | $80 |
-| 30,000 | $120 |
-| 40,000 | $160 |
-| 50,000 | $200 |
-| 60,000 | $240 |
-| 70,000 | $280 |
-| 80,000 | $320 |
-| 90,000 | $360 |
-| 100,000 | $400 |
-| 125,000 | $500 |
-| 150,000 | $600 |
-| 175,000 | $700 |
-| 200,000 | $800 |
-| 250,000 | $1,000 |
-| 300,000 | $1,200 |
-
-*B2C M2M Token Add-On (yearly — 11× monthly)*
-
-| M2M Tokens | Price/year |
-|-----------|------------|
-| 5,000 | Included |
-| 7,500 | $330 |
-| 10,000 | $440 |
-| 20,000 | $880 |
-| 30,000 | $1,320 |
-| 40,000 | $1,760 |
-| 50,000 | $2,200 |
-| 60,000 | $2,640 |
-| 70,000 | $3,080 |
-| 80,000 | $3,520 |
-| 90,000 | $3,960 |
-| 100,000 | $4,400 |
-| 125,000 | $5,500 |
-| 150,000 | $6,600 |
-| 175,000 | $7,700 |
-| 200,000 | $8,800 |
-| 250,000 | $11,000 |
-| 300,000 | $13,200 |
+Base prices (monthly and yearly) by MAU tier, and every B2C add-on — Auth0 for AI Agents
+(adds 50% to base, rounded up to the dollar; unlimited Token Vault, all forms of CIBA) and
+M2M tokens — are in the **B2C section of the fetched pricing page**. Read them there; which
+plans each add-on is available on is in the B2C Feature Comparison below.
 
 ---
 
@@ -216,7 +109,7 @@ No credit card needed to sign up.
 
 ### Plan Highlights
 
-**Essentials — from $150/month**
+**Essentials**
 - Everything in Free, plus:
 - Unlimited** Organizations
 - 3 SSO Enterprise Connections
@@ -228,7 +121,7 @@ No credit card needed to sign up.
 - Standard Support
 - Add-ons: Enterprise MFA, Enterprise SSO Connections, M2M Tokens
 
-**Professional — from $800/month**
+**Professional**
 - Everything in Essentials, plus:
 - Enhanced Attack Protection
 - Use your existing User Database for Logins
@@ -246,123 +139,13 @@ No credit card needed to sign up.
 - Enterprise Administration & Support
 - Add-ons: Advanced Security Features, Private Deployment
 
-### B2B Base Price by MAUs (monthly)
+### B2B Prices
 
-| MAUs | Essentials | Professional |
-|------|-----------|--------------|
-| 500 | $150 | $800 |
-| 1,000 | $300 | $800 |
-| 2,500 | $700 | $1,200 |
-| 5,000 | $1,300 | $1,500 |
-| 7,500 | $1,725 | $1,800 |
-| 10,000 | $2,100 | $2,400 |
-| 20,000 | $3,800 | Contact us |
-| 30,000+ | Contact us | Contact us |
-
-### B2B Base Price by MAUs (yearly)
-
-| MAUs | Essentials | Professional |
-|------|-----------|--------------|
-| 500 | $1,650 | $8,800 |
-| 1,000 | $3,300 | $8,800 |
-| 2,500 | $7,700 | $13,200 |
-| 5,000 | $14,300 | $16,500 |
-| 7,500 | $18,975 | $19,800 |
-| 10,000 | $23,100 | $26,400 |
-| 20,000 | $41,800 | Contact us |
-| 30,000+ | Contact us | Contact us |
-
-### B2B Add-ons
-
-**Auth0 for AI Agents**
-- Adds 50% to the base price (rounded up to the dollar)
-- Unlimited Token Vault
-- All forms of CIBA
-
-*B2B AI Agents Add-On Price by MAUs (monthly)*
-
-| MAUs | Essentials | Professional |
-|------|-----------|--------------|
-| 500 | $75 | $400 |
-| 1,000 | $150 | $400 |
-| 2,500 | $350 | $600 |
-| 5,000 | $650 | $750 |
-| 7,500 | $863 | $900 |
-| 10,000 | $1,050 | $1,200 |
-| 20,000 | $1,900 | Contact us |
-| 30,000+ | Contact us | Contact us |
-
-*B2B AI Agents Add-On Price by MAUs (yearly — 11× monthly)*
-
-| MAUs | Essentials | Professional |
-|------|-----------|--------------|
-| 500 | $825 | $4,400 |
-| 1,000 | $1,650 | $4,400 |
-| 2,500 | $3,850 | $6,600 |
-| 5,000 | $7,150 | $8,250 |
-| 7,500 | $9,493 | $9,900 |
-| 10,000 | $11,550 | $13,200 |
-| 20,000 | $20,900 | Contact us |
-| 30,000+ | Contact us | Contact us |
-
-**M2M Tokens — Essentials and Professional plan** (Professional plan 5,000 included)
-
-*B2B M2M Token Add-On (monthly)*
-
-| M2M Tokens | Price/month |
-|-----------|-------------|
-| 2,500 | $10 |
-| 5,000 | $20 |
-| 7,500 | $30 |
-| 10,000 | $40 |
-| 20,000 | $80 |
-| 30,000 | $120 |
-| 40,000 | $160 |
-| 50,000 | $200 |
-| 60,000 | $240 |
-| 70,000 | $280 |
-| 80,000 | $320 |
-| 90,000 | $360 |
-| 100,000 | $400 |
-| 125,000 | $500 |
-| 150,000 | $600 |
-| 175,000 | $700 |
-| 200,000 | $800 |
-| 250,000 | $1,000 |
-| 300,000 | $1,200 |
-
-*B2B M2M Token Add-On (yearly — 11× monthly)*
-
-| M2M Tokens | Price/year |
-|-----------|------------|
-| 2,500 | $110 |
-| 5,000 | $220 |
-| 7,500 | $330 |
-| 10,000 | $440 |
-| 20,000 | $880 |
-| 30,000 | $1,320 |
-| 40,000 | $1,760 |
-| 50,000 | $2,200 |
-| 60,000 | $2,640 |
-| 70,000 | $3,080 |
-| 80,000 | $3,520 |
-| 90,000 | $3,960 |
-| 100,000 | $4,400 |
-| 125,000 | $5,500 |
-| 150,000 | $6,600 |
-| 175,000 | $7,700 |
-| 200,000 | $8,800 |
-| 250,000 | $11,000 |
-| 300,000 | $13,200 |
-
-
-**Enterprise SSO Connections**
-- Essentials: 3 included. $100/month ($1,100/year) per additional connection (max 30 total)
-- Professional: 5 included. $100/month ($1,100/year) per additional connection (max 30 total)
-
-**Enterprise MFA**
-- Essentials: $100/month ($1,100/year)
-- Professional: Included
+Base prices (monthly and yearly) by MAU tier, and every B2B add-on — Auth0 for AI Agents,
+M2M tokens, additional Enterprise SSO connections, and Enterprise MFA — are in the **B2B
+section of the fetched pricing page**. Read them there; which plans each add-on is available
+on, and how many Enterprise Connections each plan includes, are in the B2B Feature Comparison
+below.
 
 ---
 

--- a/plugins/auth0/skills/auth0/references/feature-audit-remediation.md
+++ b/plugins/auth0/skills/auth0/references/feature-audit-remediation.md
@@ -1,0 +1,98 @@
+# Auth0 tenant audit — remediation reference
+
+This reference covers how to apply approved fixes from an Auth0 tenant configuration audit: the command-shape mapping, the per-item guided flow, the express-mode batch flow, and the commands that are never run without explicit user confirmation. It assumes an audit report already exists (with "Immediate Actions" and "After Upgrading" lists) and the user has chosen a remediation mode — Express or Guided — for applying fixes via the Auth0 CLI.
+
+Fixes are applied as two ordered loops: **Loop A — Immediate Actions** (fixes available on the tenant's current plan) and **Loop B — After Upgrading** (fixes gated behind a plan upgrade). Loop A runs first; after it completes, ask whether the customer has upgraded before starting Loop B.
+
+## Command-shape mapping
+
+For each item, build the command. **Use a first-class subcommand when one exists; fall back to `auth0 api <method>` with an explicit JSON payload when there isn't.** Run `auth0 <cmd> --help` first if uncertain about flag names.
+
+| Category | First-class command (if available) | Fallback `auth0 api` path |
+|---|---|---|
+| Tenant settings | `auth0 tenants settings update` | `PATCH /api/v2/tenants/settings` |
+| Brute-force protection | `auth0 protection brute-force-protection update` | `PATCH /api/v2/attack-protection/brute-force-protection` |
+| Breached password detection | `auth0 protection breached-password-detection update` | `PATCH /api/v2/attack-protection/breached-password-detection` |
+| Suspicious IP throttling | `auth0 protection suspicious-ip-throttling update` | `PATCH /api/v2/attack-protection/suspicious-ip-throttling` |
+| Branding (universal login, colors, logo) | `auth0 branding update` / `auth0 universal-login update` | `PATCH /api/v2/branding` |
+| Custom domains | `auth0 domains create` / `update` | `POST/PATCH /api/v2/custom-domains` |
+| Connections (DB, social, enterprise) | `auth0 connections update <id>` | `PATCH /api/v2/connections/{id}` (full options blob) |
+| APIs / resource servers | `auth0 apis update` | `PATCH /api/v2/resource-servers/{id}` |
+| Apps / clients (callbacks, origins, grant types, refresh tokens) | `auth0 apps update` | `PATCH /api/v2/clients/{id}` |
+| Roles | `auth0 roles update` | `PATCH /api/v2/roles/{id}` |
+| Actions | `auth0 actions create/update/deploy` | `POST/PATCH /api/v2/actions/actions` |
+| Log streams | `auth0 logs streams create/update` | `POST/PATCH /api/v2/log-streams` |
+| Email provider/templates | `auth0 email provider update` / `auth0 email templates update` | `PATCH /api/v2/emails/provider` / `/api/v2/email-templates/{name}` |
+| MFA factor toggles | (none) | `PUT /api/v2/guardian/factors/{factor}` |
+| MFA policies | (none) | `PUT /api/v2/mfa/policies` |
+| Prompts customization | (none) | `PUT /api/v2/prompts/{prompt}/custom-text/{lang}` |
+| Network ACLs | (none) | `POST/PATCH /api/v2/network-acls` |
+| Auth0 Organizations | `auth0 orgs create/update` | `POST/PATCH /api/v2/organizations` |
+
+The fallback is `auth0 api <method> <path> --data '<json>'` — pick the method from the
+table's path column: `patch` for most resources, `put` for MFA factor toggles, MFA
+policies, and Prompts customization, and `post` when creating a resource. `patch` is not
+universal. Note that `auth0 api` defaults to `GET` without `--data` and `POST` with
+`--data`, so always state the method explicitly.
+
+## Per-item flow (Guided mode)
+
+For each item, when in **Guided** mode:
+1. **Build the CLI command(s).** Multiple commands are fine — e.g. updating callbacks + origins + grant types on an app may need 1-3 calls.
+2. **Show the diff.** Print the current value (fetch with `auth0 api get ...`) and the proposed change side-by-side. Never show only the proposed payload.
+3. **Print the exact command(s)** about to run, including JSON payloads.
+4. **Ask via `AskUserQuestion`**: Implement now / Queue / Skip. Only proceed on Implement now.
+5. **Execute via Bash**, capture stdout/stderr.
+6. **Verify** by re-fetching the same resource and confirming the field changed. Never claim success on exit code alone.
+7. If a command fails, **don't retry destructively** — surface the error and ask the user how to proceed.
+
+## Batch flow (Express mode, Immediate Actions only)
+
+For Loop A in **Express** mode:
+1. **Build all CLI commands up front** for every Immediate Action.
+2. **Render one consolidated preview** to chat — a numbered list, each entry showing: action title · target app/resource · the exact command(s) it'll run. Mark anything mutating connections, deleting data, or rotating secrets as `[risky]` and exclude from the batch (handle individually after).
+3. **Ask via `AskUserQuestion`** with three options:
+   - **Apply all** — execute every non-risky item in order, one progress line per item (`✓ #1 callbacks updated`, `⚠ #3 failed: ...`).
+   - **Select a subset** — fall back to the per-item Guided flow above for the user to pick.
+   - **Skip remediation** — write all items to `state/queue.json` with `status: "skipped"`, exit remediation.
+4. After Apply all, re-fetch each touched resource to verify (same as the Guided flow's verify step). Surface failures inline; don't abort the batch on a single error.
+5. Any `[risky]` items pulled out of the batch get the Guided per-item flow afterwards.
+
+For Loop B (After Upgrading) in **Express** mode: still use the Guided per-item flow. Plan-gated changes are higher-stakes and individually consequential — never batch.
+
+### Loop A — Immediate Actions
+
+Iterate the "Immediate Actions — Available Today (Free)" items from the audit report.
+
+- **Express** → use the batch flow above.
+- **Guided** → use the per-item flow above.
+
+### Plan upgrade gate
+
+After Loop A, ask via `AskUserQuestion`:
+> "Has `<Customer>` upgraded to `<recommended_plan>`?"
+
+Options:
+- **Yes — proceed** → Loop B
+- **Not yet — queue for after upgrade** → write all After Upgrading items to `state/queue.json` with `status: "pending_upgrade"`, print the upgrade link `https://manage.auth0.com/dashboard/<region>/<tenant>/billing`, end
+- **Skip remaining** → write items with `status: "skipped"` (with optional rationale), end
+
+### Loop B — After Upgrading
+
+Always uses the Guided per-item flow regardless of mode (plan-gated changes are too consequential to batch). If any command fails with a plan-feature error, surface it and ask whether to queue.
+
+## Never-without-confirmation list (applies to all modes)
+
+Even in Express mode, these commands are blocked unless the user explicitly types the action verbatim:
+- `auth0 logout`
+- `auth0 tenants delete`
+- `auth0 apps delete` (any app, especially the CheckMate app)
+- `auth0 connections delete`
+- `auth0 api delete <anything>`
+
+## Closing the run
+
+After Loop B (or gate exit) completes:
+- Update state: `last_run_at`, append applied + queued + skipped findings to `state/history.jsonl`
+- Print: tenant, report path, applied count, queued count, skipped count
+- If anything was applied, suggest re-running the audit to confirm the fixes show clean

--- a/plugins/auth0/skills/auth0/references/feature-audit.md
+++ b/plugins/auth0/skills/auth0/references/feature-audit.md
@@ -1,0 +1,486 @@
+# Auth0 tenant audit (CheckMate) — full workflow
+
+Use this reference when the user wants to run an Auth0 tenant configuration / security audit and produce a tenant configuration report (Auth0 Platform Development Review format — markdown + styled PDF) tailored to their product context, or wants to apply the audit's recommendations. It bootstraps the Auth0 CLI and a dedicated audit M2M application if needed, gathers lightweight public company context so findings read in the customer's own terms, and implements approved fixes via the Auth0 CLI with per-command confirmation.
+
+You produce a personalized tenant audit as a **markdown brief plus styled PDF**, walk the user through the recommendations as two ordered loops (free-now vs after-upgrading), and apply approved fixes via the Auth0 CLI with per-command confirmation.
+
+The audit is run with CheckMate (`@auth0/auth0-checkmate`), a Node CLI that calls the Auth0 Management API and emits a JSON (and optionally PDF) report. The Auth0 CLI (`auth0`) is what you use both to bootstrap CheckMate's M2M app and to apply the recommendations.
+
+For the feature→plan matrix (Free/Essentials/Professional/Enterprise, B2C + B2B) that is the source of truth for triaging findings into Immediate vs After-Upgrading, use the co-loaded pricing reference. For the step-by-step remediation flows (command-shape mapping, guided/batch flows, the never-without-confirmation list), use the co-loaded remediation reference — it is what the two apply loops (Phase 6) hand off to. The markdown report skeleton this audit's brief MUST follow lives at `assets/audit/report-template.md`; the matching HTML skeleton (CSS-styled, used to render the PDF) lives at `assets/audit/report-template.html`. The PDF is rendered from the HTML by the script at the skill's `scripts/render_pdf.sh` (invoke it as `${CLAUDE_SKILL_DIR}/scripts/render_pdf.sh`). Company context is gathered inline in Phase 3 — no external skill required. Tenant-configuration CLI usage beyond what's inlined below (full command reference, flags, output formatting) is covered by the tooling reference loaded alongside this one.
+
+## Chat output rules (terse mode)
+
+This workflow runs many phases. Keep chat tight to make the run feel fast:
+- **One status line per phase max** — e.g. `Phase 1 ✓ CLI ready · tenant: acme.us.auth0.com`. No paragraph narration of what you're about to do.
+- Use `✓` for success, `⚠` for warnings (will fix automatically), `✗` for errors that need user input.
+- Show full detail only when (a) something fails, (b) the user must answer a question, or (c) Phase 5 chat summary at end.
+- Don't restate what's in the report files — point to the file path and stop.
+- Final-run summary may be 3-5 lines (top findings, applied count, queued count, file paths).
+
+## Tool-aware execution (agent portability)
+
+This workflow targets Claude Code first but works on any agent that can run shell commands and read files. It references several tools by their Claude Code names; map each to your agent's equivalent:
+
+| Reference in this workflow | Claude Code | Other agents (Codex, Cursor, Aider, Continue, Cline, etc.) |
+|---|---|---|
+| `AskUserQuestion` (mode selector, per-finding triage, confirmations) | Native multi-choice button UI | Ask the user as plain text with explicit options — e.g. "Reply: `express` / `guided` / `audit`" or "Apply this fix? `y`es / `q`ueue / `s`kip". Same content, plain prompt. |
+| `TodoWrite` (progress tracking) | Native todo list tool | Use your agent's progress mechanism, or skip — progress tracking is optional. |
+| `${CLAUDE_SKILL_DIR}` env var (path to skill folder) | Auto-set by Claude Code | Substitute the absolute path to wherever the customer extracted the skill. |
+
+State files for this workflow live at `~/.auth0-checkmate/state/` regardless of agent (vendor-neutral).
+
+## Phase 0 — Pre-flight + mode
+
+State cache lives at `~/.auth0-checkmate/state/setup.json` (create dir on first write):
+```json
+{
+  "schema_version": 1,
+  "tenant_domain": "tenant.region.auth0.com",
+  "checkmate_client_id": "...",
+  "company_domain": "example.com",
+  "mode": "guided",
+  "last_run_at": "2026-06-01T12:34:56Z"
+}
+```
+`mode` is `"express"`, `"guided"`, or `"audit"` (set in Phase 0.3, gates Phases 6-7).
+**Treat the state file as a cache, not source of truth.** Re-validate each field (Phase 1.1, Phase 2.1) before trusting it. Secrets (the M2M client_secret) live in `~/.auth0-checkmate.env` (mode 600) — never write secrets to the state file.
+
+### 0.1 Pre-flight diagnostic (silent → one-line status table)
+
+Run all checks **without prompting**, then render a single compact status block. Keep it under 8 lines.
+
+Checks to run in parallel (no chat output during checks):
+| Check | Command | Result |
+|---|---|---|
+| CLI installed | `auth0 --version` | version or missing |
+| Tenant session | `auth0 tenants list --json` | first tenant or none |
+| CheckMate app | `auth0 apps list --json \| jq '.[]\|select(.name\|test("CheckMate";"i"))'` | client_id or none |
+| M2M scopes | `auth0 api get client-grants?client_id=<id>` | scope count or none |
+| CheckMate npm | `command -v a0checkmate` | path or missing |
+| Node version | `node -v` | version or missing |
+| Reviewer | read `state/operator.json` | name or missing |
+| Company domain | read `state/setup.json.company_domain` | domain or missing |
+| Enrichment cache | newest `state/enrichment_*.json` | age or missing |
+
+Render to chat:
+```
+auth0-checkmate pre-flight:
+  ✓ Auth0 CLI v1.8.2
+  ✓ Logged in to acme.us.auth0.com
+  ✓ CheckMate M2M app present (cm_xxxxxx · 26/26 scopes)
+  ⚠ a0checkmate npm package not installed (will install)
+  ⚠ Company domain not cached (will ask)
+  → Estimated setup: ~30s
+```
+
+Use `✓` (ready), `⚠` (will fix automatically), `✗` (blocking — needs user input). If any `✗`, surface the action needed and pause for input.
+
+### 0.2 Capture missing inputs
+
+If reviewer or company domain is missing, ask in **one** combined `AskUserQuestion` (don't split into separate prompts). Save reviewer to `state/operator.json` (`reviewer_name`, optional `reviewer_org` for the report subtitle), company domain to `state/setup.json.company_domain`.
+
+Skip this step entirely when both are cached.
+
+### 0.3 Mode selector
+
+Single `AskUserQuestion`:
+
+> **How do you want to handle the recommendations?**
+> - **Express** — produce the report, then apply Immediate Actions in one batch confirmation; per-command confirm only for After-Upgrading items. Fastest.
+> - **Guided** — produce the report, then walk through each recommendation with per-command confirmation. Safest. (default)
+> - **Audit only** — produce the report and stop. No fixes applied.
+
+Save the chosen mode to `state/setup.json.mode`. The choice gates Phases 6 + 7 below.
+
+## Phase 1 — Auth0 CLI bootstrap
+
+### 1.1 Verify
+```bash
+auth0 --version              # CLI installed?
+auth0 tenants list --json    # session active? returns tenants array
+```
+
+If `--version` fails, install per platform:
+- macOS — `brew tap auth0/auth0-cli && brew install auth0`
+- Linux / macOS (curl) — download the binary with `curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b .` (it lands in `./auth0`; move it onto `$PATH` with `sudo mv ./auth0 /usr/local/bin` if you want to run it from any directory)
+- Windows — `scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git && scoop install auth0`, or via PowerShell: fetch the latest release tag from the GitHub releases API, download `auth0-cli_<version>_Windows_x86_64.zip`, expand it, and add it to `$PATH`
+- Any platform with Go ≥ 1.21 — `go install github.com/auth0/auth0-cli/cmd/auth0@latest` (ensure `$GOPATH/bin` is on `$PATH`)
+- Manual — download the release archive for your OS/architecture from the auth0-cli GitHub releases page and extract it; make sure `PATH` and `HOME` include the extraction folder
+
+Autocompletion instructions for supported shells are available by running `auth0 completion -h`.
+
+If `tenants list` returns empty / 401, authenticate. There are two ways:
+- **As a user** (recommended for personal/interactive machines) — device authorization flow, run `auth0 login`. **Cannot** be used for private cloud tenants.
+- **As a machine** (recommended for servers, CI, or private cloud tenants) — client credentials flow:
+  ```bash
+  auth0 login --domain <domain> --client-id <client-id> --client-secret <client-secret>
+  # or, with a private key instead of a secret:
+  auth0 login --domain <domain> --client-id <client-id> --client-assertion-private-key <path-to-private-key> --client-assertion-signing-alg <signing-algorithm>
+  ```
+
+**Critical:** the session must carry `create:client_grants` and `read:client_grants` so Phase 2's grant call doesn't 403:
+
+```bash
+auth0 login --scopes "create:client_grants,read:client_grants"
+```
+
+For non-interactive shells (CI, agent without TTY), or private cloud tenants, use the client-credentials login above. Detect TTY before invoking the device flow:
+```bash
+[ -t 0 ] && auth0 login --scopes "create:client_grants,read:client_grants" || echo "Non-interactive: use client-credentials login"
+```
+
+When an access token expires, the CLI prompts to confirm the default tenant (`Continue login with default tenant 'your-tenant.auth0.com'? [y/N]`) or lets you pick a different one — select `y` to proceed with the default, `N` to choose another. Note that CLI usage consumes Management API rate limits according to the subscription plan.
+
+### 1.2 Pin tenant
+Save the tenant domain returned by `auth0 tenants list --json` (`.[0].domain` if only one, otherwise ask the user to pick) into `state/setup.json.tenant_domain`. **Don't parse region from the domain suffix** — use the value the CLI returns. Custom domains (private cloud) are valid here.
+
+**This pinned `tenant_domain` is the canonical Auth0-hosted URL.** Every report reference to the tenant URL — header right rail, "authentication is served from `<tenant_domain>`" narrative, CLI commands — reads from `state/setup.json.tenant_domain`. Never derive it from the company context, never parse it from the company domain. The company context provides company-level fields (name, products, business model, integrations) — never the tenant URL.
+
+## Phase 2 — Dedicated CheckMate M2M app
+
+### 2.1 Detect existing
+```bash
+auth0 apps list --json | jq -r '.[] | select(.name|test("CheckMate";"i")) | {client_id, name}'
+```
+
+If a match exists, fetch its current client grant for the Management API audience and **diff scopes** against the required list (Phase 2.3). Missing scopes → `PATCH` the existing grant; **never delete + recreate** (rotates secret silently).
+
+### 2.2 Create if missing
+```bash
+auth0 apps create --name "Auth0 CheckMate" --type m2m \
+  --description "CheckMate tenant audit (managed by this workflow)" \
+  --json
+```
+
+The JSON response carries `client_id` and `client_secret`. **Never echo the secret outside the user's chat or write it to disk** other than `~/.auth0-checkmate.env` (Phase 2.4).
+
+> Free-plan tenants are limited to 1 free M2M app for the Management API. If create fails with a quota error, list existing M2M apps with Management API grants and ask the user which to reuse.
+
+### 2.3 Authorize Management API scopes (26 read scopes)
+
+```
+read:tenant_settings read:custom_domains read:prompts read:clients
+read:connections read:connections_options read:resource_servers
+read:client_grants read:roles read:branding read:email_provider
+read:email_templates read:phone_providers read:phone_templates
+read:shields read:attack_protection read:self_service_profiles
+read:guardian_factors read:mfa_policies read:actions read:log_streams
+read:logs read:network_acls read:event_streams read:hooks read:rules
+```
+
+Grant via the Management API (the CLI `auth0 api` is a raw wrapper):
+```bash
+auth0 api post "client-grants" --data '{
+  "client_id":"<id>",
+  "audience":"https://<tenant_domain>/api/v2/",
+  "scope":["read:tenant_settings","read:custom_domains","read:prompts","read:clients","read:connections","read:connections_options","read:resource_servers","read:client_grants","read:roles","read:branding","read:email_provider","read:email_templates","read:phone_providers","read:phone_templates","read:shields","read:attack_protection","read:self_service_profiles","read:guardian_factors","read:mfa_policies","read:actions","read:log_streams","read:logs","read:network_acls","read:event_streams","read:hooks","read:rules"]
+}'
+```
+
+Some tenants reject `read:hooks` / `read:rules` (deprecated). On 400, retry without those two and proceed.
+
+If the grant call returns 403, the login session is missing `create:client_grants` — go back to Phase 1.1 and re-login with that scope.
+
+### 2.4 Persist creds to a portable env file
+
+Write a dedicated env file at `~/.auth0-checkmate.env` and lock its permissions. This works the same way on macOS, Linux, WSL, and Git Bash — no shell-rc surgery required. Fish users: see the Portability section below.
+
+```bash
+ENV_FILE="$HOME/.auth0-checkmate.env"
+cat > "$ENV_FILE" <<'EOF'
+# Auth0 CheckMate credentials — managed by this workflow.
+# Treat as secret. Restrict permissions and exclude from dotfile repos / backups.
+export AUTH0CHECKMATE_DOMAIN="<tenant_domain>"
+export AUTH0CHECKMATE_CLIENT_ID="<client_id>"
+export AUTH0CHECKMATE_CLIENT_SECRET="<client_secret>"
+EOF
+chmod 600 "$ENV_FILE"
+```
+
+**Replace `<tenant_domain>`, `<client_id>`, and `<client_secret>` with the values from Phase 2 before writing this file.** The heredoc is single-quoted to prevent shell expansion — substitute inline, e.g. `sed -i "s/<tenant_domain>/$DOMAIN/" ~/.auth0-checkmate.env`, or open the file in an editor. The workflow reloads this file in Phase 4 via `source`. The user does NOT need to add anything to their shell rc — but they can, for convenience: `echo 'source ~/.auth0-checkmate.env' >> ~/.zshrc` (or `~/.bashrc`).
+
+Save `client_id` (NOT the secret) to the state file.
+
+### About the CheckMate CLI itself
+
+CheckMate for Auth0 (`@auth0/auth0-checkmate`) is a command-line utility that performs configuration checks on your Auth0 tenant, validating key settings and generating a detailed audit report. It requires Node.js v20.18.3 or higher and a valid Auth0 tenant.
+
+It makes use of the Auth0 Management API, which consumes the tenant's rate limits — use it thoughtfully to avoid throttling. Its usage is visible in the tenant's log events in several ways: the `User-Agent` HTTP header (`${packageName}/${packageVersion}`, e.g. `@auth0/auth0-checkmate/1.4.0`, unless the client modifies it), the `client_name` and `scopes` assigned when configuring initial access, and `seccft` events (successful exchange of an access token for a client-credentials grant) in Auth0 logs.
+
+Install it globally with `npm install -g @auth0/auth0-checkmate`, then run it with `a0checkmate` and follow the interactive prompts. Update with `npm update -g @auth0/auth0-checkmate`. Alternatively, run from source: clone `auth0/auth0-checkmate`, `cd` into it, `npm install`, then `npm start`.
+
+The dedicated M2M application this phase creates authorizes calls to the Management API and needs exactly the 26 read scopes listed in 2.3 — no more. CheckMate also accepts these environment variables for a CI-friendly, non-interactive configuration (used directly in Phase 4.2):
+```text
+AUTH0CHECKMATE_DISABLE_PDF_REPORTING=true|false
+AUTH0CHECKMATE_DOMAIN=your_domain
+AUTH0CHECKMATE_CLIENT_ID=your_client_id
+AUTH0CHECKMATE_CLIENT_SECRET=your_client_secret
+AUTH0CHECKMATE_FILE_PATH="./reports"
+AUTH0CHECKMATE_SHOW_VALIDATORS=false
+```
+
+## Phase 3 — Company context (lightweight, parallel)
+
+Kick this off **before** running CheckMate — it's network-bound and independent. The goal is narrow: make the audit *relevant to the customer's product* — what they build, who logs in, and what they integrate with — so each finding reads in their own terms. This is **not** a sales-qualification step: do **not** produce fit scores, a "plan fit" verdict, or firmographics (funding, valuation, investors, headcount). The plan suggestion in Phase 5 is derived from the customer's use case + this tenant's actual findings + the pricing reference — never from a company fit score.
+
+Given the company domain, gather public context with whatever web fetch / search tools the agent has. Treat live data as the primary source of truth; use training knowledge only to supplement.
+
+**Pages to read (best-effort, cap ~3000 chars each):** `/` (value prop, products, target market), `/about` (what they do), `/login` `/signin` (auth surfaces + current-provider signals), `/pricing` (B2B vs B2C, tiers), `/security` `/trust` (posture, compliance), `/docs` `/developers` (auth standards, API patterns), `/integrations` `/partners` (third-party APIs — relevant to Token Vault / A4AA), `/careers` (auth tech named in job posts).
+
+**Current auth-provider detection (optional, best-effort):** scan the homepage + login-page HTML and job posts. A login redirect to a provider domain is the strongest signal. Patterns: Auth0 (`.auth0.com`, `auth0-spa-js`), Clerk (`clerk.com`, `@clerk/`, `pk_live_`), WorkOS (`workos.com`, `authkit`), AWS Cognito (`cognito-idp`, `amazoncognito.com`), Firebase Auth (`firebaseapp.com`, `identitytoolkit.googleapis.com`), Okta / Keycloak / FusionAuth / Frontegg / Supabase (provider domain or SDK name). Record provider + confidence (high = redirect match, medium = single SDK signal, low = inference) + the exact evidence.
+
+**Classify (best-effort; use `null` when unsure — never invent):**
+- `company_name`, `product_summary` — name the product(s) and what they do, who the end users are.
+- `business_model` — B2C / B2B / B2B SaaS / Marketplace / Platform / Fintech / Other.
+- `ai_use_case` — AI-Native / AI-Differentiated / AI-Enhanced / None / Unknown, with a one-line description.
+- `login_portal_assessment` — the distinct login surfaces and who uses each (consumers / business customers / developers / partners / internal staff).
+- `user_types`, `auth_standards_detected` (OIDC / OAuth2 / SAML / JWT / WebAuthn), `notable_auth_features` (MFA, SSO, passwordless, social, magic links, API keys, bot protection).
+- `integrations` — third-party APIs the product or its agents touch (Gmail, Slack, Salesforce, Stripe, GitHub, Jira, HubSpot, …). Used **only** to judge whether Token Vault / CIBA recommendations are relevant.
+
+Save the resulting JSON to `~/.auth0-checkmate/state/enrichment_<domain>_<timestamp>.json` (`company_context_*.json` is also fine).
+
+If context gathering fails (no internet, web tool errors), **don't block** — continue with CheckMate. The Phase 5 report degrades gracefully: findings stay accurate, they just won't be framed in product-specific language.
+
+## Phase 4 — Run CheckMate + gather tenant facts
+
+### 4.1 Prereqs
+- Node ≥ 20.18.3 (`node -v`). CheckMate ships Puppeteer which downloads Chromium (~150 MB) on install — flag this to the user before installing.
+- Install if missing: `npm install -g @auth0/auth0-checkmate`
+
+### 4.2 Run with env-var config
+
+Use an absolute report path (relative paths resolve to cwd which may be wrong) and disable PDF generation — the JSON is what Phase 5 consumes, and skipping PDF avoids the Chromium dependency:
+
+```bash
+REPORT_DIR="$HOME/Documents/auth0_checkmate_reports"
+mkdir -p "$REPORT_DIR"
+source ~/.auth0-checkmate.env 2>/dev/null  # ensure env vars are available
+AUTH0CHECKMATE_DOMAIN="$AUTH0CHECKMATE_DOMAIN" \
+AUTH0CHECKMATE_CLIENT_ID="$AUTH0CHECKMATE_CLIENT_ID" \
+AUTH0CHECKMATE_CLIENT_SECRET="$AUTH0CHECKMATE_CLIENT_SECRET" \
+AUTH0CHECKMATE_FILE_PATH="$REPORT_DIR" \
+AUTH0CHECKMATE_DISABLE_PDF_REPORTING=true \
+AUTH0CHECKMATE_SHOW_VALIDATORS=false \
+a0checkmate
+```
+
+### 4.3 Locate output
+CheckMate writes `<tenant>_<locale>_<YYYYMMDD_HHMMSS>_report.json` (and a `.pdf` unless disabled) into `FILE_PATH`. Pick the newest:
+```bash
+ls -t "$REPORT_DIR"/*_report.json | head -1
+```
+
+The JSON's main array lives at `data.report.summary[]` with fields like `severity` (info/warning/critical), `title`, `severity_message`, `detailsLength`, plus per-finding details. Confirm the exact shape before parsing — versions may evolve.
+
+### 4.4 Gather extra tenant facts (for the report template)
+
+The Phase 5 report needs more than CheckMate alone provides. Run these in parallel and capture each output:
+
+```bash
+auth0 apps list --json                   # apps_list — count + names for Section 1, 3, 4
+auth0 logs list --number 50 --json       # logs_sample — to flag "Active" login activity
+auth0 api get tenants/settings           # tenant_settings — for "Current Auth0 Tier" detection (look for plan/subscription hints; fallback "Free Plan"). Map detected features against the pricing reference to infer the tier when no explicit plan field is present.
+auth0 api get custom-domains             # custom_domains — empty array → triggers "Branding Gap"
+auth0 api get connections                # connections — for enterprise-connection check
+auth0 api get log-streams                # log_streams — empty array → triggers "Observability Gap"
+auth0 api get attack-protection/breached-password-detection  # for "Account Security" section
+```
+
+These outputs feed directly into the Phase 5 fusion.
+
+## Phase 5 — Produce the personalized report (markdown + PDF)
+
+Read all inputs:
+- CheckMate JSON (`*_report.json`) — severities, finding titles, details
+- Enrichment JSON (`state/enrichment_<domain>_<ts>.json`, may be missing if Phase 3 failed)
+- Tenant facts from Phase 4.4
+- `state/operator.json` — reviewer name
+- `state/setup.json.tenant_domain` — canonical tenant URL
+
+**Produce three files** following the locked report skeleton:
+1. A **markdown brief** following the markdown report template in `assets/audit/`
+2. A **styled HTML brief** following `assets/audit/report-template.html` — same data, render-ready
+3. A **PDF** rendered from the HTML by `${CLAUDE_SKILL_DIR}/scripts/render_pdf.sh`
+
+Key rules below.
+
+### Source-of-truth rule
+Every `<tenant_domain>` reference (header right rail, "authentication is served from..." narrative, CLI commands) reads from `state/setup.json.tenant_domain`. Never from the company context. The company context provides company-level fields (name, products, business model, integrations).
+
+### Header
+- Title: **Auth0 Platform Development Review**
+- Subtitle: `Prepared by <reviewer_org>` — **omit the line entirely if `reviewer_org` is blank** (most self-audit cases)
+- Right rail: `<plan_tag>` · `<Customer Name>` · `<tenant_domain>` · `<Month DD, YYYY>`
+- Metadata table:
+  - **Prepared by:** `state/operator.json.reviewer_name`
+  - **Date of Review:** today
+  - **Customer Account:** `<Customer Name> (<tenant_domain>)`
+  - **Current Auth0 Tier:** plan from `tenant_settings`, fallback "Free Plan"
+  - **Use Case Diagnosis:** `<business_model> — <product_summary_short>` from the company context
+  - **Recommended Plan:** `<recommended_plan>` — the plan that fits the customer's use case and unlocks this tenant's *After Upgrading* findings (derived from the use case + findings + the pricing reference; plan name only, no price) ` · Auth for AI Agents: <Yes|No>` (Yes only when Phase 3 found concrete agent / third-party integrations Token Vault or CIBA would serve). Example: `B2B Essentials · Auth for AI Agents: Yes`
+
+### Section 1 — Account Health
+- Metrics table:
+  - Applications Registered: count from `apps_list`
+  - Login Activity: "Active (detected on canonical domain)" / "Inactive" — derived from `logs_sample`
+  - Security Findings: `<N> High`, `<N> Moderate`, `<N> Low / Info`, `<N> Passing` from CheckMate severity breakdown
+- 2-4 personalized **Gap callouts** — bold name + 1-2 sentence narrative naming customer products / portals / users from enrichment. Standard candidates (include only when CheckMate evidence + enrichment context support it):
+  - **The Branding Gap** — empty `custom_domains` → name canonical `tenant_domain`, name 2-3 affected products
+  - **The Security Gap** — no MFA configured → reference customer's user types / data sensitivity
+  - **The Production Readiness Gap** — dev URLs in prod, implicit grant types → name offending apps from `apps_list`
+  - **The Compliance Gap** — empty `log_streams` + regulated industry / EU tenant
+  - **The Observability Gap** — empty `log_streams` (generic version)
+
+### Section 2 — Executive Summary
+- Opening paragraph: name customer products from enrichment, apps count from `apps_list`, "graduating from working setup to production-grade enterprise-ready" framing, then state CheckMate finding counts (`<N> High` and `<N> Moderate`).
+- **Configuration Posture at a Glance** table: Severity / Count / Key Examples (top 3-5 finding titles per row, dot-separated).
+
+### Section 3 — Strategic Opportunities & Action Plan
+Four-column table: **Feature Area · The Enterprise Challenge · The Solution · Strategic Impact**. Standard rows when applicable:
+
+- **Brand Trust & UX → Custom Domains** (no `custom_domains`)
+- **Per-Organization Management → Auth0 Organizations** (B2B + multi-customer apps)
+- **Enterprise SSO → Enterprise Connections (SAML / OIDC)** (B2B + no enterprise connections)
+- **Account Security → MFA (WebAuthn / Authenticator App)** (no MFA)
+- **Observability → Log Streaming** (no `log_streams`)
+- **AI Agent Security → Token Vault (A4AA)** (`ai_use_case` ∈ AI-Native/AI-Differentiated + integrations)
+- **Human-in-the-Loop AI → CIBA (A4AA)** (autonomous-action workflows in enrichment)
+
+Every row weaves enrichment data — name products, customer types, business model, integrations, region.
+
+### Section 4 — Recommended Roadmap & Next Steps
+- **Recommended Plan banner:** `<recommended_plan>` — the plan that fits the customer's use case and unlocks the *After Upgrading* fixes (from the use case + the triage table + the pricing reference). Append " + Auth for AI Agents (A4AA)" only when Phase 3 found concrete agent / third-party integrations Token Vault or CIBA would serve. **Never quote or estimate an Enterprise price;** if Enterprise-only findings exist, note they require Auth0 sales.
+- 1-paragraph rationale tying plan to enrichment (name customer products, business model)
+- **Immediate Actions — Available Today (Free):** numbered list of CheckMate findings actionable on the **current** plan. Name affected apps/connections explicitly. Feeds the remediation reference's Loop A.
+- **After Upgrading:** numbered list of fixes requiring the recommended plan. Feeds the remediation reference's Loop B.
+- **Key Documentation:** 2-column grid of doc links matched to Section 3 rows.
+- Footer: `Confidential · Auth0 tenant configuration review for <Customer Name> · <Month YYYY>`
+
+### Triage rule (Immediate vs After Upgrading)
+
+**The source of truth for which plan a feature requires is the co-loaded pricing reference** — the full Auth0 feature→plan matrix (B2C + B2B). Read it before triaging; do NOT guess from feature names or memory. A finding goes into **Immediate Actions** only if its fix is achievable on the tenant's **current** plan (detected in Phase 4.4, fallback Free). Everything else goes into **After Upgrading**, labeled with the minimum plan that unlocks it.
+
+Common misconception to avoid: **Custom Domains is NOT an upgrade feature** — the Free plan includes 1 custom domain (credit-card verification required). Never place it under "After Upgrading."
+
+Quick reference for the findings CheckMate emits (verify against the pricing reference — it wins on any conflict):
+
+| CheckMate finding | Minimum plan | Loop |
+|---|---|---|
+| Application Grant Types (remove `implicit`, Auth Code + PKCE) | **Free** (app config) | Immediate |
+| Cross Origin Authentication (disable) | **Free** | Immediate |
+| Refresh Tokens (enable rotating) | **Free** | Immediate |
+| PKCE Enforcement / Token Sender-Constraining | **Free** | Immediate |
+| Databases – Password Complexity / Email Attribute Verification | **Free** (connection config) | Immediate |
+| Brute Force Protection / Suspicious IP Throttling | **Free** (all plans) | Immediate |
+| Session Management / Tenant Login URI / Allowed Logout URLs | **Free** (tenant settings) | Immediate |
+| Management API Access Control (M2M scopes) | **Free** | Immediate |
+| **Custom Domains** | **Free** (1, CC verification) | **Immediate** |
+| Email Providers / Email Templates (Email Workflow) | **Essentials** | After Upgrading |
+| Log Streams | **Essentials** (1 stream) | After Upgrading |
+| MFA factors / Multifactor Policy / MFA for Password Reset† | **Essentials** (Pro MFA Factors) | After Upgrading |
+| Breached Password Detection (blocking) / Enhanced Password Protection | **Professional** | After Upgrading |
+| Security Center | **Professional** (B2C) | After Upgrading |
+| Tenant Access Control List (ACL) | **Enterprise** (add-on) | After Upgrading |
+| OIDC Back-Channel Logout | **Enterprise** | After Upgrading |
+| Private Key JWT / JAR / PAR | **Enterprise** | After Upgrading |
+| CIBA (A4AA) | Essentials + **A4AA add-on** | After Upgrading |
+| Token Vault (A4AA) | Free gets 2; more via **A4AA add-on** | After Upgrading (scale) |
+
+† The Password Reset *Action* itself deploys on Free (5 Actions included), but it can only **challenge** MFA once MFA factors are enabled, which requires Essentials+. Treat the end-to-end "MFA on password reset" outcome as Essentials.
+
+Enterprise-only findings (Tenant ACL, Back-Channel Logout, Private Key JWT) are out of self-service scope — list them under After Upgrading but note they require an Enterprise plan / Auth0 sales, not a self-service upgrade.
+
+### Fusion checklist (verify before saving — every item is mandatory)
+
+The point of this workflow is to fuse enrichment intelligence into the audit so the customer sees **why each recommendation matters for their specific business**, not generic best-practice. Before saving the files, walk this checklist. If any item fails, regenerate that section.
+
+1. **Header metadata** uses the customer's actual `company_name`, `business_model`, `product_summary_short`, and the derived `<recommended_plan>` — no template placeholders.
+2. **Section 1 metrics** show real `apps_count` from `auth0 apps list`, real CheckMate severity counts, real login activity derived from `auth0 logs list`.
+3. **Section 1 Gap callouts** each name at least one specific product, app, or user segment from enrichment / `apps_list`. If a callout reads generically ("enterprise clients...", "the affected apps..."), rewrite it with concrete names or omit it.
+4. **Section 2 opening paragraph** lists the customer's products by name (e.g. "Customer Portal, Admin Console, Mobile App") — never "the customer's apps".
+5. **Section 3 — every row's `Enterprise Challenge` cell** references concrete enrichment data: product names, business model, user types, integrations, region, AI workflows, or industry. **If you cannot fill any cell with company-specific content, OMIT the row entirely.** A generic row is worse than no row.
+6. **Section 4 plan rationale** names the customer's products and ties them to the recommended plan's specific features.
+7. **Section 4 action lists** name affected apps/connections explicitly (e.g. "Disable implicit grant on `Default App, Admin Console Web`" — never "Disable implicit grant on the affected apps").
+8. **No `{{placeholder}}` strings** remain in either rendered file.
+
+Final lint:
+```bash
+grep -nE '\{\{|enterprise clients[^A-Za-z]|the customer[^A-Za-z]|the affected apps' "$MD_PATH" "$HTML_PATH"
+```
+Output must be empty. If non-empty, rewrite the flagged passages with company-specific content.
+
+### Output paths
+Write all three to `~/Documents/`, with the same timestamped basename:
+```
+auth0_checkmate_<sanitized_tenant>_<YYYYMMDD_HHMMSS>.md
+auth0_checkmate_<sanitized_tenant>_<YYYYMMDD_HHMMSS>.html
+auth0_checkmate_<sanitized_tenant>_<YYYYMMDD_HHMMSS>.pdf
+```
+(Date-time, not just date — same-day re-runs must not collide. Sanitize `tenant_domain` by replacing `.` with `_`.)
+
+### Render the PDF
+```bash
+"${CLAUDE_SKILL_DIR}/scripts/render_pdf.sh" "$HTML_PATH" "$PDF_PATH"
+# ${CLAUDE_SKILL_DIR} is the absolute path to this skill folder (auto-set by Claude Code).
+# Other agents: substitute the absolute path to wherever this skill folder was extracted.
+```
+
+If the script exits non-zero, surface the renderer's error message — the markdown and HTML are already saved, so the user has fallback artifacts. Common cause: no Chrome / Chromium / Edge / Brave / Arc app installed and no `wkhtmltopdf` / `weasyprint`. The script's stderr message tells the user how to fix.
+
+### Chat summary
+Render a short chat summary: top 3-5 findings by severity, each with a one-line personalized "why this matters for `<Company>`" framed in the customer's product/business terms. End with the three file paths.
+
+## Phase 6 — Walk the user through the report
+
+Branch on `state/setup.json.mode` (set in Phase 0.3):
+
+- **Audit only** → render the chat summary, print the three file paths (md / html / pdf), END the run. Do NOT proceed to remediation.
+- **Express** or **Guided** → render the chat summary, print file paths, then continue to remediation using the co-loaded remediation reference. The report's "Immediate Actions" and "After Upgrading" lists are the canonical work queues.
+
+Remediation itself — the command-shape mapping, the per-item guided flow, the express-mode batch flow, the plan-upgrade gate, and the never-without-confirmation list — is covered in full by the remediation reference loaded alongside this one; every applied fix still requires per-command confirmation, every change is verified by re-fetching the resource, and a failed command is never retried destructively.
+
+## State files
+
+Located under `~/.auth0-checkmate/state/` (created lazily):
+
+| File | Purpose |
+|---|---|
+| `setup.json` | cache: tenant_domain, checkmate_client_id, company_domain, last_run_at — secrets excluded |
+| `operator.json` | reviewer name + optional org/role for the report header |
+| `enrichment_<domain>_<ts>.json` | one per enrichment run |
+| `queue.json` | queued / skipped / pending_upgrade items across runs |
+| `history.jsonl` | append-only log of applied/queued/skipped findings per run |
+
+## Pitfalls to remember
+
+- `read:hooks` / `read:rules` are deprecated; some tenants 400 on grant. Retry without them.
+- Free-plan tenants: 1 M2M app quota for Management API. Reuse if name match.
+- `AUTH0CHECKMATE_FILE_PATH` is relative-to-cwd by default — always pass an absolute path.
+- Tenant region: trust `auth0 tenants list --json`, don't parse the domain.
+- State file is a cache — re-validate each field every run; never act on it without verification.
+- `~/.auth0-checkmate.env` is not auto-sourced. The workflow does it in Phase 4; outside the workflow, the user has to either `source` it manually each session or chain it into their shell rc.
+
+## Portability notes (cross-OS / cross-shell)
+
+This workflow is designed to work for any Auth0 customer, not just the author's machine.
+
+**Operating systems**
+- macOS, Linux, and Windows-WSL are first-class. Native Windows (PowerShell / cmd) is not supported by this workflow's bash steps; users on native Windows should run inside WSL or Git Bash.
+- `~/Documents` exists by default on macOS and Windows; on Linux it depends on user setup. If `~/Documents` doesn't exist, fall back to `~/auth0-checkmate-reports` (create it on first write).
+
+**Shells**
+- `~/.auth0-checkmate.env` uses POSIX `export` syntax — works for bash, zsh, dash, ksh, and Git Bash.
+- Fish shell users: the env file syntax differs (`set -gx` instead of `export`). The workflow writes the POSIX form by default; a fish-specific file at `~/.config/fish/conf.d/auth0-checkmate.fish` can be added by the user. Phase 4's `source ~/.auth0-checkmate.env` won't work in fish — pass env vars inline instead.
+
+**PDF renderer**
+- `scripts/render_pdf.sh` searches Chrome / Chromium / Edge / Brave / Arc on macOS, Linux, and WSL paths automatically. Falls back to `wkhtmltopdf` and then `weasyprint` if no browser is found.
+- If none are available, the markdown and HTML files still get written — the PDF step is skipped with a clear error message telling the user how to install one renderer. The workflow should NOT fail the whole run on PDF render failure.
+
+**Auth0 CLI install**
+- See Phase 1.1 for per-platform install commands. The CLI itself is a single Go binary, so any OS with Go ≥ 1.21 can use `go install` as the universal fallback.
+
+**Self-audit vs CS-audit modes**
+- `reviewer_org` blank → the report subtitle is omitted (clean self-audit look).
+- `reviewer_org` populated → the report subtitle reads "Prepared by `<reviewer_org>`" (CS / consulting / partner mode).
+- Either way, the report content is identical — the only difference is the header subtitle.
+- Enrichment provides company-level fields only — never the tenant URL. Tenant URL always comes from `state/setup.json.tenant_domain`.

--- a/plugins/auth0/skills/auth0/scripts/render_pdf.sh
+++ b/plugins/auth0/skills/auth0/scripts/render_pdf.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# render_pdf.sh — convert a styled HTML report into PDF.
+# Usage: render_pdf.sh <input.html> <output.pdf>
+# Tries headless Chrome first (zero install on macOS), then wkhtmltopdf, then weasyprint.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <input.html> <output.pdf>" >&2
+  exit 2
+fi
+
+INPUT="$1"
+OUTPUT="$2"
+
+if [[ ! -f "$INPUT" ]]; then
+  echo "render_pdf: input file not found: $INPUT" >&2
+  exit 1
+fi
+
+# Resolve to absolute paths — Chrome's --print-to-pdf is picky about cwd.
+INPUT_ABS="$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")"
+OUTPUT_DIR="$(cd "$(dirname "$OUTPUT")" && pwd)"
+OUTPUT_ABS="$OUTPUT_DIR/$(basename "$OUTPUT")"
+
+CHROME_CANDIDATES=(
+  # PATH lookups first — works on any system where Chrome is on $PATH
+  google-chrome
+  google-chrome-stable
+  chromium
+  chromium-browser
+  chrome
+  microsoft-edge
+  microsoft-edge-stable
+  brave-browser
+
+  # macOS app bundles
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  "/Applications/Chromium.app/Contents/MacOS/Chromium"
+  "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
+  "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+  "/Applications/Arc.app/Contents/MacOS/Arc"
+
+  # Linux package locations
+  /usr/bin/google-chrome
+  /usr/bin/google-chrome-stable
+  /usr/bin/chromium
+  /usr/bin/chromium-browser
+  /usr/bin/microsoft-edge
+  /usr/bin/microsoft-edge-stable
+  /usr/bin/brave-browser
+  /opt/google/chrome/google-chrome
+  /opt/google/chrome/chrome
+  /snap/bin/chromium
+  /snap/bin/chrome
+
+  # Windows / WSL fallbacks
+  "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"
+  "/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
+  "/mnt/c/Program Files/Microsoft/Edge/Application/msedge.exe"
+  "/c/Program Files/Google/Chrome/Application/chrome.exe"
+  "/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
+)
+
+resolve_chrome() {
+  local cand="$1"
+  if [[ "$cand" == /* ]] || [[ "$cand" == "./"* ]]; then
+    [[ -x "$cand" ]] && printf '%s' "$cand" && return 0
+    return 1
+  fi
+  command -v "$cand" 2>/dev/null && return 0
+  return 1
+}
+
+CHROME=""
+for cand in "${CHROME_CANDIDATES[@]}"; do
+  if resolved="$(resolve_chrome "$cand")"; then
+    CHROME="$resolved"
+    break
+  fi
+done
+
+if [[ -n "$CHROME" ]]; then
+  echo "render_pdf: using $CHROME" >&2
+  # Render to a temp file and only promote it on success — a stale PDF already
+  # sitting at OUTPUT_ABS must never be mistaken for a fresh, successful render.
+  TMP_PDF="$(mktemp -t render_pdf.XXXXXX 2>/dev/null || echo "${OUTPUT_ABS}.tmp.$$")"
+  "$CHROME" \
+    --headless=new \
+    --disable-gpu \
+    --no-pdf-header-footer \
+    --print-to-pdf="$TMP_PDF" \
+    "file://$INPUT_ABS" \
+    >/dev/null 2>&1 \
+    || "$CHROME" \
+      --headless \
+      --disable-gpu \
+      --print-to-pdf="$TMP_PDF" \
+      "file://$INPUT_ABS" \
+      >/dev/null 2>&1 || true
+  if [[ -s "$TMP_PDF" ]]; then
+    mv -f "$TMP_PDF" "$OUTPUT_ABS"
+    echo "render_pdf: wrote $OUTPUT_ABS" >&2
+    exit 0
+  fi
+  rm -f "$TMP_PDF"
+  echo "render_pdf: Chrome produced no output; trying other renderers" >&2
+fi
+
+if command -v wkhtmltopdf >/dev/null 2>&1; then
+  echo "render_pdf: using wkhtmltopdf" >&2
+  wkhtmltopdf --enable-local-file-access "$INPUT_ABS" "$OUTPUT_ABS"
+  exit $?
+fi
+
+if command -v weasyprint >/dev/null 2>&1; then
+  echo "render_pdf: using weasyprint" >&2
+  weasyprint "$INPUT_ABS" "$OUTPUT_ABS"
+  exit $?
+fi
+
+cat >&2 <<EOF
+render_pdf: no PDF renderer found.
+Tried: Chrome / Chromium / Edge / Brave / Arc on macOS, Linux, WSL paths,
+       plus wkhtmltopdf and weasyprint.
+
+Install one of:
+  - Google Chrome  https://www.google.com/chrome  (recommended; zero-config)
+  - Chromium       (Linux: \`apt install chromium\` / \`dnf install chromium\`)
+  - wkhtmltopdf    (macOS: \`brew install --cask wkhtmltopdf\` · Linux: \`apt install wkhtmltopdf\`)
+  - weasyprint     (\`pip install weasyprint\` plus system cairo + pango)
+
+The HTML report is still at: $INPUT_ABS
+EOF
+exit 1

--- a/plugins/auth0/skills/auth0/scripts/render_pdf.sh
+++ b/plugins/auth0/skills/auth0/scripts/render_pdf.sh
@@ -20,7 +20,13 @@ fi
 
 # Resolve to absolute paths — Chrome's --print-to-pdf is picky about cwd.
 INPUT_ABS="$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")"
-OUTPUT_DIR="$(cd "$(dirname "$OUTPUT")" && pwd)"
+
+OUTPUT_PARENT="$(dirname "$OUTPUT")"
+if [[ ! -d "$OUTPUT_PARENT" ]]; then
+  echo "render_pdf: output directory does not exist: $OUTPUT_PARENT" >&2
+  exit 1
+fi
+OUTPUT_DIR="$(cd "$OUTPUT_PARENT" && pwd)"
 OUTPUT_ABS="$OUTPUT_DIR/$(basename "$OUTPUT")"
 
 CHROME_CANDIDATES=(


### PR DESCRIPTION
## What this adds

An **`audit` intent** on the `auth0` skill: a developer can ask an agent to audit their own
Auth0 tenant and get back a personalized security and configuration review, plus an optional
gated remediation pass that applies the fixes they approve.

The workflow runs [CheckMate](https://github.com/auth0/auth0-checkmate) against the tenant and
turns its raw findings into something specific to that customer:

- **Bootstrap** — Auth0 CLI login, then create (or reuse) a dedicated M2M application scoped to
  26 Management API **read** scopes. Credentials land in `~/.auth0-checkmate.env`, mode `600`.
- **Company context** — a light pass over the customer's business model, products, and auth
  surfaces, so findings read as "this affects your checkout flow," not "MFA is off."
- **Triage** — each finding gets a severity, a personalized remediation note, and a bucket:
  **Immediate Actions** (fixable on the current plan) vs **After Upgrading** (needs a higher
  plan). The split comes from the feature→plan matrix, so it never tells someone to enable
  something their plan can't do.
- **Report** — Markdown + styled HTML, rendered to PDF via `scripts/render_pdf.sh`.
- **Remediation** *(opt-in)* — Guided or Express, **per-command confirmation**, each change
  verified by re-fetch. Destructive commands (`tenants delete`, `apps delete`, `connections
  delete`, `api delete`, `logout`) are never run without explicit confirmation.

Plan recommendations are deliberately **plan name only, no price** — and never a price or
estimate for Enterprise.

## How it's wired in

`SKILL.md`'s intent table and Step 4 loader route the `audit` intent to:

```
feature-audit.md             # the workflow, Phases 0–6
feature-audit-pricing.md     # feature→plan matrix; drives finding triage
feature-audit-remediation.md # Phase 7: command mapping + safety gates
tooling-{tooling}.md          # CLI / MCP / Terraform, per project context
```

Plus `assets/audit/report-template.{md,html}` and `scripts/render_pdf.sh`.

Pricing is **not vendored**. `feature-audit-pricing.md` keeps the feature→plan matrix locally —
that's what triage routes on and it changes rarely — but every dollar figure is fetched from
[`auth0.com/pricing.md`](https://auth0.com/pricing.md) at quote time. The file used to carry a
verbatim copy of that page, which drifts the moment it lands: the live page has already added an
Event Streams row our snapshot never had. Thanks @brth31 and @sanchitmehtagit for flagging it.

## Gates

| Check | Result |
|---|---|
| `check_router_reachability.py` | all references routable, no second-hop links |
| `check_routing_evals.py` | routing cases resolve, incl. the new `audit` case |
| `skillsaw --strict` | 0 errors / 0 warnings, Grade A |

Behavioral coverage lands in `evals/behavioral/cases/audit.json` as an expectations-only case,
like the other cases that touch a live tenant — it needs `auth0 login` and a real CheckMate
scan, so it can't run unattended. `evals/behavioral/README.md` records what a machine-graded
port would have to fix first.

## Relationship to #127

This PR restructures the work from **#127**, which added the tenant audit as a standalone
`auth0-checkmate` skill. `main` has since moved to a one-skill architecture — a single `auth0`
router over a flat pool of on-demand reference files, where only `SKILL.md` may live in the
skill root and no reference may link to another. #127 predates that, so its content is
re-landed to fit rather than merged as-is.

The intent is that nothing material changes, only where it lives:

| #127 (`auth0-checkmate`) | Here | |
|---|---|---|
| `SKILL.md` Phases 0–6 | `references/feature-audit.md` | |
| `SKILL.md` Phase 7 + closing | `references/feature-audit-remediation.md` | |
| `references/auth0-pricing.md` | `references/feature-audit-pricing.md` | matrix verbatim; prices now fetched |
| `references/checkmate-readme.md`, `auth0-cli-readme.md` | inlined into `feature-audit.md` | the one-hop rule forbids reference→reference links |
| `references/report-template.{md,html}` | `assets/audit/report-template.{md,html}` | relocated |
| `scripts/render_pdf.sh` | `scripts/render_pdf.sh` | verbatim, plus an output-dir guard |
| `tests/evals.json`, `tests/graders.json` | `evals/behavioral/cases/audit.json` | per-skill `tests/` was retired |

Preserved: all seven phases, the exact 26 read scopes, `data.report.summary[]` parsing, the
full finding→plan triage table (including the "Custom Domains is Free, not an upgrade" caveat),
the fusion checklist + placeholder lint, and the two-loop gated remediation.

Also restored from #127 — the `auth0 api` method guidance in `feature-audit-remediation.md`
(`patch` for most resources, `put` for MFA/prompt toggles, `post` for creates; `patch` is not
universal, and `auth0 api` defaults to `GET` without `--data`, so the method must be explicit).

> **Stacked PR.** #142 (the plan-aware health check, also from #127) builds on this branch and
> reuses the pricing and remediation references added here. Merge this first; #142 then
> retargets to `main`.
