### PR TITLE
fix(auth0): correct Swift ID token claims-reading API

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-swift.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift.md
@@ -403,19 +403,33 @@ let credentialsManager = CredentialsManager(authentication: authentication)
 | `org_id` | String | Organization ID |
 | `org_name` | String | Organization name |
 
-### Decoding Claims
+### Reading User Profile Claims
+
+Read the user's profile from stored credentials with the `CredentialsManager`
+`user` property. It decodes the ID token and returns a `UserInfo?` whose
+properties expose the standard OIDC claims (`sub`, `name`, `email`, `picture`, …):
 
 ```swift
 import Auth0
 
-// Decode ID token claims
-if let claims = try? IDTokenClaimsValidation().validate(credentials.idToken) {
-    print("User ID: \(claims.subject)")
-    print("Email: \(claims.email ?? "none")")
+// Reuse the existing credentialsManager instance
+if let user = credentialsManager.user {
+    print("User ID: \(user.sub)")
+    print("Name: \(user.name ?? "none")")
+    print("Email: \(user.email ?? "none")")
 }
+```
 
-// Or decode manually with JWT libraries
-// The ID token is a standard JWT — decode payload with any JWT library
+To decode the ID token manually, use JWTDecode (bundled with Auth0.swift):
+
+```swift
+import JWTDecode
+
+if let jwt = try? decode(jwt: credentials.idToken) {
+    let email = jwt.claim(name: "email").string
+    let name = jwt.claim(name: "name").string
+    print("Email: \(email ?? "none"), Name: \(name ?? "none")")
+}
 ```
 
 ---


### PR DESCRIPTION
## What

The Swift reference's claims-decoding example prescribed `IDTokenClaimsValidation().validate(idToken)` to read `email` / `name`. That symbol is not a public claims API and does not return a claims object, so profile-loading code generated from it does not compile.

Replace it with the correct Auth0.swift approach:
- Read the profile from `credentialsManager.user`, a `UserInfo?` exposing the standard OIDC claims (`sub`, `name`, `email`, `picture`, …), reusing the existing `CredentialsManager` instance.
- Add a `JWTDecode` example (bundled with Auth0.swift) for decoding the ID token manually.

## How this surfaced — the eval flywheel

Caught by the auth0-evals-runner `swift_quickstart` eval (run 29835398213), mode **agent-mcp-skills**, model **claude-haiku-4-5**. The judge grader "Does the solution correctly integrate Auth0 into a Swift iOS app with webAuth() login/logout, credential management, and proper SwiftUI state handling?" **failed**:

> The overall structure is correct (webAuth login/logout, credentials manager, SwiftUI state with @StateObject/@EnvironmentObject). However, `IDTokenClaimsValidation().validate(...)` is not a valid Auth0.swift API for extracting claims like email/name — that type is for internal token validation and does not return claims. To decode ID token claims you'd use JWTDecode or `credentialsManager.user`, so the profile-loading code would not compile/work as written.

The agent faithfully reproduced what the skill taught, so the fix belongs in the reference file. This closes the loop: eval (agent+mcp,skills, claude-haiku-4-5) flags a bad API in the skill → skill corrected → next run should pass the profile-loading criterion.

## Verification

- `python3 scripts/check_router_reachability.py` → PASS
- `python3 scripts/check_routing_evals.py` → PASS (18/18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Auth0 Swift guidance for reading user profile claims.
  * Added examples for accessing standard OIDC claims, including subject, name, and email.
  * Documented manual ID-token decoding as an alternative approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->