### PR TITLE
docs(auth0): use unmistakable secret placeholders (java-mvc, terraform)

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-java-mvc.md
+++ b/plugins/auth0/skills/auth0/references/framework-java-mvc.md
@@ -95,7 +95,7 @@ Store credentials as environment variables (never hardcode in source):
 ```bash
 export AUTH0_DOMAIN="your-tenant.auth0.com"
 export AUTH0_CLIENT_ID="your-client-id"
-export AUTH0_CLIENT_SECRET="your-client-secret"
+export AUTH0_CLIENT_SECRET="<YOUR_CLIENT_SECRET>"
 ```
 
 Or use a `.env` file (add to `.gitignore`):
@@ -103,7 +103,7 @@ Or use a `.env` file (add to `.gitignore`):
 ```properties
 AUTH0_DOMAIN=your-tenant.auth0.com
 AUTH0_CLIENT_ID=your-client-id
-AUTH0_CLIENT_SECRET=your-client-secret
+AUTH0_CLIENT_SECRET=<YOUR_CLIENT_SECRET>
 ```
 
 > **Agent instruction:** Never write actual credential values to files. Instead, instruct the user to create or update `.env` with their credentials. Provide the template with placeholders only. Always add `.env` to `.gitignore` if not already present. Warn the user: _"Check your `.env` for duplicate Auth0 entries if you've configured it previously."_
@@ -1118,7 +1118,7 @@ Create a `.env` file in your project root (add to `.gitignore`):
 ```properties
 AUTH0_DOMAIN=your-tenant.auth0.com
 AUTH0_CLIENT_ID=your-client-id
-AUTH0_CLIENT_SECRET=your-client-secret
+AUTH0_CLIENT_SECRET=<YOUR_CLIENT_SECRET>
 ```
 
 > **Agent instruction:** Never write actual credential values to files. Instruct the user to populate `.env` with their credentials. If `.env` already exists, remind the user to append (not overwrite). Always add `.env` to `.gitignore` automatically.
@@ -1136,7 +1136,7 @@ Use a `.env` file in the project root:
 ```properties
 AUTH0_DOMAIN=your-tenant.auth0.com
 AUTH0_CLIENT_ID=your-client-id
-AUTH0_CLIENT_SECRET=your-client-secret
+AUTH0_CLIENT_SECRET=<YOUR_CLIENT_SECRET>
 ```
 
 > **Agent instruction:** Never write actual credential values to files. Instruct the user to populate `.env` with their own values. Never retrieve secrets from CLI output. Always ensure `.env` is in `.gitignore`.
@@ -1156,7 +1156,7 @@ Set on the system or in the container startup script:
 ```bash
 export AUTH0_DOMAIN="your-tenant.auth0.com"
 export AUTH0_CLIENT_ID="your-client-id"
-export AUTH0_CLIENT_SECRET="your-client-secret"
+export AUTH0_CLIENT_SECRET="<YOUR_CLIENT_SECRET>"
 ```
 
 **Option 2: Servlet context parameters (web.xml)**

--- a/plugins/auth0/skills/auth0/references/tooling-terraform.md
+++ b/plugins/auth0/skills/auth0/references/tooling-terraform.md
@@ -189,5 +189,5 @@ terraform apply -var-file="auth0.tfvars"
 # auth0.tfvars (add to .gitignore — contains secrets)
 auth0_domain        = "your-tenant.auth0.com"
 auth0_client_id     = "your-m2m-client-id"
-auth0_client_secret = "your-m2m-client-secret"
+auth0_client_secret = "<YOUR_M2M_CLIENT_SECRET>"
 ```


### PR DESCRIPTION
Part of the ClawHub security-audit remediation.

**Theme: exposed-secret-literal false positives.** Files: framework-java-mvc, tooling-terraform.

The audit's 10 'exposed secret literal' hits were all obvious placeholders (no real secrets). To stop the scanner flagging them, lowercase-hyphen placeholders assigned to secret keys are rewritten to the angle-bracket convention used elsewhere in the skill:
- java-mvc: 5 AUTH0_CLIENT_SECRET placeholder assignments → <YOUR_CLIENT_SECRET> (env-read lines left untouched).
- terraform: auth0_client_secret literal → <YOUR_M2M_CLIENT_SECRET> (variable reference left untouched).

Doc-only. Verified: skillsaw --strict (0/0), reachability, routing evals.