### PR TITLE
fix(android): correct logout callback onSuccess signature to Void?

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-android.md
+++ b/plugins/auth0/skills/auth0/references/framework-android.md
@@ -97,7 +97,7 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
    WebAuthProvider.logout(account)
        .withScheme(getString(R.string.com_auth0_scheme))
        .start(this, object : Callback<Void?, AuthenticationException> {
-           override fun onSuccess(result: Void) {
+           override fun onSuccess(result: Void?) {
                // User logged out
            }
            override fun onFailure(error: AuthenticationException) {
@@ -521,7 +521,7 @@ Log out the user and clear their session:
 WebAuthProvider.logout(account)
     .withScheme(getString(R.string.com_auth0_scheme))  // Match your configured scheme
     .start(this, object : Callback<Void?, AuthenticationException> {
-        override fun onSuccess(result: Void) {
+        override fun onSuccess(result: Void?) {
             // User logged out successfully
             // Clear your app's local state
         }


### PR DESCRIPTION
## Summary

The Android skill's Web Auth **logout** examples declared `override fun onSuccess(result: Void)` while the callback is typed `Callback<Void?, AuthenticationException>`. The nullability mismatch (`Void` vs `Void?`) fails Kotlin compilation. Two of the file's four logout samples were already correct (`Void?`); this aligns the remaining two.

Found via an `android_quickstart` eval run (Claude Haiku 4.5, agent+mcp+skills): the model faithfully copied the buggy sample, and the holistic judge flagged the resulting non-compiling logout callback as the single failing grader.

## Changes

- `framework-android.md`: `onSuccess(result: Void)` -> `onSuccess(result: Void?)` in both logout examples (lines ~100 and ~524).

## Test plan

- [x] `grep "onSuccess(result: Void)"` returns no non-nullable matches
- [x] Signature now matches the `Callback<Void?, ...>` type parameter and the other correct samples in the file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Auth0 Android logout callback examples to use the correct nullable `Void` result type.
  * Improved consistency between the documented callback implementation and its declared type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->