### PR TITLE
docs(auth0): add sensitive-data cautions for user export and CLI --json

### DIFF
--- a/plugins/auth0/skills/auth0/references/feature-migration.md
+++ b/plugins/auth0/skills/auth0/references/feature-migration.md
@@ -953,6 +953,8 @@ Detailed guide for exporting users from existing auth providers and importing th
 
 ## Exporting Users from Common Providers
 
+**Caution:** These export files contain password hashes and PII. Never commit them (add to `.gitignore`), keep them out of shared/CI logs, and delete them once the import succeeds.
+
 ### Firebase
 
 **Via Firebase Console:**

--- a/plugins/auth0/skills/auth0/references/tooling-cli.md
+++ b/plugins/auth0/skills/auth0/references/tooling-cli.md
@@ -98,6 +98,8 @@ auth0 users import --connection-name "Username-Password-Authentication" \
   --users '[...]' --upsert --json
 ```
 
+**Note:** `--json` output for user commands returns full profiles (email, metadata) and import payloads carry password hashes — avoid piping to shared logs/CI output.
+
 ### Roles — Manage RBAC Roles
 
 Create roles, assign permissions, and assign roles to users.


### PR DESCRIPTION
Part of the ClawHub security-audit remediation.

**Theme: missing sensitive-data warnings.** Files: feature-migration, tooling-cli.

- feature-migration: caution under 'Exporting Users from Common Providers' that export files contain password hashes and PII — don't commit (add to .gitignore), keep out of shared/CI logs, delete after import.
- tooling-cli: note that `--json` user command output returns full profiles and import payloads carry password hashes — avoid piping to shared logs/CI output.

Doc-only. Verified: skillsaw --strict (0/0), reachability, routing evals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security guidance for user export and import files, including password hashes and personally identifiable information.
  * Warned against committing sensitive files or exposing CLI output in shared logs and CI systems.
  * Recommended deleting sensitive export files after successful imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->