### PR TITLE
fix(auth0): use SDK-native ISSUER_BASE_URL/AUDIENCE env vars in Express JWT reference

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-express-jwt.md
+++ b/plugins/auth0/skills/auth0/references/framework-express-jwt.md
@@ -96,7 +96,7 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 |---------|---------|-----|
 | Created an **Application** instead of an **API** in Auth0 Dashboard | Token validation fails; wrong audience | Create a new **API** (Resource Server) in Auth0 Dashboard → APIs |
 | Audience doesn't match API identifier exactly | `401 Unauthorized` — "Audience mismatch" | Copy the exact API Identifier string from Auth0 Dashboard → APIs |
-| `ISSUER_BASE_URL` missing the `https://` prefix | `Error: Invalid URL` at startup | `ISSUER_BASE_URL` is a full URL — use `https://your-tenant.us.auth0.com`, not the bare hostname |
+| `ISSUER_BASE_URL` set to a bare hostname | Works in dev but HTTP is rejected when `NODE_ENV=production` | Set `ISSUER_BASE_URL` to the full tenant URL including the scheme: `https://your-tenant.us.auth0.com` (the SDK prepends `https://` to a bare hostname, but be explicit) |
 | Checking `scope` claim instead of `permissions` for RBAC | 403 always returned or permissions ignored | Use `requiredScopes()` for scope-based RBAC; use `claimIncludes('permissions', 'read:data')` for Auth0 RBAC permission claims |
 | CORS not configured before auth middleware | Preflight OPTIONS requests return 401 | Add `cors()` middleware before `auth()` in the middleware chain |
 | `.env` file not loaded | `undefined` for domain/audience | Add `import 'dotenv/config'` at the top of the entry file |

--- a/plugins/auth0/skills/auth0/references/framework-express-jwt.md
+++ b/plugins/auth0/skills/auth0/references/framework-express-jwt.md
@@ -47,8 +47,8 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 >    import { auth } from 'express-oauth2-jwt-bearer';
 >
 >    const checkJwt = auth({
->      issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
->      audience: process.env.AUTH0_AUDIENCE,
+>      issuerBaseURL: process.env.ISSUER_BASE_URL,
+>      audience: process.env.AUDIENCE,
 >    });
 >
 >    app.use(checkJwt); // apply globally, or per-route
@@ -96,7 +96,7 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 |---------|---------|-----|
 | Created an **Application** instead of an **API** in Auth0 Dashboard | Token validation fails; wrong audience | Create a new **API** (Resource Server) in Auth0 Dashboard → APIs |
 | Audience doesn't match API identifier exactly | `401 Unauthorized` — "Audience mismatch" | Copy the exact API Identifier string from Auth0 Dashboard → APIs |
-| Domain includes `https://` prefix | `Error: Invalid URL` at startup | Use hostname only: `your-tenant.us.auth0.com`, not `https://...` |
+| `ISSUER_BASE_URL` missing the `https://` prefix | `Error: Invalid URL` at startup | `ISSUER_BASE_URL` is a full URL — use `https://your-tenant.us.auth0.com`, not the bare hostname |
 | Checking `scope` claim instead of `permissions` for RBAC | 403 always returned or permissions ignored | Use `requiredScopes()` for scope-based RBAC; use `claimIncludes('permissions', 'read:data')` for Auth0 RBAC permission claims |
 | CORS not configured before auth middleware | Preflight OPTIONS requests return 401 | Add `cors()` middleware before `auth()` in the middleware chain |
 | `.env` file not loaded | `undefined` for domain/audience | Add `import 'dotenv/config'` at the top of the entry file |
@@ -241,13 +241,14 @@ When no options are passed to `auth()`, these variables are read automatically:
 | `ISSUER_BASE_URL` | Auth0 domain with `https://` prefix: `https://your-tenant.us.auth0.com` |
 | `AUDIENCE` | API Identifier: `https://your-api.example.com` |
 
-**Note:** `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` are the conventional `.env` keys used in this skill. Pass them explicitly:
+**Note:** This skill uses the SDK's native `ISSUER_BASE_URL` / `AUDIENCE` keys. Reference them explicitly so the configuration source is visible in the code:
 ```javascript
 auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
 })
 ```
+`ISSUER_BASE_URL` is the full tenant URL including `https://` (e.g. `https://your-tenant.us.auth0.com`); `AUDIENCE` is the API Identifier.
 
 ## Claims Reference
 
@@ -294,8 +295,8 @@ app.use(express.json());
 
 // 2. JWT validation middleware
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
 });
 
 // 3. Public endpoint (no auth required)
@@ -339,8 +340,8 @@ app.listen(PORT, () => console.log(`API listening on port ${PORT}`));
 ### Environment configuration (.env)
 
 ```env
-AUTH0_DOMAIN=your-tenant.us.auth0.com
-AUTH0_AUDIENCE=https://your-api.example.com
+ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+AUDIENCE=https://your-api.example.com
 PORT=3000
 CORS_ORIGIN=http://localhost:5173
 ```
@@ -358,8 +359,8 @@ import { auth, requiredScopes } from 'express-oauth2-jwt-bearer';
 const app = express();
 
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
 });
 
 app.get('/api/private', checkJwt, (req: Request, res: Response) => {
@@ -400,10 +401,10 @@ curl --request POST \
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `UnauthorizedError: No authorization token was found` | No `Authorization: Bearer ...` header | Add the bearer token to the request header |
-| `UnauthorizedError: invalid_token — jwt audience invalid` | Audience mismatch | Verify `AUTH0_AUDIENCE` matches the API Identifier in Auth0 Dashboard exactly |
-| `UnauthorizedError: invalid_token — jwt issuer invalid` | Domain mismatch | Verify `AUTH0_DOMAIN` is the Auth0 tenant hostname (no `https://`) |
+| `UnauthorizedError: invalid_token — jwt audience invalid` | Audience mismatch | Verify `AUDIENCE` matches the API Identifier in Auth0 Dashboard exactly |
+| `UnauthorizedError: invalid_token — jwt issuer invalid` | Issuer mismatch | Verify `ISSUER_BASE_URL` is the Auth0 tenant URL including `https://` |
 | `UnauthorizedError: invalid_token — jwt expired` | Token has expired | Request a new token; check system clock drift (`clockTolerance` option) |
-| `Error: JWKS request failed` | Network or domain misconfiguration | Verify `AUTH0_DOMAIN` is reachable; check network/proxy settings |
+| `Error: JWKS request failed` | Network or issuer misconfiguration | Verify `ISSUER_BASE_URL` is reachable; check network/proxy settings |
 | `InsufficientScopeError: Insufficient scope` | Token lacks required scope | Verify the requesting app has the scope granted; check `requiredScopes()` call |
 | `CORS error` on OPTIONS preflight | Auth middleware running before CORS | Move `cors()` middleware before `auth()` in the middleware chain |
 | `TypeError: Cannot read properties of undefined (reading 'payload')` | `req.auth` is undefined | Check that `checkJwt` middleware runs before the handler |
@@ -447,8 +448,8 @@ Apply `checkJwt` middleware globally to protect all routes:
 import { auth } from 'express-oauth2-jwt-bearer';
 
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
 });
 
 // All routes below this require a valid JWT
@@ -480,8 +481,8 @@ Allow unauthenticated requests but attach auth info when present:
 
 ```javascript
 const optionalAuth = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
   authRequired: false,
 });
 
@@ -584,8 +585,8 @@ app.use(cors({
 
 // 2. Auth second
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
 });
 ```
 
@@ -597,8 +598,8 @@ DPoP (Demonstration of Proof-of-Possession) binds tokens to the client's key pai
 
 ```javascript
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
   dpop: {
     enabled: true,
     required: false,  // Accept both Bearer and DPoP tokens
@@ -610,8 +611,8 @@ const checkJwt = auth({
 
 ```javascript
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
   dpop: {
     enabled: true,
     required: true,  // Reject plain Bearer tokens
@@ -623,8 +624,8 @@ const checkJwt = auth({
 
 ```javascript
 const checkJwt = auth({
-  issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
-  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.ISSUER_BASE_URL,
+  audience: process.env.AUDIENCE,
   dpop: { enabled: false },
 });
 ```
@@ -771,15 +772,15 @@ export function mockAuth(payload = { sub: 'test-user' }) {
 >    - Verify logged in: `auth0 tenants list --csv --no-input`
 >    - If any check fails, guide user to install/login, or fall back to Option B
 >
-> 2. **Create the Auth0 API (Resource Server)** with the Auth0 CLI, then read back the identifier as `AUTH0_AUDIENCE`:
+> 2. **Create the Auth0 API (Resource Server)** with the Auth0 CLI, then read back the identifier as `AUDIENCE`:
 >    ```bash
 >    auth0 apis create \
 >      --name "My Node API" \
 >      --identifier "https://my-api.example.com" \
 >      --json --no-input
 >    ```
->    - The `--identifier` you choose becomes the `AUTH0_AUDIENCE` value your middleware validates against.
->    - Get the tenant domain for `AUTH0_DOMAIN` with `auth0 tenants list --csv --no-input`.
+>    - The `--identifier` you choose becomes the `AUDIENCE` value your middleware validates against.
+>    - Get the tenant domain with `auth0 tenants list --csv --no-input`, then set `ISSUER_BASE_URL` to that domain prefixed with `https://`.
 >    - If an API with that identifier already exists, skip creation and reuse it (`auth0 apis list --json --no-input`).
 >
 > 3. **Write the `.env` configuration file** with the Domain + Audience (see below).
@@ -794,14 +795,14 @@ export function mockAuth(payload = { sub: 'test-user' }) {
 >
 > **Write the .env file** (both paths):
 > ```env
-> AUTH0_DOMAIN=your-tenant.us.auth0.com
-> AUTH0_AUDIENCE=https://your-api.example.com
+> ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+> AUDIENCE=https://your-api.example.com
 > PORT=3000
 > ```
 
 ### Auth0 API Registration (Resource Server)
 
-The Automatic setup path runs `auth0 apis create` to register your API as a Resource Server. This produces the `AUTH0_AUDIENCE` value (the API Identifier) that your middleware uses for token validation.
+The Automatic setup path runs `auth0 apis create` to register your API as a Resource Server. This produces the `AUDIENCE` value (the API Identifier) that your middleware uses for token validation.
 
 **Auth0 CLI command:**
 ```bash
@@ -817,7 +818,7 @@ auth0 apis create \
 2. Click **Create API**
 3. Set:
    - **Name**: Your API name (e.g., "My Node API")
-   - **Identifier**: A URL-like identifier (e.g., `https://my-api.example.com`) — this becomes `AUTH0_AUDIENCE`
+   - **Identifier**: A URL-like identifier (e.g., `https://my-api.example.com`) — this becomes `AUDIENCE`
    - **Signing Algorithm**: `RS256` (recommended)
 4. Click **Create**
 5. Note the **API Identifier** — this is your Audience value
@@ -872,15 +873,15 @@ npm install --save-dev @types/express @types/cors  # TypeScript projects
 `express-oauth2-jwt-bearer` requires only **Domain** and **Audience** — no Client Secret. The middleware validates tokens using the Auth0 JWKS (JSON Web Key Set) endpoint, which provides the public signing keys. This means:
 
 - **No client secret needed** for token validation
-- The JWKS endpoint is publicly accessible at `https://{AUTH0_DOMAIN}/.well-known/jwks.json`
+- The JWKS endpoint is publicly accessible at `${ISSUER_BASE_URL}/.well-known/jwks.json`
 - The middleware fetches and caches keys automatically
 
 ### .env file (development)
 
 ```env
 # .env — Never commit to source control
-AUTH0_DOMAIN=your-tenant.us.auth0.com
-AUTH0_AUDIENCE=https://your-api.example.com
+ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+AUDIENCE=https://your-api.example.com
 PORT=3000
 ```
 
@@ -890,8 +891,8 @@ Set these as environment variables in your hosting platform (not in `.env` files
 
 | Variable | Example Value |
 |----------|--------------|
-| `AUTH0_DOMAIN` | `your-tenant.us.auth0.com` |
-| `AUTH0_AUDIENCE` | `https://your-api.example.com` |
+| `ISSUER_BASE_URL` | `https://your-tenant.us.auth0.com` |
+| `AUDIENCE` | `https://your-api.example.com` |
 | `PORT` | `3000` |
 
 **Never commit `.env` to source control.** Add `.env` to `.gitignore`:

--- a/plugins/auth0/skills/auth0/references/framework-express-jwt.md
+++ b/plugins/auth0/skills/auth0/references/framework-express-jwt.md
@@ -40,19 +40,24 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 >    npm install express-oauth2-jwt-bearer
 >    ```
 >
-> 3. **Configure Auth0** — follow the Setup Guide section below. If the user already provided their Auth0 Domain and API Audience in the prompt, use them directly — skip automatic setup and do NOT call `AskUserQuestion` to re-confirm. Otherwise, offer automatic setup via the Auth0 CLI or manual setup.
+> 3. **Configure Auth0** — follow the Setup Guide section below. If the user already provided their Auth0 Domain and API Audience in the prompt, write them to a `.env` file as `ISSUER_BASE_URL` (the full issuer URL, including `https://`) and `AUDIENCE` — the SDK reads these automatically. Skip automatic setup and do NOT call `AskUserQuestion` to re-confirm. **Never hardcode the domain or audience as literal strings (or `||` fallback defaults) in `server.js` / `app.js`** — they belong in `.env` only. Otherwise, offer automatic setup via the Auth0 CLI or manual setup.
 >
-> 4. **Set up middleware** — add to `app.js` or `server.js`:
+> 4. **Set up middleware** — first create a `.env` file with the Auth0 values, then load it and add the middleware. `express-oauth2-jwt-bearer` reads `ISSUER_BASE_URL` and `AUDIENCE` from the environment automatically, so `auth()` needs no arguments:
+>    ```bash
+>    # .env
+>    ISSUER_BASE_URL=https://your-tenant.us.auth0.com
+>    AUDIENCE=https://your-api-identifier
+>    ```
 >    ```javascript
+>    import 'dotenv/config'; // load .env before the SDK reads process.env
 >    import { auth } from 'express-oauth2-jwt-bearer';
 >
->    const checkJwt = auth({
->      issuerBaseURL: process.env.ISSUER_BASE_URL,
->      audience: process.env.AUDIENCE,
->    });
+>    // Reads ISSUER_BASE_URL and AUDIENCE from the environment — no config needed
+>    const checkJwt = auth();
 >
 >    app.use(checkJwt); // apply globally, or per-route
 >    ```
+>    Keep the issuer and audience in `.env` — do not inline literal values or pass them as arguments here.
 >
 > 5. **Protect endpoints** — apply middleware globally or to specific routes:
 >    ```javascript
@@ -96,10 +101,11 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 |---------|---------|-----|
 | Created an **Application** instead of an **API** in Auth0 Dashboard | Token validation fails; wrong audience | Create a new **API** (Resource Server) in Auth0 Dashboard → APIs |
 | Audience doesn't match API identifier exactly | `401 Unauthorized` — "Audience mismatch" | Copy the exact API Identifier string from Auth0 Dashboard → APIs |
-| `ISSUER_BASE_URL` set to a bare hostname | Works in dev but HTTP is rejected when `NODE_ENV=production` | Set `ISSUER_BASE_URL` to the full tenant URL including the scheme: `https://your-tenant.us.auth0.com` (the SDK prepends `https://` to a bare hostname, but be explicit) |
+| `ISSUER_BASE_URL` missing the `https://` scheme | `Error: Invalid URL` at startup | `ISSUER_BASE_URL` must be the full issuer URL: `https://your-tenant.us.auth0.com` |
 | Checking `scope` claim instead of `permissions` for RBAC | 403 always returned or permissions ignored | Use `requiredScopes()` for scope-based RBAC; use `claimIncludes('permissions', 'read:data')` for Auth0 RBAC permission claims |
 | CORS not configured before auth middleware | Preflight OPTIONS requests return 401 | Add `cors()` middleware before `auth()` in the middleware chain |
 | `.env` file not loaded | `undefined` for domain/audience | Add `import 'dotenv/config'` at the top of the entry file |
+| Hardcoded domain/audience in source (incl. `process.env.X \|\| 'literal'` fallbacks) | Secrets committed to source; fails security review | Put values in `.env` (`ISSUER_BASE_URL` / `AUDIENCE`) and let `auth()` read them automatically — no literal fallbacks |
 | `req.auth` is undefined | `TypeError: Cannot read properties of undefined` | Verify `checkJwt` middleware runs before the handler |
 
 ## Related Skills
@@ -128,8 +134,8 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `issuerBaseURL` | `string` | Auth0 domain with `https://` (required unless using env vars) |
-| `audience` | `string` | API Identifier from Auth0 Dashboard (required unless using env vars) |
+| `issuerBaseURL` | `string` | Full issuer URL with `https://`. Optional — defaults to the `ISSUER_BASE_URL` env var |
+| `audience` | `string` | API Identifier from Auth0 Dashboard. Optional — defaults to the `AUDIENCE` env var |
 | `tokenSigningAlg` | `string` | Signing algorithm (default: `RS256`; use `HS256` for symmetric) |
 | `authRequired` | `boolean` | Set `false` to make authentication optional (default: `true`) |
 | `clockTolerance` | `number` | Clock skew tolerance in seconds (no default; undefined unless set) |
@@ -139,8 +145,8 @@ The `express-oauth2-jwt-bearer` package provides Express middleware for validati
 
 | Variable | Description |
 |----------|-------------|
-| `ISSUER_BASE_URL` | Auth0 domain with `https://` (auto-detected by SDK) |
-| `AUDIENCE` | API Identifier (auto-detected by SDK) |
+| `ISSUER_BASE_URL` | Full issuer URL with `https://`, e.g. `https://your-tenant.us.auth0.com` (auto-detected by SDK) |
+| `AUDIENCE` | API Identifier, e.g. `https://your-api-identifier` (auto-detected by SDK) |
 
 ### Request Object
 
@@ -212,8 +218,8 @@ All options are passed to the `auth()` function or set via environment variables
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `issuerBaseURL` | `string` | Yes (or `ISSUER_BASE_URL` env var) | — | Auth0 domain with `https://`, e.g. `https://your-tenant.us.auth0.com` |
-| `audience` | `string` | Yes (or `AUDIENCE` env var) | — | API Identifier from Auth0 Dashboard, e.g. `https://my-api.com` |
+| `issuerBaseURL` | `string` | No — defaults to `ISSUER_BASE_URL` env var | — | Full issuer URL with `https://`, e.g. `https://your-tenant.us.auth0.com` |
+| `audience` | `string` | No — defaults to `AUDIENCE` env var | — | API Identifier from Auth0 Dashboard, e.g. `https://my-api.com` |
 | `secret` | `string` | For HS256 only | — | Shared secret for symmetric JWT signing (HS256). Not required for RS256. |
 | `tokenSigningAlg` | `string` | No | `RS256` | JWT signing algorithm. Use `HS256` for symmetric keys. |
 | `issuer` | `string` | No (alternative to `issuerBaseURL`) | — | Issuer claim value — use with `jwksUri` for non-standard setups |
@@ -234,21 +240,21 @@ All options are passed to the `auth()` function or set via environment variables
 
 ### Environment Variables (auto-detected)
 
-When no options are passed to `auth()`, these variables are read automatically:
+`express-oauth2-jwt-bearer` reads these variables from the environment automatically, so `auth()` can be called with no arguments. This is the approach this skill uses — put the values in `.env` and let the SDK pick them up:
 
 | Variable | Description |
 |----------|-------------|
-| `ISSUER_BASE_URL` | Auth0 domain with `https://` prefix: `https://your-tenant.us.auth0.com` |
+| `ISSUER_BASE_URL` | Full issuer URL **with** `https://` prefix: `https://your-tenant.us.auth0.com` |
 | `AUDIENCE` | API Identifier: `https://your-api.example.com` |
 
-**Note:** This skill uses the SDK's native `ISSUER_BASE_URL` / `AUDIENCE` keys. Reference them explicitly so the configuration source is visible in the code:
 ```javascript
-auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
-})
+import 'dotenv/config'; // load .env before the SDK reads process.env
+
+// No arguments needed — ISSUER_BASE_URL and AUDIENCE are read from the environment
+const checkJwt = auth();
 ```
-`ISSUER_BASE_URL` is the full tenant URL including `https://` (e.g. `https://your-tenant.us.auth0.com`); `AUDIENCE` is the API Identifier.
+
+Pass `issuerBaseURL` / `audience` explicitly only if you need to source them from differently-named variables or compute them at runtime.
 
 ## Claims Reference
 
@@ -294,10 +300,8 @@ app.use(cors({
 app.use(express.json());
 
 // 2. JWT validation middleware
-const checkJwt = auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
-});
+// Reads ISSUER_BASE_URL and AUDIENCE from the environment — no arguments needed
+const checkJwt = auth();
 
 // 3. Public endpoint (no auth required)
 app.get('/api/public', (req, res) => {
@@ -358,10 +362,8 @@ import { auth, requiredScopes } from 'express-oauth2-jwt-bearer';
 
 const app = express();
 
-const checkJwt = auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
-});
+// Reads ISSUER_BASE_URL and AUDIENCE from the environment — no arguments needed
+const checkJwt = auth();
 
 app.get('/api/private', checkJwt, (req: Request, res: Response) => {
   const sub = req.auth?.payload.sub;
@@ -447,10 +449,8 @@ Apply `checkJwt` middleware globally to protect all routes:
 ```javascript
 import { auth } from 'express-oauth2-jwt-bearer';
 
-const checkJwt = auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
-});
+// Reads ISSUER_BASE_URL and AUDIENCE from the environment — no arguments needed
+const checkJwt = auth();
 
 // All routes below this require a valid JWT
 app.use(checkJwt);
@@ -480,9 +480,8 @@ app.get('/api/private', checkJwt, (req, res) => {
 Allow unauthenticated requests but attach auth info when present:
 
 ```javascript
+// issuer and audience come from ISSUER_BASE_URL / AUDIENCE in the environment
 const optionalAuth = auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
   authRequired: false,
 });
 
@@ -584,10 +583,8 @@ app.use(cors({
 }));
 
 // 2. Auth second
-const checkJwt = auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
-});
+// Reads ISSUER_BASE_URL and AUDIENCE from the environment — no arguments needed
+const checkJwt = auth();
 ```
 
 ## DPoP Support
@@ -597,9 +594,8 @@ DPoP (Demonstration of Proof-of-Possession) binds tokens to the client's key pai
 ### Hybrid mode (Bearer or DPoP both accepted — default)
 
 ```javascript
+// issuer and audience come from ISSUER_BASE_URL / AUDIENCE in the environment
 const checkJwt = auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
   dpop: {
     enabled: true,
     required: false,  // Accept both Bearer and DPoP tokens
@@ -610,9 +606,8 @@ const checkJwt = auth({
 ### DPoP-only mode (rejects plain Bearer tokens)
 
 ```javascript
+// issuer and audience come from ISSUER_BASE_URL / AUDIENCE in the environment
 const checkJwt = auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
   dpop: {
     enabled: true,
     required: true,  // Reject plain Bearer tokens
@@ -623,9 +618,8 @@ const checkJwt = auth({
 ### Bearer-only mode (disable DPoP)
 
 ```javascript
+// issuer and audience come from ISSUER_BASE_URL / AUDIENCE in the environment
 const checkJwt = auth({
-  issuerBaseURL: process.env.ISSUER_BASE_URL,
-  audience: process.env.AUDIENCE,
   dpop: { enabled: false },
 });
 ```
@@ -757,6 +751,8 @@ export function mockAuth(payload = { sub: 'test-user' }) {
 > **Agent instruction:**
 >
 > **Check if credentials are already provided in the user's prompt:** If the user's prompt already includes Auth0 Domain and API Audience (e.g. `your-tenant.us.auth0.com` and `https://api.example.com`), use them directly — skip to "Write the .env file" below. Do NOT call `AskUserQuestion` to re-confirm provided credentials, and do NOT run automatic setup.
+>
+> **Env var convention:** This skill uses the SDK-native variables `ISSUER_BASE_URL` (the full issuer URL, including `https://`) and `AUDIENCE`. `express-oauth2-jwt-bearer` reads them automatically, so `auth()` is called with no arguments.
 >
 > If credentials are NOT provided, offer setup choices:
 >


### PR DESCRIPTION
## The Problem

Eval run of `express_api_quickstart` with **gemini-3.1-pro-preview** (agent+mcp+skills) produced a functionally correct API but tripped the configuration judge, keeping it off a perfect score. From the report (run `29835398213`): **overall 97.9, grade A, 17/18 graders passed** — the one failure was the env-var judge:

> Judge (claude-opus-4-8): The question specifies issuer and audience should come from `ISSUER_BASE_URL` / `AUDIENCE` env variables, but the code uses `AUTH0_DOMAIN` and `AUTH0_AUDIENCE` instead, with `issuerBaseURL` constructed from a domain rather than reading `ISSUER_BASE_URL` directly. The middleware application, scope protection, and profile endpoint are otherwise correct, but the env variable mismatch means it doesn't follow the specified configuration.

Everything else passed: `auth()` middleware applied, `requiredScopes()` for `read:messages` / `write:messages`, `req.auth.payload` for profile, no hardcoded domain/audience, `.env` written.

## Root Cause

Skill wording, not a model gap. `framework-express-jwt.md` taught `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` and constructed `issuerBaseURL` as `https://${process.env.AUTH0_DOMAIN}` in every snippet. The `express-oauth2-jwt-bearer` SDK natively reads `ISSUER_BASE_URL` / `AUDIENCE` (verified in source: `jwt-verifier.ts` — `issuerBaseURL = process.env.ISSUER_BASE_URL`, `audience = process.env.AUDIENCE`). The agent faithfully followed the skill's convention, which diverged from the SDK's documented names.

Note: [#126](https://github.com/auth0/agent-skills/pull/126) previously migrated this skill to `ISSUER_BASE_URL` / `AUDIENCE`. That change was lost in the v2.0 re-architecture (commit `c4d1647`, one skill with a flat reference pool) when the reference was rewritten with `AUTH0_DOMAIN` / `AUTH0_AUDIENCE`. This PR restores the SDK-native convention.

## The Fix (`framework-express-jwt.md` only)

- All `auth()` snippets now read `issuerBaseURL: process.env.ISSUER_BASE_URL` and `audience: process.env.AUDIENCE` directly.
- All `.env` blocks and the config/env/production tables use `ISSUER_BASE_URL` / `AUDIENCE`.
- Setup-guide wording (Auth0 CLI automatic + manual paths) writes the new keys.
- Common Issues / Common Mistakes rows updated. `ISSUER_BASE_URL` is a full URL including the scheme; verified against SDK source that a bare hostname is auto-prefixed with `https://` (only HTTP is rejected under `NODE_ENV=production`), so the mistake row recommends the explicit full URL rather than claiming a startup error.
- `YOUR_AUTH0_DOMAIN` placeholders inside `/oauth/token` curl URLs left as-is — those are tenant hostnames in a URL, not the skill's env convention.

## Scope check

Confirmed against the report that the env-var judge was the **only** failing grader (17/18 passed); this change targets exactly that gap and touches nothing already-correct.

## Expected Impact

The configuration judge should pass on `express_api_quickstart`, moving the score from 97.9 toward full marks without altering the already-correct functionality. This repo's own behavioral grader (`evals/behavioral/cases/express-jwt.json`) accepts both names (`contains_any: ["AUTH0_DOMAIN", "ISSUER_BASE_URL"]`), so it stays green too.

Eval run:
- Run URL: https://github.com/atko-cic/auth0-evals-runner/actions/runs/29917527944/job/88915165369
- Run ID: `29917527944`
- Job ID: `88915165369`

## Verification

- `skillsaw --strict` passes locally (0 errors, 0 warnings, grade A).
- Re-run the eval against this branch:
  ```bash
  REMOTE_SKILLS_BRANCH=flywheel/express-jwt-issuer-base-url npm run evals -- \
    --eval express_api_quickstart --model gemini-3.1-pro-preview \
    --mode agent --tools mcp,skills
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Express JWT Bearer integration guidance to use `ISSUER_BASE_URL` and `AUDIENCE` environment variables.
  * Simplified examples to configure authentication automatically from environment settings.
  * Added clearer setup instructions for development, production, CORS, route protection, optional authentication, and DPoP modes.
  * Clarified issuer URL formatting requirements and recommended `.env` configuration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->