### PR TITLE
fix(auth0): restore Nuxt runtimeConfig auto-population guidance

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-nuxt.md
+++ b/plugins/auth0/skills/auth0/references/framework-nuxt.md
@@ -31,6 +31,7 @@ Server-side session authentication for Nuxt 3/4. NOT the same as @auth0/auth0-vu
 | Using `useUser()` for security checks | Use `useAuth0(event).getSession()` server-side |
 | Missing callback URLs in Auth0 Dashboard | Add `http://localhost:3000/auth/callback` |
 | Weak/missing session secret | Generate: `openssl rand -hex 64` |
+| Hardcoding credentials in `nuxt.config.ts` | Leave runtimeConfig values as empty strings; Nuxt auto-fills from `NUXT_AUTH0_*` env vars |
 
 ## Quick Setup
 
@@ -54,6 +55,8 @@ NUXT_AUTH0_AUDIENCE=https://your-api  # optional
 
 ```typescript
 // 4. nuxt.config.ts
+// Leave values as empty strings — Nuxt auto-fills them from NUXT_AUTH0_* env vars at runtime.
+// If you prefer explicit mapping, use: domain: process.env.NUXT_AUTH0_DOMAIN || ''
 export default defineNuxtConfig({
   modules: ['@auth0/auth0-nuxt'],
   runtimeConfig: {


### PR DESCRIPTION
## Summary

`framework-nuxt.md` shows `runtimeConfig.auth0` with empty-string values but no longer explains *why* — that `@auth0/auth0-nuxt` auto-populates them from `NUXT_AUTH0_*` env vars at runtime. Without that note, an agent is tempted to hardcode the domain/clientId/secret directly into `nuxt.config.ts`.

## Why (flywheel regression)

Originally fixed in #114, lost in the v2.0 re-architecture (#137, `c4d1647`) when the per-skill `auth0-nuxt/SKILL.md` was consolidated into the flat reference pool.

## Changes

- Add a code comment above the `nuxt.config.ts` example: leave values as empty strings — Nuxt auto-fills from `NUXT_AUTH0_*` env vars at runtime (with the explicit `process.env.NUXT_AUTH0_DOMAIN || ''` alternative).
- Add a Common Mistakes row: hardcoding credentials in `nuxt.config.ts` → leave runtimeConfig empty; Nuxt auto-fills from env vars.

## Validation

- `skillsaw --strict` passes (0 errors, 0 warnings).