### PR TITLE
fix(auth0): correct and expand the Fastify reference (supersedes #113)

### DIFF
--- a/evals/behavioral/README.md
+++ b/evals/behavioral/README.md
@@ -30,7 +30,7 @@ behavioral/
 └── cases/
     ├── flask.json        # { slug, origin_skill, evals[], graders[] }
     ├── express-jwt.json
-    └── ...               # 19 cases; 13 have machine graders, 6 (branding,
+    └── ...               # 20 cases; 14 have machine graders, 6 (branding,
                           # custom-domains, cli, acul, audit, healthcheck) are
                           # expectations-only → manual transcript review
 ```
@@ -89,6 +89,12 @@ Notes on the negative graders:
 - **Generated lockfiles** (`package-lock.json`, `Podfile.lock`, `*.lock`, …) are
   excluded from the source scan entirely — they pin the full transitive graph,
   so substrings there don't reflect the authored code.
+- **Template files are invisible.** `SOURCE_EXTENSIONS` in `graders.mjs` covers
+  `.html` but not view-engine templates (`.ejs`, `.hbs`, `.pug`, `.liquid`, …),
+  so a grader can't assert anything about a rendered template's contents. Target
+  the server source instead — e.g. the `fastify` case checks the *argument* passed
+  to `reply.view()` in `server.js` rather than looking for `views/profile.ejs`
+  on disk. Add the extension to the set if you need template assertions.
 - `not_contains*` / `not_matches` graders are auto-invalidated if no positive
   grader passed, so an empty workspace can't score by writing nothing.
 

--- a/evals/behavioral/cases/fastify.json
+++ b/evals/behavioral/cases/fastify.json
@@ -1,0 +1,136 @@
+{
+  "slug": "fastify",
+  "origin_skill": "auth0-fastify",
+  "skill_name": "auth0-fastify",
+  "_comment": "Session-based Fastify web app. Note that .ejs is NOT in the grader engine's SOURCE_EXTENSIONS, so template files are invisible to the scan — every grader here targets the server source (server.js / .env) instead. See ../README.md.",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add Auth0 authentication to a Fastify web application using the @auth0/auth0-fastify SDK. It should render server-side pages, with a public home page and a protected profile page.\n\n**Auth0 Credentials:**\n- Domain: `dev-example.auth0.com`\n- Client ID: `abc123def456ghi789jkl012`\n- Client Secret: `YOUR_AUTH0_CLIENT_SECRET`",
+      "expected_output": "Working Fastify web app with Auth0 session-based login, logout, a public home page, and a session-protected profile route",
+      "expectations": [
+        "Auth0 SDK (@auth0/auth0-fastify) present in project",
+        "Has correct import statement (@auth0/auth0-fastify)",
+        "Registers the Auth0 plugin via fastify.register",
+        "Awaits plugin registration (Fastify v5 requires await before auth0Client is used at setup time)",
+        "Configures all five required plugin options (domain, clientId, clientSecret, appBaseUrl, sessionSecret)",
+        "Auth0 domain dev-example.auth0.com written to .env config file",
+        "Client ID abc123def456ghi789jkl012 written to .env config file",
+        "Reads credentials from environment variables rather than hardcoding them",
+        "Protects a route using a preHandler that checks getSession",
+        "Retrieves the user profile with getUser",
+        "Does NOT hand-roll /auth/login, /auth/logout or /auth/callback routes — the plugin mounts them",
+        "Does not use the stateless API SDK (@auth0/auth0-fastify-api) or bare JWT validation for a session-based web app",
+        "Does not use unrelated auth libraries (@fastify/passport, fastify-auth0-verify, express-openid-connect)",
+        "Passes template names relative to @fastify/view's root option (e.g. 'home.ejs', not 'views/home.ejs')",
+        "Solution correctly integrates session-based Auth0 auth in Fastify",
+        "At least 2 skill-specific advanced patterns present (correct template path resolution, TokenSet destructuring, session config, reusable preHandler, logout URL href)"
+      ]
+    }
+  ],
+  "graders": [
+    {
+      "type": "matches",
+      "pattern": "@auth0/auth0-fastify(?![-a-z])",
+      "description": "Auth0 SDK (@auth0/auth0-fastify) present in project"
+    },
+    {
+      "type": "matches",
+      "pattern": "from\\s+['\"]@auth0/auth0-fastify['\"]|require\\s*\\(\\s*['\"]@auth0/auth0-fastify['\"]",
+      "description": "Has correct import statement (@auth0/auth0-fastify)"
+    },
+    {
+      "type": "matches",
+      "pattern": "\\.register\\s*\\(\\s*\\w*[aA]uth0",
+      "description": "Registers the Auth0 plugin via fastify.register"
+    },
+    {
+      "type": "matches",
+      "pattern": "await\\s+\\w+\\.register\\s*\\(",
+      "description": "Awaits plugin registration (Fastify v5 requires await before auth0Client is used at setup time)"
+    },
+    {
+      "type": "all",
+      "description": "Configures all five required plugin options (domain, clientId, clientSecret, appBaseUrl, sessionSecret)",
+      "graders": [
+        { "type": "matches", "pattern": "domain\\s*:" },
+        { "type": "matches", "pattern": "clientId\\s*:" },
+        { "type": "matches", "pattern": "clientSecret\\s*:" },
+        { "type": "matches", "pattern": "appBaseUrl\\s*:" },
+        { "type": "matches", "pattern": "sessionSecret\\s*:" }
+      ]
+    },
+    {
+      "type": "file_contains",
+      "file_pattern": "**/.env*",
+      "value": "dev-example.auth0.com",
+      "description": "Auth0 domain dev-example.auth0.com written to .env config file"
+    },
+    {
+      "type": "file_contains",
+      "file_pattern": "**/.env*",
+      "value": "abc123def456ghi789jkl012",
+      "description": "Client ID abc123def456ghi789jkl012 written to .env config file"
+    },
+    {
+      "type": "matches",
+      "pattern": "process\\.env\\.AUTH0_DOMAIN",
+      "description": "Reads credentials from environment variables rather than hardcoding them"
+    },
+    {
+      "type": "all",
+      "description": "Protects a route using a preHandler that checks getSession",
+      "graders": [
+        { "type": "matches", "pattern": "preHandler" },
+        { "type": "matches", "pattern": "getSession\\s*\\(" }
+      ]
+    },
+    {
+      "type": "matches",
+      "pattern": "getUser\\s*\\(",
+      "description": "Retrieves the user profile with getUser"
+    },
+    {
+      "type": "not_matches",
+      "pattern": "\\.(get|post)\\s*\\(\\s*['\"`]/auth/(login|logout|callback)['\"`]",
+      "description": "Does NOT hand-roll /auth/login, /auth/logout or /auth/callback routes — the plugin mounts them"
+    },
+    {
+      "type": "not_matches",
+      "pattern": "['\"]@auth0/auth0-fastify-api['\"]|requireAuth\\s*\\(",
+      "description": "Does not use the stateless API SDK (@auth0/auth0-fastify-api) or bare JWT validation for a session-based web app"
+    },
+    {
+      "type": "not_contains_any",
+      "values": [
+        "@fastify/passport",
+        "fastify-auth0-verify",
+        "express-openid-connect",
+        "@auth0/auth0-spa-js"
+      ],
+      "description": "Does not use unrelated auth libraries (@fastify/passport, fastify-auth0-verify, express-openid-connect)"
+    },
+    {
+      "type": "not_matches",
+      "pattern": "view(Async)?\\s*\\(\\s*['\"`]\\.?/?views/",
+      "description": "Passes template names relative to @fastify/view's root option (e.g. 'home.ejs', not 'views/home.ejs')"
+    },
+    {
+      "type": "judge",
+      "question": "Does the solution correctly integrate Auth0 into a Fastify web application with: (1) the @auth0/auth0-fastify plugin registered via fastify.register with domain, clientId, clientSecret, appBaseUrl and sessionSecret, (2) reliance on the plugin's built-in /auth/login, /auth/logout and /auth/callback routes rather than hand-written equivalents, (3) at least one route protected by a preHandler that calls fastify.auth0Client.getSession() and redirects to /auth/login when there is no session, and (4) a profile/user route that reads the user via fastify.auth0Client.getUser()?",
+      "examples": "PASS: Registers the plugin with all five options from process.env, links to /auth/login and /auth/logout in templates without defining those routes, and guards /profile with a preHandler calling getSession() that redirects when the session is falsy.\nPASS: Uses a shared requireSession preHandler function reused across several protected routes, with getUser() supplying the view data.\nFAIL: Defines its own fastify.get('/auth/login') that builds an Auth0 authorize URL by hand instead of using the mounted route.\nFAIL: Uses @auth0/auth0-fastify-api with requireAuth() and Bearer tokens for what is a server-rendered, session-based web app.\nFAIL: Hardcodes the domain and client secret in server.js instead of reading process.env.",
+      "framework": "fastify",
+      "description": "correctness-judge: Solution correctly integrates session-based Auth0 auth in Fastify"
+    },
+    {
+      "type": "judge",
+      "question": "Check ONLY for these skill-specific advanced patterns (NOT basic SDK usage like registering the plugin, getSession, getUser, or importing the SDK). Look for at least 2 of: (1) template names passed to reply.view/viewAsync are relative to @fastify/view's root option (e.g. 'profile.ejs') rather than repeating the directory ('views/profile.ejs'), (2) the result of getAccessToken() is destructured or property-accessed for .accessToken rather than being used as a string directly, (3) explicit sessionConfiguration (rolling, absoluteDuration, inactivityDuration, or cookie options), (4) a single reusable preHandler function shared across multiple protected routes rather than an inline closure duplicated per route, (5) logout() treated as returning a URL object, redirecting with .href. These are advanced patterns taught by the skill that are NOT part of standard quickstart knowledge. Answer YES only if at least 2 of these advanced patterns are present, NO otherwise.",
+      "examples": "PASS: Registers @fastify/view with root: './views' AND calls reply.view('profile.ejs', ...) without the directory prefix, AND defines one requireSession preHandler reused by /profile and /dashboard.\nPASS: Destructures const { accessToken } = await fastify.auth0Client.getAccessToken(...) AND configures sessionConfiguration with rolling and absoluteDuration.\nFAIL: Only registers the plugin and calls getSession/getUser — no shared preHandler, no session config, template paths repeat the views/ directory.\nFAIL: Uses await fastify.auth0Client.getAccessToken(...) directly as the Bearer token value without reading .accessToken.",
+      "framework": "fastify",
+      "description": "skill-attribution-judge: At least 2 skill-specific advanced patterns present (correct template path resolution, TokenSet destructuring, session config, reusable preHandler, logout URL href)"
+    }
+  ],
+  "scaffold": {
+    "package.json": "{\n  \"name\": \"fastify-auth0-eval\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"dependencies\": {\n    \"fastify\": \"^5.3.2\"\n  }\n}\n"
+  }
+}

--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -44,6 +44,22 @@
       "expect_refs": ["framework-php-api/index.md", "tooling-cli/index.md"]
     },
     {
+      "id": "integrate-fastify-web",
+      "_comment": "Web-app half of the fastify variant split. Asserts the session-based ref is routed, not the API one — the two are distinguished only by Step 2's variant disambiguation table.",
+      "intent": "integrate",
+      "framework": "fastify",
+      "tooling": "cli",
+      "expect_refs": ["framework-fastify/index.md", "tooling-cli/index.md"]
+    },
+    {
+      "id": "integrate-fastify-api",
+      "_comment": "API half of the same split — a resource server doing JWT validation only.",
+      "intent": "integrate",
+      "framework": "fastify-api",
+      "tooling": "cli",
+      "expect_refs": ["framework-fastify-api/index.md", "tooling-cli/index.md"]
+    },
+    {
       "id": "integrate-flask-terraform",
       "intent": "integrate",
       "framework": "flask",

--- a/plugins/auth0/skills/auth0/references/framework-fastify/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-fastify/index.md
@@ -3,12 +3,24 @@
 
 Add authentication to Fastify web applications using @auth0/auth0-fastify.
 
+> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running:
+>
+> ```bash
+> gh api repos/auth0/auth0-fastify/releases --jq '[.[] | select(.tag_name | startswith("auth0-fastify-v")) | .tag_name | ltrimstr("auth0-fastify-v")] | .[0]'
+> ```
+>
+> Use the returned version in all `package.json` dependency lines instead of any hardcoded version below. Do **not** use `releases/latest` — that endpoint can return the sibling `auth0-fastify-api-v*` package's version instead.
+
+## Critical rules
+
+- **You MUST ask the user for explicit confirmation before running any setup step that writes to `.env`.** Never read the contents of `.env` during setup; if you believe you need to, ask the user for explicit permission first and wait for confirmation.
+- To obtain a client secret, always have the user run `auth0 apps show <CLIENT_ID> --reveal-secrets` in their own terminal, rather than running `--reveal-secrets` from the agent — this keeps secrets out of agent context.
 
 ## Prerequisites
 
 - Fastify application (v5.x or newer)
 - Node.js 20 LTS or newer
-- Auth0 account and application configured
+- Auth0 **Regular Web Application** configured
 - If Auth0 isn't set up yet, set it up first with the Auth0 CLI (`auth0 login`, then `auth0 apps create`)
 
 ## When NOT to Use
@@ -18,7 +30,6 @@ Add authentication to Fastify web applications using @auth0/auth0-fastify.
 - **Mobile applications** - Use the Auth0 integration workflow for React Native/Expo
 - **Stateless APIs** - Use `@auth0/auth0-fastify-api` instead for JWT validation without sessions
 - **Microservices** - Use JWT validation for service-to-service auth
-
 
 ## Quick Start Workflow
 
@@ -41,6 +52,8 @@ APP_BASE_URL=http://localhost:3000
 ```
 
 Generate secret: `openssl rand -hex 64`
+
+> `AUTH0_DOMAIN` is the bare hostname — no `https://` prefix and no trailing slash.
 
 ### 3. Configure Auth Plugin
 
@@ -73,10 +86,14 @@ await fastify.register(fastifyAuth0, {
 fastify.listen({ port: 3000 });
 ```
 
-This automatically creates:
-- `/auth/login` - Login endpoint
-- `/auth/logout` - Logout endpoint
-- `/auth/callback` - OAuth callback
+This automatically registers (because `mountRoutes` defaults to `true`):
+
+- `GET /auth/login` - redirects to Auth0 Universal Login. Accepts a `?returnTo=` query param, which the SDK sanitises against `appBaseUrl` before use.
+- `GET /auth/callback` - handles the OAuth callback, creates the session, and redirects to the `returnTo` captured at login.
+- `GET /auth/logout` - clears the session and redirects to the Auth0 logout endpoint.
+- `POST /auth/backchannel-logout` - receives OIDC back-channel logout tokens from Auth0.
+
+Set `mountRoutes: false` to register none of them and roll your own.
 
 ### 4. Add Routes
 
@@ -84,7 +101,7 @@ This automatically creates:
 // Public route
 fastify.get('/', async (request, reply) => {
   const session = await fastify.auth0Client.getSession({ request, reply });
-  return reply.view('views/home.ejs', {
+  return reply.viewAsync('home.ejs', {
     isAuthenticated: !!session,
   });
 });
@@ -99,32 +116,36 @@ fastify.get('/profile', {
   }
 }, async (request, reply) => {
   const user = await fastify.auth0Client.getUser({ request, reply });
-  return reply.view('views/profile.ejs', { user });
+  return reply.viewAsync('profile.ejs', { user });
 });
 ```
 
 ### 5. Test Authentication
 
-Start your server:
-
 ```bash
 node server.js
 ```
 
-Visit `http://localhost:3000` and test the login flow.
+Visit `http://localhost:3000` and verify each of these in order:
 
+1. Clicking login redirects to the Auth0 Universal Login page.
+2. After authenticating, you land back on the app with a session established.
+3. `/profile` renders the user's name and email; visiting it while logged out redirects to login.
+4. Logout clears the session and returns you to the home page in a logged-out state.
+
+If step 1 or 2 fails, read the server logs before changing code — a callback URL mismatch is by far the most common cause, and it reports itself explicitly. Confirm the URL Auth0 rejected matches an entry in Allowed Callback URLs exactly, including scheme, port, and path.
 
 ## Common Mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Forgot to add callback URL in Auth0 Dashboard | Add `/auth/callback` path to Allowed Callback URLs (e.g., `http://localhost:3000/auth/callback`) |
-| Missing or weak SESSION_SECRET | Generate secure 64-char secret with `openssl rand -hex 64` and store in .env |
-| App created as SPA type in Auth0 | Must be Regular Web Application type for server-side auth |
+| Callback URL mismatch | The redirect URI is `<appBaseUrl>` + the `callback` route path (`/auth/callback` by default). Add that exact URL (note the `/auth/` prefix) to Allowed Callback URLs in the Auth0 Dashboard |
+| App created as SPA or Native type | Must be **Regular Web Application** — other types have no usable client secret for the code exchange |
 | Session secret exposed in code | Always use environment variables, never hardcode secrets |
-| Wrong appBaseUrl for production | Update APP_BASE_URL to match your production domain |
-| Not awaiting fastify.register | Fastify v4+ requires awaiting plugin registration |
-
+| `https://` prefix or trailing slash in `AUTH0_DOMAIN` | Use the bare hostname (`your-tenant.auth0.com`) |
+| Wrong `appBaseUrl` for production | Update `APP_BASE_URL` to match your production origin — it drives both the redirect URI and the post-logout return URL |
+| Reading `fastify.auth0Client` before the plugin loads | Fastify defers plugin registration until `ready()`/`listen()`. Route handlers always see the decorator; setup-time code needs `await fastify.register(...)` |
+| Treating `getAccessToken()`'s result as a string | It resolves to a `TokenSet` — read `.accessToken` off it |
 
 ## Related Skills
 
@@ -133,31 +154,40 @@ Visit `http://localhost:3000` and test the login flow.
 - Multi-factor authentication → ask for MFA (feature:mfa)
 - Manage Auth0 resources from the terminal → the Auth0 CLI (`tooling-cli`)
 
-
 ## Quick Reference
 
 **Plugin Options:**
-- `domain` - Auth0 tenant domain (required)
-- `clientId` - Auth0 client ID (required)
-- `clientSecret` - Auth0 client secret (required)
-- `appBaseUrl` - Application URL (required)
-- `sessionSecret` - Session encryption secret (required, min 64 chars)
-- `audience` - API audience (optional, for calling APIs)
 
-**Client Methods:**
-- `fastify.auth0Client.getSession({ request, reply })` - Get user session
-- `fastify.auth0Client.getUser({ request, reply })` - Get user profile
-- `fastify.auth0Client.getAccessToken({ request, reply })` - Get access token
-- `fastify.auth0Client.logout(options, { request, reply })` - Logout user
+| Option | Required | Description |
+|--------|----------|-------------|
+| `domain` | Yes | Auth0 tenant domain, or a `DomainResolver` function for multi-custom-domain setups |
+| `clientId` | Yes | Auth0 application Client ID |
+| `clientSecret` | No* | Client Secret. *Required unless you authenticate with `clientAssertionSigningKey` (private key JWT) |
+| `appBaseUrl` | Conditional | Application origin (e.g. `http://localhost:3000`). **Required when `domain` is a string.** Optional when `domain` is a resolver function — then it is inferred per request from the host/proto headers |
+| `sessionSecret` | Yes | Session encryption secret (required, min 64 chars) — `openssl rand -hex 64` generates a 128-character one |
+| `audience` | No | API identifier — set it to have the SDK request an access token for that API at login |
+| `mountRoutes` | No | Mount the built-in login/callback/logout/back-channel-logout routes. Default `true` |
+| `routes` | No | Override individual route paths. Keys: `login`, `callback`, `logout`, `backchannelLogout` |
+| `pushedAuthorizationRequests` | No | Use PAR for the authorization request |
+| `sessionConfiguration` | No | `rolling` (default `true`), `absoluteDuration` (default 3 days), `inactivityDuration` (default 1 day), and `cookie` options — all durations in seconds |
+| `sessionStore` | No | Custom server-side session store; defaults to a stateless encrypted cookie. **Required for back-channel logout** — the default stateless store cannot revoke sessions by logout token; provide a stateful store that implements `deleteByLogoutToken` to support `/auth/backchannel-logout` |
+| `customFetch` | No | Replacement `fetch` implementation (proxies, retries, instrumentation) |
+| `discoveryCache` | No | TTL config (seconds) for cached OIDC discovery metadata and JWKS |
+
+**Client Methods** — all on `fastify.auth0Client` after registration:
+- `getSession({ request, reply })` - resolves to `SessionData` or `undefined` (when not authenticated). Carries `user`, `idToken`, `refreshToken`, `tokenSets`
+- `getUser({ request, reply })` - resolves to `UserClaims` or `undefined` — the user's ID token claims (`sub`, `name`, `email`, `picture`, `org_id`, …)
+- `getAccessToken({ request, reply })` - resolves to a `TokenSet`; read the token from `.accessToken` (also carries `audience`, `scope`, `expiresAt`). Optionally takes `{ audience, scope }` as a first argument. **Note:** requesting a different `audience` than the one configured at plugin registration requires Multi-Resource Refresh Tokens (MRRT) to be enabled on the Auth0 tenant — without it Auth0 rejects the token exchange. If the user logged in before `audience` was configured, they must re-login to pick up the new audience
+- `logout({ returnTo }, { request, reply })` - resolves to a `URL` — the Auth0 logout URL; redirect with `logoutUrl.href`
 
 **Common Use Cases:**
-- Protected routes → Use `preHandler` to check session (see Step 4)
+- Protected routes → use `preHandler` to check the session (see Step 4)
 - Check auth status → `!!session`
 - Get user info → `getUser({ request, reply })`
-- Call APIs → `getAccessToken({ request, reply })`
-
+- Call APIs → set `audience`, then `getAccessToken({ request, reply })`
 
 ## References
 
 - [Auth0 Fastify Documentation](https://auth0.com/docs/quickstart/webapp/fastify)
 - [SDK GitHub Repository](https://github.com/auth0/auth0-fastify)
+- [SDK Examples](https://github.com/auth0/auth0-fastify/blob/main/packages/auth0-fastify/EXAMPLES.md)


### PR DESCRIPTION
Supersedes #113, which was opened against the pre-consolidation `auth0-fastify` skill. Ports what survived the re-architecture, fixes a rendering bug, and corrects five API inaccuracies.

## Bug fix

`reply.view('views/home.ejs')` **cannot render**. `@fastify/view` resolves the template name relative to its `root` option, which the snippet sets to `./views` — so the path resolved to `./views/views/home.ejs`. Fixed to the bare name, matching [the SDK's own web example](https://github.com/auth0/auth0-fastify/blob/main/examples/example-fastify-web/src/index.ts#L42).

## Accuracy fixes

Verified against `auth0-fastify` v1.5.0 and `@auth0/auth0-server-js` 1.11.0:

| Was documented as | Actually |
|---|---|
| `appBaseUrl` — "required" | Required only when `domain` is a string; optional with a resolver function |
| `getAccessToken()` → access token | Resolves to a `TokenSet` — read `.accessToken` |
| `logout()` → logout URL | Returns a `URL` object; redirect with `.href` |
| `sessionStore` optional, no caveats | Required for back-channel logout — the default stateless store cannot revoke sessions by logout token |
| `getAccessToken({ audience })` — no caveats | Requires Multi-Resource Refresh Tokens (MRRT) enabled on the tenant |

## Other changes

- Version lookup uses `gh api` with a tag-prefix filter instead of `releases/latest`, which can return the sibling `auth0-fastify-api` package's version
- Upstream fetch example wraps `fetch`/`response.json()` in a try-catch to return 502 instead of 500 on network failures
- MD031: blank lines around fenced code block in agent-instruction blockquote

## Eval coverage

This framework had **none**. Adds:

- **Routing:** `integrate-fastify-web` + `integrate-fastify-api`, locking down the variant split that previously had no test.
- **Behavioral:** `evals/behavioral/cases/fastify.json`, 16 graders (14 machine + 2 judge).

The machine graders were checked **both ways**: all 14 pass against a spec-correct fixture, and each of the four negative graders fires on the defect it targets (hand-rolled `/auth/login`, wrong SDK, unrelated auth lib, `views/`-prefixed template path). The SDK-detection regex uses a negative lookahead so `@auth0/auth0-fastify-api` alone doesn't satisfy it.