### PR TITLE
fix(auth0): remove stray paren in ionic-vue logout snippet

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-ionic-vue.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-vue.md
@@ -155,7 +155,7 @@ import { IonButton } from '@ionic/vue';
 
 const domain = import.meta.env.VITE_AUTH0_DOMAIN;
 // Agent: read appId from capacitor.config.ts and replace this value
-const packageId = "YOUR_PACKAGE_ID";)
+const packageId = "YOUR_PACKAGE_ID";
 const logoutUri = `${packageId}://${domain}/capacitor/${packageId}/callback`;
 
 const { logout } = useAuth0();


### PR DESCRIPTION
## Summary

The Ionic Vue logout snippet in `framework-ionic-vue.md` has a stray `)` after the `packageId` assignment, producing invalid JavaScript:

```js
const packageId = "YOUR_PACKAGE_ID";)   // ← stray )
```

An agent copying this snippet emits code that fails to parse.

## Why (flywheel regression)

This was originally fixed in #120, but the fix was lost in the v2.0 re-architecture (#137, `c4d1647`) when the per-skill `auth0-ionic-vue/SKILL.md` was consolidated into the flat reference pool — the pre-fix text was carried over.

## Change

One-character fix: drop the stray `)`.

## Validation

- `skillsaw --strict` passes (0 errors, 0 warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Ionic Vue logout example to ensure the logout URI code is syntactically valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->