### PR TITLE
feat: package Auth0 skill for Codex plugins

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "auth0-agent-skills",
+  "interface": {
+    "displayName": "Auth0 Agent Skills"
+  },
+  "plugins": [
+    {
+      "name": "auth0",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/auth0/agent-skills.git",
+        "path": "./plugins/auth0",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer tools"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "auth0-agent-skills",
   "interface": {
-    "displayName": "Auth0 Agent Skills"
+    "displayName": "Auth0"
   },
   "plugins": [
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Key top-level docs:
 - [`docs/architecture.md`](./docs/architecture.md) — why one skill, and how the
   router resolves a request to reference files.
 - [`docs/openai-plugin.md`](./docs/openai-plugin.md) — OpenAI/Codex plugin
-  packaging, local testing, and public submission.
+  packaging, pre-submission testing, and public submission.
 
 ## Before you change a skill
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ Key top-level docs:
   are below.
 - [`PLUGIN.md`](./PLUGIN.md) — plugin/marketplace architecture.
 - [`README.md`](./README.md) — user-facing install and skill catalog.
+- [`docs/architecture.md`](./docs/architecture.md) — why one skill, and how the
+  router resolves a request to reference files.
+- [`docs/openai-plugin.md`](./docs/openai-plugin.md) — OpenAI/Codex plugin
+  packaging, local testing, and public submission.
 
 ## Before you change a skill
 

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -60,7 +60,7 @@ rationale, routing flow, and the CI-enforced reachability invariant.
 auth0/agent-skills/
 ├── .agents/
 │   └── plugins/
-│       └── marketplace.json      # OpenAI/Codex local marketplace
+│       └── marketplace.json      # OpenAI/Codex repo marketplace
 ├── .claude-plugin/
 │   └── marketplace.json          # Marketplace metadata
 ├── .cursor-plugin/
@@ -99,10 +99,12 @@ auth0/agent-skills/
 
 ### .agents/plugins/marketplace.json
 
-**Purpose**: OpenAI/Codex local marketplace metadata.
+**Purpose**: OpenAI/Codex marketplace metadata for this repository.
 
-Use it to test the plugin locally in ChatGPT desktop or Codex. Public listing
-requires submission and approval through the OpenAI plugin submission portal.
+Use it to install the plugin in ChatGPT desktop or Codex ahead of a public
+listing. The entry tracks the published `main` snapshot, so it does not pick up
+uncommitted local edits. Public listing requires submission and approval through
+the OpenAI plugin submission portal.
 
 ### .claude-plugin/marketplace.json
 
@@ -155,10 +157,10 @@ cp -r plugins/auth0/skills/auth0 ~/.claude/skills/
 
 ### OpenAI / Codex
 
-For local testing, add `.agents/plugins/marketplace.json` to the ChatGPT
-desktop or Codex Plugins UI and install Auth0. Public distribution requires
-submission through https://platform.openai.com/plugins and OpenAI approval.
-See [`docs/openai-plugin.md`](docs/openai-plugin.md).
+Add `.agents/plugins/marketplace.json` to the ChatGPT desktop or Codex Plugins
+UI to install Auth0 from the published `main` snapshot. Public distribution
+requires submission through https://platform.openai.com/plugins and OpenAI
+approval. See [`docs/openai-plugin.md`](docs/openai-plugin.md).
 
 ---
 

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -1,6 +1,6 @@
-# Claude Code Plugin Architecture
+# Agent Plugin Architecture
 
-This repository provides a **single Claude Code plugin** managed by a marketplace.json file.
+This repository provides one canonical Auth0 skill distributed through Claude Code, Cursor, and OpenAI/Codex plugin packaging. The OpenAI package is also usable by ChatGPT desktop through the universal plugin directory.
 
 ## Architecture Overview
 
@@ -62,6 +62,9 @@ auth0/agent-skills/
 │   └── marketplace.json          # Marketplace metadata
 ├── .cursor-plugin/
 │   └── marketplace.json          # Cursor marketplace metadata
+├── .agents/
+│   └── plugins/
+│       └── marketplace.json      # OpenAI/Codex local marketplace
 ├── plugins/
 │   └── auth0/                    # Single unified plugin
 │       ├── .claude-plugin/
@@ -93,6 +96,13 @@ auth0/agent-skills/
 
 ## File Purposes
 
+### .agents/plugins/marketplace.json
+
+**Purpose**: OpenAI/Codex local marketplace metadata.
+
+Use it to test the plugin locally in ChatGPT desktop or Codex. Public listing
+requires submission and approval through the OpenAI plugin submission portal.
+
 ### .claude-plugin/marketplace.json
 
 **Purpose**: Master marketplace listing for the plugin
@@ -117,7 +127,14 @@ auth0/agent-skills/
 
 ## Installation Methods
 
-### Method 1: Marketplace (Recommended)
+### OpenAI / Codex
+
+For local testing, add `.agents/plugins/marketplace.json` to the ChatGPT
+desktop or Codex Plugins UI and install Auth0. Public distribution requires
+submission through https://platform.openai.com/plugins and OpenAI approval.
+See [`docs/openai-plugin.md`](docs/openai-plugin.md).
+
+### Method 1: Claude marketplace (Recommended)
 
 1. Open Claude Code
 2. Navigate to **Settings > Plugins**
@@ -156,7 +173,8 @@ no per-framework skill to pick.
 
 ### Update Version
 
-Edit `.claude-plugin/marketplace.json` and `plugins/auth0/.claude-plugin/plugin.json`.
+Edit the relevant marketplace and plugin manifests. For OpenAI/Codex, update
+`.agents/plugins/marketplace.json` and `plugins/auth0/.codex-plugin/plugin.json`.
 
 ### Create Release
 

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -58,13 +58,13 @@ rationale, routing flow, and the CI-enforced reachability invariant.
 
 ```
 auth0/agent-skills/
+├── .agents/
+│   └── plugins/
+│       └── marketplace.json      # OpenAI/Codex local marketplace
 ├── .claude-plugin/
 │   └── marketplace.json          # Marketplace metadata
 ├── .cursor-plugin/
 │   └── marketplace.json          # Cursor marketplace metadata
-├── .agents/
-│   └── plugins/
-│       └── marketplace.json      # OpenAI/Codex local marketplace
 ├── plugins/
 │   └── auth0/                    # Single unified plugin
 │       ├── .claude-plugin/
@@ -83,7 +83,8 @@ auth0/agent-skills/
 │               ├── assets/            # Templates (e.g. ACUL screens)
 │               └── scripts/           # validate-skill.sh, reachability check
 ├── docs/
-│   └── architecture.md               # Why one skill + routing details
+│   ├── architecture.md               # Why one skill + routing details
+│   └── openai-plugin.md              # OpenAI/Codex packaging + submission
 ├── .gitignore
 ├── CODE_OF_CONDUCT.md
 ├── CONTRIBUTING.md
@@ -127,36 +128,37 @@ requires submission and approval through the OpenAI plugin submission portal.
 
 ## Installation Methods
 
-### OpenAI / Codex
-
-For local testing, add `.agents/plugins/marketplace.json` to the ChatGPT
-desktop or Codex Plugins UI and install Auth0. Public distribution requires
-submission through https://platform.openai.com/plugins and OpenAI approval.
-See [`docs/openai-plugin.md`](docs/openai-plugin.md).
-
-### Method 1: Claude marketplace (Recommended)
+### Claude marketplace (Recommended)
 
 1. Open Claude Code
 2. Navigate to **Settings > Plugins**
 3. Search "Auth0"
 4. Install "Auth0 Agent Skills"
 
-### Method 2: CLI Installation
+### CLI Installation
 
 ```bash
 # Install the auth0 skill
 npx skills add auth0/agent-skills
 ```
 
-### Method 3: Manual Installation
+### Manual Installation
 
 ```bash
 git clone https://github.com/auth0/agent-skills.git
 cd agent-skills
 
 # Copy the auth0 skill
+mkdir -p ~/.claude/skills
 cp -r plugins/auth0/skills/auth0 ~/.claude/skills/
 ```
+
+### OpenAI / Codex
+
+For local testing, add `.agents/plugins/marketplace.json` to the ChatGPT
+desktop or Codex Plugins UI and install Auth0. Public distribution requires
+submission through https://platform.openai.com/plugins and OpenAI approval.
+See [`docs/openai-plugin.md`](docs/openai-plugin.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![License](https://img.shields.io/:license-apache-blue.svg?style=flat)](https://opensource.org/licenses/Apache-2.0)
 
-AI agent skills that help coding assistants implement Auth0 authentication correctly. Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com), [GitHub Copilot](https://github.com/features/copilot), and [40+ other agents](https://agentskills.io/clients) that support the [Agent Skills](https://agentskills.io) format.
+AI agent skills that help coding assistants implement Auth0 authentication correctly. Works with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com), [Codex](https://openai.com/codex/), [GitHub Copilot](https://github.com/features/copilot), and [40+ other agents](https://agentskills.io/clients) that support the [Agent Skills](https://agentskills.io) format.
 
 [Documentation](https://auth0.com/docs/quickstart/agent-skills) · [Getting Started](#prerequisites) · [Feedback](#feedback)
 
 ## Prerequisites
 
 - An [Auth0 account](https://auth0.com/signup) (free)
-- An AI coding assistant (Claude Code, Cursor, GitHub Copilot, or any [Agent Skills-compatible](https://agentskills.io/clients) tool)
+- An AI coding assistant (Claude Code, Cursor, Codex, GitHub Copilot, or any [Agent Skills-compatible](https://agentskills.io/clients) tool)
 
 ## Install
 
@@ -40,6 +40,16 @@ You can also install via `Cursor Settings → Rules → Add Rule → Remote Rule
 ```bash
 npx skills add auth0/agent-skills --agent github-copilot
 ```
+
+### Codex / ChatGPT plugins
+
+The repository includes an OpenAI-compatible skills-only plugin. For local
+Codex or ChatGPT desktop testing, add this repository's marketplace from
+`.agents/plugins/marketplace.json`, then install **Auth0** from the Plugins UI.
+
+For public availability, Auth0 must submit the plugin through the
+[OpenAI plugin submission portal](https://platform.openai.com/plugins). Approval
+is required before it appears in the universal ChatGPT and Codex directory.
 
 ### Any Agent (Skills CLI)
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ npx skills add auth0/agent-skills --agent github-copilot
 
 ### Codex / ChatGPT plugins
 
-The repository includes an OpenAI-compatible skills-only plugin. For local
-Codex or ChatGPT desktop testing, add this repository's marketplace from
-`.agents/plugins/marketplace.json`, then install **Auth0** from the Plugins UI.
+The repository includes an OpenAI-compatible skills-only plugin. Add this
+repository's marketplace from `.agents/plugins/marketplace.json`, then install
+**Auth0** from the Plugins UI. It tracks the published `main` snapshot.
 
 For public availability, Auth0 must submit the plugin through the
 [OpenAI plugin submission portal](https://platform.openai.com/plugins). Approval

--- a/docs/openai-plugin.md
+++ b/docs/openai-plugin.md
@@ -17,7 +17,7 @@ plugins/auth0/
 The canonical skill content is shared with the Claude and Cursor packages; do
 not create a Codex-specific copy of the skill.
 
-## Local testing
+## Testing before submission
 
 The repository includes an OpenAI-compatible marketplace at:
 
@@ -30,6 +30,10 @@ restart the host if necessary, and test in a new conversation. Test direct and
 indirect authentication requests, framework routing, reference loading, and
 negative requests that should not activate the skill.
 
+The entry resolves `plugins/auth0` from the published `main` branch, so push
+your changes before reinstalling — an uncommitted working tree is not what gets
+installed.
+
 For Codex CLI, inspect configured marketplaces with:
 
 ```bash
@@ -39,7 +43,7 @@ codex plugin marketplace upgrade
 
 ## Public publication
 
-A manifest and local marketplace do not publish the plugin. To list Auth0 in
+A manifest and repository marketplace do not publish the plugin. To list Auth0 in
 the universal ChatGPT and Codex directory:
 
 1. Open the [OpenAI plugin submission portal](https://platform.openai.com/plugins).

--- a/docs/openai-plugin.md
+++ b/docs/openai-plugin.md
@@ -1,0 +1,53 @@
+# OpenAI / Codex plugin
+
+This repository packages the unified `auth0` skill as a skills-only OpenAI
+plugin. ChatGPT and Codex use the same universal plugin format and directory.
+
+## Package layout
+
+```text
+plugins/auth0/
+├── .codex-plugin/
+│   └── plugin.json
+└── skills/
+    └── auth0/
+        └── SKILL.md
+```
+
+The canonical skill content is shared with the Claude and Cursor packages; do
+not create a Codex-specific copy of the skill.
+
+## Local testing
+
+The repository includes an OpenAI-compatible marketplace at:
+
+```text
+.agents/plugins/marketplace.json
+```
+
+Add that marketplace in the ChatGPT desktop or Codex Plugins UI, install Auth0,
+restart the host if necessary, and test in a new conversation. Test direct and
+indirect authentication requests, framework routing, reference loading, and
+negative requests that should not activate the skill.
+
+For Codex CLI, inspect configured marketplaces with:
+
+```bash
+codex plugin marketplace list
+codex plugin marketplace upgrade
+```
+
+## Public publication
+
+A manifest and local marketplace do not publish the plugin. To list Auth0 in
+the universal ChatGPT and Codex directory:
+
+1. Open the [OpenAI plugin submission portal](https://platform.openai.com/plugins).
+2. Create a **Skills only** submission.
+3. Upload the tested `plugins/auth0` bundle.
+4. Provide Auth0 listing, legal, support, and brand metadata.
+5. Add starter prompts and five positive plus three negative test cases.
+6. Submit for review and publish after approval.
+
+The OpenAI submission requires a verified developer or business identity and
+Apps Management write access for the submitting organization.

--- a/plugins/auth0/.codex-plugin/plugin.json
+++ b/plugins/auth0/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auth0",
   "version": "2.0.1",
-  "description": "Implement and troubleshoot Auth0 authentication across web, mobile, and API applications.",
+  "description": "Add Auth0 authentication to any app — login, MFA, SSO, Organizations, RBAC, ACUL, custom domains, and branding. Debug auth errors, validate JWTs, manage token lifecycles, and migrate from Clerk, Firebase, or Cognito. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, Spring Boot, Go, Swift, Android, Flutter, Laravel, PHP, ASP.NET Core, React Native, Expo, Ionic, .NET MAUI, and more.",
   "skills": "./skills/",
   "author": {
     "name": "Auth0",
@@ -14,7 +14,7 @@
   "interface": {
     "displayName": "Auth0",
     "shortDescription": "Add Auth0 authentication to your application",
-    "longDescription": "Implement and troubleshoot Auth0 authentication across web, mobile, and API applications.",
+    "longDescription": "Add Auth0 authentication to any app — login, MFA, SSO, Organizations, RBAC, ACUL, custom domains, and branding. Debug auth errors, validate JWTs, manage token lifecycles, and migrate from Clerk, Firebase, or Cognito. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, Spring Boot, Go, Swift, Android, Flutter, Laravel, PHP, ASP.NET Core, React Native, Expo, Ionic, .NET MAUI, and more.",
     "developerName": "Auth0",
     "category": "Developer tools",
     "websiteURL": "https://auth0.com",

--- a/plugins/auth0/.codex-plugin/plugin.json
+++ b/plugins/auth0/.codex-plugin/plugin.json
@@ -1,14 +1,26 @@
 {
   "name": "auth0",
   "version": "2.0.1",
-  "description": "A single unified Auth0 skill that detects your framework, feature, and tooling, then loads the right reference guides for adding authentication — login, MFA, Organizations, ACUL, custom domains, branding, JWT validation, migration, and debugging — to any app.",
+  "description": "Implement and troubleshoot Auth0 authentication across web, mobile, and API applications.",
   "skills": "./skills/",
   "author": {
     "name": "Auth0",
-    "email": "support@auth0.com"
+    "email": "support@auth0.com",
+    "url": "https://auth0.com"
   },
+  "homepage": "https://auth0.com/developers",
   "repository": "https://github.com/auth0/agent-skills",
   "license": "Apache-2.0",
+  "interface": {
+    "displayName": "Auth0",
+    "shortDescription": "Add Auth0 authentication to your application",
+    "longDescription": "Implement and troubleshoot Auth0 authentication across web, mobile, and API applications.",
+    "developerName": "Auth0",
+    "category": "Developer tools",
+    "websiteURL": "https://auth0.com",
+    "privacyPolicyURL": "https://auth0.com/privacy",
+    "termsOfServiceURL": "https://auth0.com/terms"
+  },
   "keywords": [
     "auth0",
     "quickstart",

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -6,9 +6,9 @@ Auth0 skills for setting up authentication, migrating from other providers, impl
 
 **Via Codex / ChatGPT desktop:**
 
-For local testing, add the repository marketplace from
-`.agents/plugins/marketplace.json` to the Plugins UI, then install **Auth0**.
-The public plugin directory requires submission and approval through the
+Add the repository marketplace from `.agents/plugins/marketplace.json` to the
+Plugins UI, then install **Auth0**. It tracks the published `main` snapshot. The
+public plugin directory requires submission and approval through the
 [OpenAI plugin submission portal](https://platform.openai.com/plugins).
 
 **Via Claude Code:**

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -4,6 +4,13 @@ Auth0 skills for setting up authentication, migrating from other providers, impl
 
 ## Installation
 
+**Via Codex / ChatGPT desktop:**
+
+For local testing, add the repository marketplace from
+`.agents/plugins/marketplace.json` to the Plugins UI, then install **Auth0**.
+The public plugin directory requires submission and approval through the
+[OpenAI plugin submission portal](https://platform.openai.com/plugins).
+
 **Via Claude Code:**
 
 First, add the Auth0 marketplace if you haven't already:


### PR DESCRIPTION
## Summary

- package the unified Auth0 skill as an OpenAI/Codex skills-only plugin
- add a repo-local OpenAI marketplace for ChatGPT desktop and Codex testing
- document local testing and public submission requirements
- enrich the Codex manifest with publisher and install-surface metadata

## Validation

- `bash plugins/auth0/skills/auth0/scripts/validate-skill.sh`
- `python3 scripts/check_router_reachability.py plugins/auth0/skills/auth0`
- `python3 scripts/check_routing_evals.py plugins/auth0/skills/auth0`
- `uvx skillsaw --strict`

All checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing the Auth0 plugin through OpenAI/Codex and ChatGPT desktop.
  * Added marketplace metadata and plugin details for discovery, authentication, and developer tooling.
  * Added guidance for local installation, testing, and public plugin submission.

* **Documentation**
  * Updated prerequisites and supported AI coding assistants.
  * Documented plugin packaging, validation, publishing, installation workflows, and supported distribution channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->