### PR TITLE
fix(auth0): gate tooling reference load on tenant-config need

### DIFF
--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -249,13 +249,17 @@ present and consistent.
 
 ## Step 3: Detect tooling
 
-Read the project file tree. This is a project-context decision, not a product preference.
+This step does **not** decide *whether* to load a tooling reference — Step 4
+does that, per intent, and only when the task actually needs Auth0 tenant
+configuration. This step only picks **which variant** to use if and when one is
+loaded. It's a project-context decision, not a product preference: read the
+project file tree.
 
-| Project has... | Load |
+| Project has... | Tooling variant |
 |---|---|
-| `terraform/` directory OR any `*.tf` files | `tooling-terraform.md` |
-| Auth0 MCP server active in this agent session | `tooling-mcp.md` |
-| Anything else (default) | `tooling-cli.md` |
+| `terraform/` directory OR any `*.tf` files | terraform → `tooling-terraform.md` |
+| Auth0 MCP server active in this agent session | mcp → `tooling-mcp.md` |
+| Neither (default variant) | cli → `tooling-cli.md` |
 
 ---
 
@@ -267,22 +271,22 @@ Step 1, then read the reference files it lists.
 ### integrate
 ```
 Read: references/framework-{framework}.md
-Read: references/tooling-{tooling}.md
+If the task requires Auth0 tenant configuration (create/update an app or API, set callback/logout URLs, enable factors, add a domain) and it isn't already provisioned: Read references/tooling-{tooling}.md
 Follow the integration workflow in framework-{framework}.md.
-Use tooling-{tooling}.md for all Auth0 tenant configuration steps.
+When tenant configuration is needed, use tooling-{tooling}.md for those steps.
 ```
 
 ### feature:mfa
 ```
 Read: references/feature-mfa.md
-Read: references/tooling-{tooling}.md
+If the task requires Auth0 tenant configuration (enable factors, set MFA policy) and it isn't already provisioned: Read references/tooling-{tooling}.md
 If framework detected: Read references/framework-{framework}.md (for SDK-side step-up trigger)
 ```
 
 ### feature:organizations
 ```
 Read: references/feature-organizations.md
-Read: references/tooling-{tooling}.md
+If the task requires Auth0 tenant configuration (create organizations, connections, enable org login) and it isn't already provisioned: Read references/tooling-{tooling}.md
 If framework detected: Read references/framework-{framework}.md
 If multi-tenant architecture / B2B SaaS design question: also Read references/pattern-multi-tenant.md
 ```
@@ -290,25 +294,25 @@ If multi-tenant architecture / B2B SaaS design question: also Read references/pa
 ### feature:custom-domains
 ```
 Read: references/feature-custom-domains.md
-Read: references/tooling-{tooling}.md
+If the task requires Auth0 tenant configuration (add/verify the custom domain) and it isn't already provisioned: Read references/tooling-{tooling}.md
 ```
 
 ### feature:acul
 ```
 Read: references/feature-acul.md
-Read: references/tooling-{tooling}.md
+If the task requires Auth0 tenant configuration (enable ACUL, configure screens/prompts) and it isn't already provisioned: Read references/tooling-{tooling}.md
 ```
 
 ### feature:branding
 ```
 Read: references/feature-branding.md
-Read: references/tooling-{tooling}.md
+If the task requires Auth0 tenant configuration (apply branding/theme to the tenant) and it isn't already provisioned: Read references/tooling-{tooling}.md
 ```
 
 ### feature:dpop
 ```
 Read: references/feature-dpop.md
-Read: references/tooling-{tooling}.md
+If the task requires Auth0 tenant configuration (enable/enforce DPoP on the app or API) and it isn't already provisioned: Read references/tooling-{tooling}.md
 If a SPA framework is detected (vue/react/angular/spa-js): Read references/framework-{framework}.md
 DPoP is SPA-only (no SSR: Next.js/Nuxt) — feature-dpop.md states the exclusion.
 ```
@@ -335,7 +339,7 @@ Read: references/pattern-rate-limiting.md
 ### migrate
 ```
 Read: references/feature-migration.md
-Read: references/tooling-{tooling}.md
+If the task requires Auth0 tenant configuration (create the new app/API, import users, set URLs) and it isn't already provisioned: Read references/tooling-{tooling}.md
 If framework detected: Read references/framework-{framework}.md
 ```
 


### PR DESCRIPTION
## Summary

The `auth0` router loaded `tooling-cli.md` into nearly every task. Two layers combined to cause it:

1. **Step 3** declared `cli` the catch-all default (`Anything else (default) → tooling-cli.md`).
2. **Step 4** read `references/tooling-{tooling}.md` **unconditionally** in all 8 framework/feature/migrate branches. Since `{tooling}` resolves to `cli` for any project without Terraform files or an active MCP session, the CLI reference was pulled in even for pure code-side work that never touches the Auth0 tenant.

Loading a tooling reference is correct when the task actually configures the tenant (create app/API, set callback URLs, enable MFA factors, brand the login page) — the framework files deliberately delegate app-creation to it. The bug was that it loaded even when no tenant config was needed.

### Changes (`plugins/auth0/skills/auth0/SKILL.md`)

- **Step 3** reframed from a "which file to load" trigger into a "which variant to use *if* one is loaded" selector. Same three-row mapping; only the framing changed.
- **Step 4** gated the tooling read behind `If the task requires Auth0 tenant configuration ... and it isn't already provisioned:` in all 8 config-touching branches (integrate, mfa, organizations, custom-domains, acul, branding, dpop, migrate).
- `### tooling` keeps its unconditional read (that intent *is* the tooling task). `guidance`/`debug`/`debug:rate-limit`/`upgrade-sdk` were already tooling-free and are untouched.

## Test plan

- `python3 scripts/check_routing_evals.py` → PASS (18/18). Existing `expect_refs` that list tooling files remain valid because the scorer treats the unmodeled tenant-config `If` as optional (allowed, not required).
- `python3 scripts/check_router_reachability.py` → PASS (no orphans, broken routes, or second hops).
- `skillsaw --strict` not run locally (`uv`/`uvx` unavailable on this machine); changes are content-only within existing Step 3/Step 4 structure — CI will run it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when Auth0 tooling guidance is needed based on tenant configuration requirements and existing provisioning.
  * Updated setup instructions for integration, migration, and feature-related workflows, including MFA, organizations, custom domains, branding, and DPoP.
  * Refined tooling variant selection guidance while preserving framework-specific instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->