### PR TITLE
fix(evals): flywheel fixes from Android quickstart eval run

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-android.md
+++ b/plugins/auth0/skills/auth0/references/framework-android.md
@@ -143,6 +143,8 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
 | Forgetting `.validateClaims()` on direct auth calls | Always call `.validateClaims()` when using `AuthenticationAPIClient` directly (for database, passwordless, or API login). Web Auth validates automatically. |
 | Storing tokens in SharedPreferences without encryption | Use `SecureCredentialsManager` to store credentials. Never store tokens manually in plain text. The manager encrypts tokens at rest. |
 | Missing manifest placeholders | Add `manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "@string/com_auth0_scheme"]` to your `build.gradle` `defaultConfig` block. |
+| Replacing `@string/` placeholders with literals because "Gradle can't resolve resources" | The `@string/...` values ARE valid here. `manifestPlaceholders` are substituted into `AndroidManifest.xml` at manifest-merge time, where `@string/` resource references resolve normally — they are not evaluated in Gradle's build-config context. Keep the `@string/com_auth0_domain` / `@string/com_auth0_scheme` references; this is the pattern Auth0 documents and recommends. |
+| Manually declaring, or removing with `tools:node="remove"`, a `RedirectActivity`/`AuthorizeActivity` in `AndroidManifest.xml` | Do neither. SDK v2+ auto-registers the callback `intent-filter` via manifest merging using the `manifestPlaceholders`. You do not add a redirect activity yourself, and you must NOT strip the merged one with `tools:node="remove"` — doing so breaks callback handling and login/logout will hang. |
 
 ## Related Capabilities
 


### PR DESCRIPTION
## Summary

Rolling collection of flywheel fixes surfaced by eval report runs. **More fixes will be added to this branch/PR.**

First fix (already included):

### Android: inoculate against hallucinated manifest anti-patterns

The `android_quickstart` eval (haiku-4.5, skill + MCP) exposed a small-model hallucination: even with the `auth0` skill loaded, the agent hand-wrote a redirect activity into `AndroidManifest.xml` and marked it `tools:node="remove"` — which deletes the SDK's auto-merged callback activity and breaks login/logout callbacks.

Root cause: the skill correctly said the SDK auto-merges the callback activity, but never said *don't declare one yourself* or *never `tools:node="remove"` the merged one*. That silence let the model fill the gap with stale SDK-v1 muscle memory.

Fix: added two defensive rows to the common-mistakes table in `framework-android.md`:
- `@string/` manifestPlaceholders ARE valid (resolved at manifest-merge time, not Gradle build-config context) — the pattern Auth0 documents and recommends.
- Never manually declare, nor `tools:node="remove"`, the `RedirectActivity`/`AuthorizeActivity`. The SDK auto-registers the callback intent-filter via manifest merging.

## Notes / follow-ups

- The same eval also revealed inconsistent grader verdicts on this solution: grader [13] false-failed on `@string/` while graders [10]/[12] rubber-stamped the harmful `tools:node="remove"`. A grader-prompt tightening is a candidate follow-up for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for correctly using `@string/` placeholders in Android manifest configuration.
  * Added a warning against manually modifying the SDK’s callback activities or intent filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->