### PR TITLE
fix(auth0): remove hardcoded Auth0.getInstance init from Android reference

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-android.md
+++ b/plugins/auth0/skills/auth0/references/framework-android.md
@@ -330,12 +330,16 @@ Avoid:
 Entry point for SDK initialization:
 
 ```kotlin
-// From strings.xml
+// Always initialize from strings.xml — never pass the client ID or domain as
+// string literals in Kotlin/Java source.
 val account = Auth0.getInstance(context)
-
-// Direct
-val account = Auth0.getInstance("CLIENT_ID", "DOMAIN")
 ```
+
+> The `com_auth0_client_id` and `com_auth0_domain` values live in `strings.xml`
+> (`res/values/strings.xml`), and `Auth0.getInstance(context)` reads them from
+> there. Do NOT hardcode credentials in `.kt`/`.java` source — keep
+> configuration in `strings.xml` so it stays in one place and matches the SDK's
+> expected setup.
 
 ### WebAuthProvider
 

--- a/plugins/auth0/skills/auth0/references/framework-android.md
+++ b/plugins/auth0/skills/auth0/references/framework-android.md
@@ -53,6 +53,7 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
 
    val account = Auth0.getInstance(context)
    ```
+   > **IMPORTANT:** `Auth0.getInstance(context)` auto-reads `com_auth0_client_id` and `com_auth0_domain` from `strings.xml`. **Never** pass `clientId` or `domain` as arguments (e.g. `Auth0.getInstance(clientId, domain)`) — that hardcodes credentials in source.
 
 4. **Add Auth UI**: Implement login and logout with Web Auth:
 
@@ -134,6 +135,7 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
 
 | Mistake | Fix |
 |---------|-----|
+| Hardcoding credentials via `Auth0.getInstance(clientId, domain)` | Use `Auth0.getInstance(context)` — it auto-reads `com_auth0_client_id` and `com_auth0_domain` from `strings.xml`. Never pass the client ID or domain as arguments or string literals in source. |
 | App type not set to Native in Auth0 Dashboard | Create a Native application type in your Auth0 tenant. The Android SDK requires Native app configuration, not Machine-to-Machine or other types. |
 | Missing callback URL in Allowed Callback URLs | Add `{SCHEME}://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback` to your Auth0 application's Allowed Callback URLs setting, where `{SCHEME}` matches `com_auth0_scheme` in `strings.xml` (e.g., `demo` by default). |
 | Missing `<uses-permission android:name="android.permission.INTERNET" />` | Add the INTERNET permission to `AndroidManifest.xml`. The SDK requires network access for authentication. |


### PR DESCRIPTION
## Summary

The Android framework reference's API Reference showed `Auth0.getInstance("CLIENT_ID", "DOMAIN")` as an equal alternative to `Auth0.getInstance(context)`. This is the literal-credential variant that hardcodes the client ID and domain directly in `.kt` source instead of placing them in `strings.xml` (`com_auth0_client_id` / `com_auth0_domain`).

## Why this matters

An Android eval run scored 0/100 on the Security dimension because the agent hardcoded the client ID and domain into Kotlin source. Lower-capability models (e.g. Claude Haiku) tend to gravitate to the simplest, most direct integration snippet they find in a reference and copy it verbatim. When an anti-pattern is presented as an equal alternative, those models reach for it. The fix is to not offer the anti-pattern at all: remove the direct-credential variant so there's only one correct way to initialize.

This removes the direct variant entirely so it can't be copied, and adds an explicit note to always initialize from `strings.xml`.

## Changes

- Remove `Auth0.getInstance("CLIENT_ID", "DOMAIN")` from the API Reference `Auth0` init example.
- Annotate the `Auth0.getInstance(context)` example and add a note directing credentials to `strings.xml`.

## Test plan

- [ ] `uvx skillsaw --strict` passes.