### PR TITLE
docs(auth0): review-before-run installers, broaden confirmation gates

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-android.md
+++ b/plugins/auth0/skills/auth0/references/framework-android.md
@@ -11,7 +11,7 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
 
 ## Critical rules
 
-- Before running any part of the automatic setup that writes to `strings.xml`, you MUST ask the user for explicit confirmation before proceeding.
+- Before running any part of any setup path (automatic or manual) that writes to `strings.xml`, you MUST ask the user for explicit confirmation before proceeding.
 - After either automatic or manual Auth0 configuration, you MUST apply the required Post-Setup changes to the project (manifest placeholders in `app/build.gradle` for `auth0Domain` and `auth0Scheme`, etc.) before treating the integration as complete.
 
 ## Prerequisites
@@ -1086,8 +1086,15 @@ SCHEME="demo"
 
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
-  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0/auth0-cli/auth0 || \
-  curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    brew install auth0/auth0-cli/auth0
+  else
+    # Download and review the install script before executing
+    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
+    echo "⚠️  Review the install script at /tmp/auth0-install.sh before running"
+    sh /tmp/auth0-install.sh -b /usr/local/bin
+    rm /tmp/auth0-install.sh
+  fi
 fi
 
 # Login
@@ -1212,7 +1219,7 @@ After the script runs, proceed to **Post-Setup Steps** below.
 
 ### Manual Setup (User-Provided Credentials)
 
-> **Agent instruction:** Ask the user for their Auth0 **Client ID** and **Domain**. Then update `strings.xml` with the values they provide:
+> **Agent instruction:** Ask the user for their Auth0 **Client ID** and **Domain**. Before writing to `strings.xml`, ask the user for explicit confirmation and do not proceed until they confirm. Then update `strings.xml` with the values they provide:
 > ```xml
 > <string name="com_auth0_client_id">USER_PROVIDED_CLIENT_ID</string>
 > <string name="com_auth0_domain">USER_PROVIDED_DOMAIN</string>

--- a/plugins/auth0/skills/auth0/references/framework-angular.md
+++ b/plugins/auth0/skills/auth0/references/framework-angular.md
@@ -786,7 +786,15 @@ Complete setup instructions for Angular applications.
 
 ## Quick Setup (Automated)
 
+> **Agent instruction:** Before running any of the automated steps below, you MUST ask the user how they want to configure Auth0 and wait for their answer:
+> - Question: "How would you like to configure Auth0 for this project?"
+> - Options: "Automatic setup (Recommended) — the Auth0 CLI logs you in, creates the app, and returns credentials to write into your environment files" / "Manual setup — I'll provide my Domain and Client ID (see Manual Setup below)"
+>
+> Do NOT proceed to the script below until the user chooses the automatic path.
+
 ### Bash Script
+
+> **Agent instruction:** The script below runs `auth0 login` (opens a browser session) and `auth0 apps create` (creates a new application in the user's Auth0 tenant). Before running it, you MUST ask the user for explicit confirmation and not proceed until they confirm.
 
 ```bash
 #!/bin/bash

--- a/plugins/auth0/skills/auth0/references/framework-ionic-angular.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-angular.md
@@ -1036,8 +1036,11 @@ If the Auth0 CLI is not installed, instruct the user:
 # macOS
 brew install auth0/auth0-cli/auth0
 
-# Linux
-curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh
+# Linux — download and review the install script before executing
+curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
+echo "⚠️  Review the install script at /tmp/auth0-install.sh before running"
+sh /tmp/auth0-install.sh
+rm /tmp/auth0-install.sh
 ```
 
 If not logged in:

--- a/plugins/auth0/skills/auth0/references/framework-ionic-vue.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-vue.md
@@ -995,7 +995,13 @@ npx cap open android  # Build and run on device from Android Studio
 > ```bash
 > brew install auth0/auth0-cli/auth0
 > ```
-> On Linux: `curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh`
+> On Linux, download and review the install script before executing:
+> ```bash
+> curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
+> echo "⚠️  Review the install script at /tmp/auth0-install.sh before running"
+> sh /tmp/auth0-install.sh
+> rm /tmp/auth0-install.sh
+> ```
 >
 > ---
 >

--- a/plugins/auth0/skills/auth0/references/framework-php-api.md
+++ b/plugins/auth0/skills/auth0/references/framework-php-api.md
@@ -8,6 +8,7 @@ Protect PHP API endpoints with JWT access token validation using `auth0/auth0-ph
 - TOKEN ISOLATION: the agent must NEVER directly see, display, echo, log, or store access token values. Do not run `auth0 test token` on its own, and do not ask the user to paste a token into the conversation.
 - When testing protected endpoints, ALWAYS chain token acquisition and the `curl` call in a single `&&` command that captures the token into a shell variable and uses it immediately.
 - A Client ID is REQUIRED for the M2M token flow — if M2M setup was not completed, ask the user first.
+- Before any setup step that writes to a `.env` file, ask the user for explicit confirmation first.
 - ALWAYS read `domain` and `audience` from environment variables; never embed credentials in source.
 
 ## Prerequisites

--- a/plugins/auth0/skills/auth0/references/framework-php.md
+++ b/plugins/auth0/skills/auth0/references/framework-php.md
@@ -3,6 +3,10 @@
 
 Add login, logout, and user profile to a PHP web application using `auth0/auth0-php`.
 
+## Critical rules
+
+- Before any setup step that writes to a `.env` file, ask the user for explicit confirmation first.
+
 ## Prerequisites
 
 - PHP 8.2+ with extensions: `mbstring`, `openssl`, `json`

--- a/plugins/auth0/skills/auth0/references/framework-spa-js.md
+++ b/plugins/auth0/skills/auth0/references/framework-spa-js.md
@@ -905,7 +905,11 @@ if ! command -v auth0 &> /dev/null; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
     brew install auth0/auth0-cli/auth0
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
+    # Download and review the install script before executing
+    curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
+    echo "⚠️  Review the install script at /tmp/auth0-install.sh before running"
+    sh /tmp/auth0-install.sh -b /usr/local/bin
+    rm /tmp/auth0-install.sh
   else
     echo "Please install Auth0 CLI: https://github.com/auth0/auth0-cli#installation"
     exit 1
@@ -1065,7 +1069,11 @@ brew install auth0/auth0-cli/auth0
 
 **Linux:**
 ```bash
-curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh
+# Download and review the install script before executing
+curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
+echo "⚠️  Review the install script at /tmp/auth0-install.sh before running"
+sh /tmp/auth0-install.sh
+rm /tmp/auth0-install.sh
 ```
 
 **Windows:**


### PR DESCRIPTION
Part of the ClawHub security-audit remediation.

**Theme: confirmation gates + remote-script execution.** Files: framework-android, -spa-js, -ionic-angular, -ionic-vue, -angular, -php, -php-api.

- `curl … install.sh | sh` direct pipes (spa-js, android, ionic-angular, ionic-vue) switched to the download-to-/tmp, review, then run pattern used by express/nextjs/angular. All fetch Auth0's first-party install.sh; the concern was piping straight to a shell without review.
- android: broadened the strings.xml confirmation rule to cover the manual path too (was automatic-only), and added a confirm reminder to the Manual Setup block.
- angular: added an automated-vs-manual choice + a confirmation reminder before `auth0 login` / `auth0 apps create` (tenant mutation) in Quick Setup.
- php / php-api: added a top-of-file .env confirmation critical rule.

Doc-only. Verified: skillsaw --strict (0/0), reachability, routing evals.