### PR TITLE
fix(swift): remove programmatic-init example with hardcoded credentials keeping reference file leaner

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-swift.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift.md
@@ -295,28 +295,6 @@ private let auth = AuthenticationService()
 | `ClientId` | String | Yes | Your Auth0 application Client ID |
 | `Domain` | String | Yes | Your Auth0 tenant domain (e.g., `tenant.auth0.com`) |
 
-### Programmatic Initialization
-
-Use when you cannot use `Auth0.plist` (e.g., reading credentials from environment):
-
-```swift
-// Web Auth with explicit credentials
-Auth0
-    .webAuth(clientId: "YOUR_CLIENT_ID", domain: "YOUR_DOMAIN")
-    .start()
-
-// Authentication API with explicit credentials
-Auth0
-    .authentication(clientId: "YOUR_CLIENT_ID", domain: "YOUR_DOMAIN")
-    .login(usernameOrEmail: "user@example.com", password: "password",
-           realmOrConnection: "Username-Password-Authentication",
-           scope: "openid profile email")
-
-// CredentialsManager with explicit credentials
-let authentication = Auth0.authentication(clientId: "YOUR_CLIENT_ID", domain: "YOUR_DOMAIN")
-let credentialsManager = CredentialsManager(authentication: authentication)
-```
-
 ### WebAuth Builder Options
 
 | Method | Type | Description |


### PR DESCRIPTION
## Summary

The Swift reference's **Programmatic Initialization** section taught the explicit-credentials factory form with inline placeholders:

```swift
Auth0.webAuth(clientId: "YOUR_CLIENT_ID", domain: "YOUR_DOMAIN").start()
Auth0.authentication(clientId: "YOUR_CLIENT_ID", domain: "YOUR_DOMAIN")...
```

This form isn't required for the skill — the recommended `Auth0.plist` path already covers configuration. Lower- and mid-capability models tend to reach for the programmatic form and paste real credential values directly into Swift source, which trips the L3 security graders.

Also we should not add all integration patterns in skill . it should onloy have recommended one to keep the skill. size lean

## Change

Remove the "Programmatic Initialization" section (22 lines) so the skill teaches a **single, secure** configuration path (`Auth0.plist`). It's not needed for the skill's purpose, and dropping it keeps the reference **leaner** — one canonical way to configure, less surface area for a model to pick the insecure branch.

The migration/detection references to `webAuth(domain:clientId:)` elsewhere in the file are intentionally left untouched — they identify existing call sites to upgrade during SDK migration, not patterns to author for new integrations.

## Eval signal

From `swift_quickstart` / `agent-mcp-skills` in eval run **29835398213**, three models copied the hardcoded-credentials pattern and failed **both** L3 security graders:

| Model | Grade | Security graders |
| --- | --- | --- |
| gpt-5.6-luna | B (77.1) | `barkbook_client_abc123xyz` + `dev-barkbook.us.auth0.com` FOUND in source |
| gpt-5.6-terra | B (79.5) | both hardcoded values FOUND in source |
| gemini-3.5-flash | B (81.7) | both hardcoded values FOUND in source |

Those are the eval's placeholder client ID and domain — models substituted them into `webAuth(clientId:domain:)` verbatim in `.swift` files. Removing the section removes the pattern they were copying.

## Context

Part of the eval flywheel. The companion grader fix (auth0/auth0-evals#144) makes the async/await grader correctly *accept* the valid `webAuth(clientId:domain:)` API for models that wrote correct code; this PR stops the skill from *teaching* it with hardcoded values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated programmatic initialization examples from the Auth0 Swift API reference.
  * The documentation now proceeds directly from `Auth0.plist` configuration keys to WebAuth builder options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->