### PR TITLE
docs(auth0): add token trust-boundary notes, harden .env gates and installer

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-aspnetcore-auth.md
+++ b/plugins/auth0/skills/auth0/references/framework-aspnetcore-auth.md
@@ -34,7 +34,7 @@ Add Auth0 settings to `appsettings.json`:
   "Auth0": {
     "Domain": "your-tenant.us.auth0.com",
     "ClientId": "your_client_id",
-    "ClientSecret": "your_client_secret"
+    "ClientSecret": "<YOUR_CLIENT_SECRET>"
   }
 }
 ```
@@ -44,7 +44,7 @@ Add Auth0 settings to `appsettings.json`:
 ```bash
 dotnet user-secrets set "Auth0:Domain" "your-tenant.us.auth0.com"
 dotnet user-secrets set "Auth0:ClientId" "your_client_id"
-dotnet user-secrets set "Auth0:ClientSecret" "your_client_secret"
+dotnet user-secrets set "Auth0:ClientSecret" "<YOUR_CLIENT_SECRET>"
 ```
 
 `Auth0:Domain` is your tenant domain (without `https://`). `Auth0:ClientId` and `Auth0:ClientSecret` come from your Auth0 Application settings.
@@ -790,6 +790,8 @@ public class ApiController : Controller
 }
 ```
 
+**Trust boundary:** Only send the access token to the API it was issued for (matching `audience`). Don't forward the token to third-party services that aren't the intended resource server, and never log the token.
+
 ### Configure Audience for API Calls
 
 Update `Program.cs` to request an access token for a specific audience:
@@ -820,7 +822,7 @@ Add the audience to `appsettings.json`:
 }
 ```
 
-> Store `ClientSecret` in user-secrets (`dotnet user-secrets set "Auth0:ClientSecret" "your_client_secret"`) or environment variables — never commit secrets to source control.
+> Store `ClientSecret` in user-secrets (`dotnet user-secrets set "Auth0:ClientSecret" "<YOUR_CLIENT_SECRET>"`) or environment variables — never commit secrets to source control.
 
 ---
 
@@ -1185,7 +1187,7 @@ Add the `Auth0` section:
   "Auth0": {
     "Domain": "your-tenant.us.auth0.com",
     "ClientId": "your-client-id",
-    "ClientSecret": "your-client-secret"
+    "ClientSecret": "<YOUR_CLIENT_SECRET>"
   }
 }
 ```
@@ -1196,7 +1198,7 @@ Add the `Auth0` section:
 dotnet user-secrets init
 dotnet user-secrets set "Auth0:Domain" "your-tenant.us.auth0.com"
 dotnet user-secrets set "Auth0:ClientId" "your-client-id"
-dotnet user-secrets set "Auth0:ClientSecret" "your-client-secret"
+dotnet user-secrets set "Auth0:ClientSecret" "<YOUR_CLIENT_SECRET>"
 ```
 
 User secrets override `appsettings.json` in the Development environment. In production, use environment variables:
@@ -1204,7 +1206,7 @@ User secrets override `appsettings.json` in the Development environment. In prod
 ```bash
 export Auth0__Domain="your-tenant.us.auth0.com"
 export Auth0__ClientId="your-client-id"
-export Auth0__ClientSecret="your-client-secret"
+export Auth0__ClientSecret="<YOUR_CLIENT_SECRET>"
 ```
 
 Note: Environment variable names use double underscores (`__`) to represent the `:` separator in .NET configuration keys.

--- a/plugins/auth0/skills/auth0/references/framework-expo.md
+++ b/plugins/auth0/skills/auth0/references/framework-expo.md
@@ -559,6 +559,8 @@ const fetchData = async () => {
 };
 ```
 
+**Trust boundary:** Only send the access token to the API it was issued for (matching `audience`). Don't forward the token to third-party services that aren't the intended resource server, and never log the token.
+
 ### Check for Valid Credentials
 
 ```typescript

--- a/plugins/auth0/skills/auth0/references/framework-express.md
+++ b/plugins/auth0/skills/auth0/references/framework-express.md
@@ -37,7 +37,7 @@ Create `.env`:
 SECRET=<openssl-rand-hex-32>
 BASE_URL=http://localhost:3000
 CLIENT_ID=your-client-id
-CLIENT_SECRET=your-client-secret
+CLIENT_SECRET=<YOUR_CLIENT_SECRET>
 ISSUER_BASE_URL=https://your-tenant.auth0.com
 ```
 
@@ -281,6 +281,8 @@ app.get('/call-api', requiresAuth(), async (req, res) => {
   }
 });
 ```
+
+**Trust boundary:** Only send the access token to the API it was issued for (matching `audience`). Don't forward the token to third-party services that aren't the intended resource server, and never log the token.
 
 **Note:** To call APIs, add `authorizationParams` to middleware config:
 
@@ -794,7 +796,7 @@ npm install express-openid-connect dotenv
 SECRET=<openssl-rand-hex-32>
 BASE_URL=http://localhost:3000
 CLIENT_ID=your-client-id
-CLIENT_SECRET=your-client-secret
+CLIENT_SECRET=<YOUR_CLIENT_SECRET>
 ISSUER_BASE_URL=https://your-tenant.auth0.com
 ```
 

--- a/plugins/auth0/skills/auth0/references/framework-flask.md
+++ b/plugins/auth0/skills/auth0/references/framework-flask.md
@@ -3,6 +3,11 @@
 
 Add login, logout, and user profile to a Flask web application using `auth0-server-python`.
 
+## Critical rules
+
+- Always ask the user for explicit confirmation before running any setup step that writes to a `.env` file; wait for their answer before proceeding.
+- Keep the contents of `.env` out of the agent context. If reading it seems necessary, ask the user for explicit permission first.
+
 ## Prerequisites
 
 - Flask application
@@ -748,6 +753,8 @@ async def api_call():
     return jsonify(response.json())
 ```
 
+**Trust boundary:** Only send the access token to the API it was issued for (matching `audience`). Don't forward the token to third-party services that aren't the intended resource server, and never log the token.
+
 ### Configure Audience
 
 Update the `ServerClient` initialization in `auth.py` to include `audience`:
@@ -948,8 +955,15 @@ Then ask the user for explicit confirmation before proceeding — do not continu
 
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
-  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0/auth0-cli/auth0 || \
-  curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    brew install auth0/auth0-cli/auth0
+  else
+    # Download and review the install script before executing
+    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
+    echo "⚠️  Review the install script at /tmp/auth0-install.sh before running"
+    sh /tmp/auth0-install.sh -b /usr/local/bin
+    rm /tmp/auth0-install.sh
+  fi
 fi
 
 # Login

--- a/plugins/auth0/skills/auth0/references/framework-nextjs.md
+++ b/plugins/auth0/skills/auth0/references/framework-nextjs.md
@@ -3,6 +3,11 @@
 
 Add authentication to Next.js applications using @auth0/nextjs-auth0. Supports both App Router and Pages Router.
 
+## Critical rules
+
+- Always ask the user for explicit confirmation before running any setup step that writes to a `.env` file (including `.env.local`); wait for their answer before proceeding.
+- Keep the contents of `.env` / `.env.local` out of the agent context. If reading it seems necessary, ask the user for explicit permission first.
+
 ## Prerequisites
 
 - Next.js 13+ application (App Router or Pages Router)
@@ -298,6 +303,8 @@ export async function GET() {
   return NextResponse.json(await apiResponse.json());
 }
 ```
+
+**Trust boundary:** Only send an access token to the API it was issued for (matching `audience`). Don't forward tokens to third-party services that aren't the intended resource server, and never log the token.
 
 ---
 


### PR DESCRIPTION
Part of the ClawHub security-audit remediation.

**Theme: web token-forwarding + confirmation gaps.** Files: framework-nextjs, -express, -flask, -aspnetcore-auth, -expo.

- Trust-boundary note on each external-API token-forwarding example (only send a token to the API it was issued for; don't forward to third parties; never log it).
- nextjs & flask: top-of-file .env confirmation critical rule (matching react/vue/spa-js).
- flask: Linux installer switched from `curl … | sh` to download-review-run.
- express / aspnetcore-auth: client_secret placeholders normalized to <YOUR_CLIENT_SECRET> (silences exposed-secret-literal false positive).

Doc-only. Verified: skillsaw --strict (0/0), reachability, routing evals.