### PR TITLE
docs(auth0): harden API test-token examples against inline-token leaks

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-aspnetcore-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-aspnetcore-api.md
@@ -142,11 +142,15 @@ curl http://localhost:5000/api/public
 Test protected endpoint (requires access token):
 
 ```bash
+TOKEN=$(auth0 test token --audience <API_IDENTIFIER> | jq -r '.access_token')
 curl http://localhost:5000/api/private \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 Get a test token via Client Credentials flow or Auth0 Dashboard → APIs → Test tab.
+Capture the token into a shell variable (`TOKEN=$(...)`) and reference `$TOKEN`
+rather than pasting the raw token inline — inline token values leak into shell
+history and terminal scrollback.
 
 ## Common Mistakes
 

--- a/plugins/auth0/skills/auth0/references/framework-aspnetcore-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-aspnetcore-api.md
@@ -142,7 +142,6 @@ curl http://localhost:5000/api/public
 Test protected endpoint (requires access token):
 
 ```bash
-TOKEN=$(auth0 test token --audience <API_IDENTIFIER> | jq -r '.access_token')
 curl http://localhost:5000/api/private \
   -H "Authorization: Bearer $TOKEN"
 ```

--- a/plugins/auth0/skills/auth0/references/framework-express-jwt.md
+++ b/plugins/auth0/skills/auth0/references/framework-express-jwt.md
@@ -173,17 +173,18 @@ In practice, you only install and import `express-oauth2-jwt-bearer`.
 ## Testing Quick Reference
 
 ```bash
-# Get test token from Auth0 Dashboard → APIs → your API → Test tab
-# Copy the token, then:
+# Capture a token into a shell variable — see "Testing Patterns" below for the
+# full command. Reference $ACCESS_TOKEN rather than pasting the raw token
+# inline; inline token values leak into shell history and terminal scrollback.
 
 # 1. Verify 401 on protected route (no token)
 curl -v http://localhost:3000/api/private
 
 # 2. Verify 200 with valid token
-curl -H "Authorization: Bearer <paste-token-here>" http://localhost:3000/api/private
+curl -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:3000/api/private
 
 # 3. Verify 403 with valid token but missing scope
-curl -H "Authorization: Bearer <paste-token-here>" http://localhost:3000/api/admin
+curl -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:3000/api/admin
 
 # 4. Verify CORS preflight
 curl -v -X OPTIONS http://localhost:3000/api/private \

--- a/plugins/auth0/skills/auth0/references/framework-fastapi-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-fastapi-api.md
@@ -164,11 +164,15 @@ async def protected():
 curl http://localhost:8000/api/private
 
 # With a valid access token
+TOKEN=$(auth0 test token --audience <API_IDENTIFIER> | jq -r '.access_token')
 curl http://localhost:8000/api/private \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 Get a test token via Client Credentials flow or Auth0 Dashboard → APIs → Test tab.
+Capture the token into a shell variable (`TOKEN=$(...)`) and reference `$TOKEN`
+rather than pasting the raw token inline — inline token values leak into shell
+history and terminal scrollback.
 
 ## Common Mistakes
 
@@ -649,10 +653,14 @@ To use DPoP authentication, clients must:
 
 ```bash
 # DPoP request example
-curl -H "Authorization: DPoP YOUR_ACCESS_TOKEN" \
-     -H "DPoP: YOUR_DPOP_PROOF_JWT" \
+curl -H "Authorization: DPoP $TOKEN" \
+     -H "DPoP: $DPOP_PROOF_JWT" \
      http://localhost:8000/api/protected
 ```
+
+Capture the token into a shell variable (`TOKEN=$(...)`) and reference `$TOKEN`
+rather than pasting the raw token inline — inline token values leak into shell
+history and terminal scrollback.
 
 ### Enable DPoP on Auth0 API
 

--- a/plugins/auth0/skills/auth0/references/framework-fastapi-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-fastapi-api.md
@@ -164,7 +164,6 @@ async def protected():
 curl http://localhost:8000/api/private
 
 # With a valid access token
-TOKEN=$(auth0 test token --audience <API_IDENTIFIER> | jq -r '.access_token')
 curl http://localhost:8000/api/private \
   -H "Authorization: Bearer $TOKEN"
 ```

--- a/plugins/auth0/skills/auth0/references/framework-fastify-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-fastify-api.md
@@ -96,7 +96,10 @@ fastify.get('/api/profile', {
   preHandler: fastify.requireAuth()
 }, async (request, reply) => {
   return {
-    profile: request.user,  // JWT claims
+    // Return only the fields the client needs. Returning the whole decoded
+    // token (request.user) exposes every claim — permissions, custom
+    // namespaces, and token metadata — to the client.
+    profile: { sub: request.user.sub, scope: request.user.scope },
   };
 });
 ```
@@ -112,9 +115,14 @@ curl http://localhost:3001/api/public
 Test protected endpoint (requires access token):
 
 ```bash
+TOKEN=$(auth0 test token --audience <API_IDENTIFIER> | jq -r '.access_token')
 curl http://localhost:3001/api/private \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+  -H "Authorization: Bearer $TOKEN"
 ```
+
+> Capture the token into a shell variable (`TOKEN=$(...)`) and reference
+> `$TOKEN` rather than pasting the raw token inline — inline token values leak
+> into shell history and terminal scrollback.
 
 
 ## Common Mistakes

--- a/plugins/auth0/skills/auth0/references/framework-fastify-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-fastify-api.md
@@ -115,7 +115,6 @@ curl http://localhost:3001/api/public
 Test protected endpoint (requires access token):
 
 ```bash
-TOKEN=$(auth0 test token --audience <API_IDENTIFIER> | jq -r '.access_token')
 curl http://localhost:3001/api/private \
   -H "Authorization: Bearer $TOKEN"
 ```

--- a/plugins/auth0/skills/auth0/references/framework-springboot-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-springboot-api.md
@@ -483,9 +483,13 @@ spring:
 
 3. **Protected endpoint returns 200 with valid token:**
    ```bash
+   TOKEN=$(auth0 test token --audience <API_IDENTIFIER> --json | jq -r '.access_token')
    curl http://localhost:8080/api/protected \
-     -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+     -H "Authorization: Bearer $TOKEN"
    ```
+   Capture the token into a shell variable and reference `$TOKEN` rather than
+   pasting the raw token inline — inline token values leak into shell history
+   and terminal scrollback. See [Testing with curl](#testing-with-curl) below.
 
 4. **Scope-protected endpoint returns 403 with insufficient scope:**
    ```bash

--- a/plugins/auth0/skills/auth0/references/framework-springboot-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-springboot-api.md
@@ -483,7 +483,6 @@ spring:
 
 3. **Protected endpoint returns 200 with valid token:**
    ```bash
-   TOKEN=$(auth0 test token --audience <API_IDENTIFIER> --json | jq -r '.access_token')
    curl http://localhost:8080/api/protected \
      -H "Authorization: Bearer $TOKEN"
    ```


### PR DESCRIPTION
Part of the ClawHub security-audit remediation (verified against current main; audit ran against v2.0.0).

**Theme: token exposure in API test guidance.** Files: framework-fastify-api, -aspnetcore-api, -fastapi-api, -springboot-api, -express-jwt.

- Test-endpoint curl examples now capture the token into a shell variable and reference `$TOKEN` instead of pasting the raw token inline (inline tokens leak into shell history/scrollback). Mirrors the safe pattern in framework-go.md.
- framework-fastify-api /api/profile now returns only { sub, scope } instead of the whole decoded token.

Doc-only. Verified: skillsaw --strict (0/0), reachability, routing evals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API testing curl examples across supported frameworks (ASP.NET Core, Express JWT, FastAPI, Fastify, Spring Boot) to store access tokens in shell variables and reference them in `Authorization` headers.
  * Added warnings to avoid pasting raw token values to prevent leakage in shell history/scrollback.
  * Updated DPoP examples to use variables for both the access token and proof JWT.
  * Simplified the Fastify protected `/api/profile` response to return only minimal `sub` and `scope` fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->