### PR TITLE
fix(auth0): warn against passing credentials in code for Swift

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-swift.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift.md
@@ -70,7 +70,7 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 > Auth0.webAuth(clientId: "...", domain: "...")        // ✗ never do this
 > Auth0.authentication(clientId: "...", domain: "...") // ✗ never do this
 > ```
-> The explicit-credential forms are a rare escape hatch (see the API Reference below) — never use them when `Auth0.plist` is present.
+> The explicit-credential forms are a rare escape hatch (see the API Reference below); when `Auth0.plist` is present, always prefer the no-argument forms.
 
 ### Step 3 — Configure Callback URLs
 

--- a/plugins/auth0/skills/auth0/references/framework-swift.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift.md
@@ -61,6 +61,16 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 >
 > If the user chooses **automatic**: Follow the Setup Guide — Automated Setup via Auth0 CLI section (below).
 > If the user chooses **manual**: Follow the Setup Guide — Manual Setup section (below).
+>
+> **IMPORTANT — Never pass credentials in code:** Do NOT hardcode `clientId` or `domain` in Swift source, and do NOT pass them as arguments to `Auth0.webAuth()`, `Auth0.authentication()`, or any other SDK call. The SDK reads these values automatically from `Auth0.plist`. Always use the no-argument forms:
+> ```swift
+> Auth0.webAuth()           // ✓ reads Auth0.plist automatically
+> Auth0.authentication()    // ✓ reads Auth0.plist automatically
+>
+> Auth0.webAuth(clientId: "...", domain: "...")        // ✗ never do this
+> Auth0.authentication(clientId: "...", domain: "...") // ✗ never do this
+> ```
+> The explicit-credential forms are a rare escape hatch (see the API Reference below) — never use them when `Auth0.plist` is present.
 
 ### Step 3 — Configure Callback URLs
 
@@ -258,6 +268,7 @@ private let auth = AuthenticationService()
 
 | Mistake | Fix |
 |---------|-----|
+| Hardcoding `domain`/`clientId` in Swift source when they're in `Auth0.plist` | Write them into `Auth0.plist` and call `Auth0.webAuth()` / `Auth0.authentication()` with no arguments — the SDK reads the plist automatically |
 | Auth0 app type not set to **Native** | In Auth0 Dashboard, select "Native" when creating the application |
 | Missing callback URL in Auth0 Dashboard | Add both `https://` Universal Link and `{bundle}://` custom scheme to Allowed Callback URLs and Logout URLs |
 | `Auth0.plist` not added to Xcode target | Right-click file in Navigator → "Add Files to Target" → check your app target |


### PR DESCRIPTION
## Summary

`framework-swift.md` keeps the general credential-privacy guidance (don't echo credentials) but no longer states the specific rule: don't hardcode `clientId`/`domain` in Swift source or pass them as arguments to `Auth0.webAuth()` / `Auth0.authentication()` when `Auth0.plist` is present. The API Reference still shows the explicit-credential forms as an escape hatch, so without the prohibition an agent may copy that pattern instead of the no-argument form.

## Why (flywheel regression)

Originally added in #101, lost in the v2.0 re-architecture (#137, `c4d1647`) when the per-skill `auth0-swift/SKILL.md` was consolidated into the flat reference pool.

## Changes

- Add an "IMPORTANT — Never pass credentials in code" note to the Step 2 setup instruction, with ✓/✗ examples for `Auth0.webAuth()` / `Auth0.authentication()`, and a pointer that the explicit-credential forms are a rare escape hatch — prefer the no-argument forms when `Auth0.plist` is present.
- Add a Common Mistakes row for hardcoding `domain`/`clientId` in source.
- Left the legitimate "explicit credentials (when you cannot use Auth0.plist)" API Reference section intact.

## Validation

- `skillsaw --strict` passes (0 errors, 0 warnings).