### PR TITLE
fix(router): drop tooling reference from integrate intent

### DIFF
--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -267,9 +267,7 @@ Step 1, then read the reference files it lists.
 ### integrate
 ```
 Read: references/framework-{framework}.md
-Read: references/tooling-{tooling}.md
 Follow the integration workflow in framework-{framework}.md.
-Use tooling-{tooling}.md for all Auth0 tenant configuration steps.
 ```
 
 ### feature:mfa


### PR DESCRIPTION
## Summary

The `integrate` intent unconditionally co-loaded `tooling-{tooling}.md` (tooling-cli by default) alongside the framework reference on **every** quickstart-style integration — 

```diff
 ### integrate
 Read: references/framework-{framework}.md
-Read: references/tooling-{tooling}.md
 Follow the integration workflow in framework-{framework}.md.
-Use tooling-{tooling}.md for all Auth0 tenant configuration steps.
 ```


## Why

Quickstart integrations don't need the CLI tooling reference — **the framework reference already carries the full integration workflow and cli config both**. Loading `tooling-cli.md` anyway just adds context noise, and lower-capability models hallucinate from that extra surface (e.g. inventing Management API `/api/v2/users/...` calls ). This issue was observed with Haiku 4.5 and This change fixed that.

`tooling-{tooling}.md` stays routable from the `feature:*` and `migrate` intents that genuinely provision tenant config, so nothing that needs it loses access. Router reachability check passes (`check_router_reachability.py`: all references routable).

This has following downsides:

* **Context bloat:** Extra content hurts performance, especially on smaller models like Claude Haiku, which are more prone to hallucinations.
* **More context compaction:** Loading unnecessary content increases compaction, making responses less deterministic.
* **Higher token usage:** End customers end up consuming more tokens than necessary.


Prior **Skill consolidation** this was not the case 

## Relationship to #152

#152 takes the *conditional* approach — gate the tooling load on a tenant-config need. This PR is the simpler cut for the `integrate` path specifically: quickstart integrations don't provision tenant config as part of the task, so the reference is just dropped rather than gated. If #152 lands first, this becomes a no-op simplification of the same block; happy to reconcile.

## Validation

- [x] `check_router_reachability.py` — PASS (all references routable, no broken routes, no second-hop references)
- [x] Change is 2 deletions to the `integrate` block only; no other intents touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Auth0 integration guidance to follow the framework-specific workflow.
  * Simplified instructions for tenant configuration during integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->