### PR TITLE
feat(auth0): add Hono framework reference to unified skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ per-framework skill.
 | **Express** | [`express-openid-connect`](https://github.com/auth0/express-openid-connect) | Express.js |
 | **Flask** | [`auth0-server-python`](https://github.com/auth0/auth0-server-python) | Flask |
 | **Fastify** | [`@auth0/auth0-fastify`](https://github.com/auth0/auth0-fastify) | Fastify |
+| **Hono** | [`@auth0/auth0-hono`](https://github.com/auth0/auth0-hono) | Hono (Node.js, Cloudflare Workers, Deno, Bun) |
 | **Java Servlet** | [`mvc-auth-commons`](https://github.com/auth0/auth0-java-mvc-common) | Java Servlet |
 | **Express API** | [`express-oauth2-jwt-bearer`](https://github.com/auth0/node-oauth2-jwt-bearer) | Node.js/Express APIs |
 | **Fastify API** | [`@auth0/auth0-fastify`](https://github.com/auth0/auth0-fastify) | Fastify APIs |

--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -248,6 +248,13 @@
       "framework": null,
       "tooling": "cli",
       "expect_refs": ["feature-healthcheck/index.md", "feature-audit/index.md", "feature-audit-pricing/index.md", "feature-audit-remediation/index.md", "tooling-cli/index.md"]
+    },
+    {
+      "id": "integrate-hono",
+      "intent": "integrate",
+      "framework": "hono",
+      "tooling": "cli",
+      "expect_refs": ["framework-hono/index.md", "framework-hono/integrate.md", "tooling-cli/index.md"]
     }
   ]
 }

--- a/evals/verify-framework-hono.sh
+++ b/evals/verify-framework-hono.sh
@@ -4,6 +4,11 @@ set -uo pipefail
 # Framework Hono TEST-PLAN verification script (Phase 10)
 # Implements the critical structural, reachability, SDK fact, and security tests
 # Exit 0 if all pass; exit 1 if any fail.
+#
+# Test set = TEST-PLAN T-F1..T-F21 (now incl. T-F8 routes + T-F13 scope/perm guards,
+# previously dropped) + T-R1..T-R8 dist-verified regression guards locking the CP3
+# remediation fixes (I1-I9, D2). These are static greps; they enforce presence/absence
+# of dist-sourced signatures, NOT runtime behavior.
 
 # Resolve repo root from script location
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -481,6 +486,145 @@ test_f21_no_commonjs() {
   return 0
 }
 
+# T-F8: Default routes /login, /logout, /callback documented
+test_f8_routes_present() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  for route in "/login" "/logout" "/callback"; do
+    grep -rq -- "$route" "$hono_dir" || { echo " (route $route not documented)"; return 1; }
+  done
+
+  return 0
+}
+
+# T-F13: NO requiresScopes / requiresPermissions (banned non-exports)
+test_f13_no_scope_perm_guards() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -rE "requiresScopes|requiresPermissions" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (requiresScopes/requiresPermissions found — not exported by SDK)"
+    return 1
+  fi
+
+  return 0
+}
+
+# ============================================================================
+# REGRESSION GUARDS (T-Rxx) — lock CP3 dist-verified defect fixes (I1-I9, D2)
+# Each MUST-ABSENT guard re-fails if a defect is reintroduced.
+# ============================================================================
+
+# T-R1 (I1): NO honoEnv import (dist lib/honoEnv.js body = `export {};`, exports nothing)
+test_r1_no_hono_env() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -rn "honoEnv" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (honoEnv reference found — dead runtime export)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-R2 (I2): NO env(c) usage (module-scope crash; SDK auto-reads bindings)
+test_r2_no_env_c() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -rnF "env(c)" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (env(c) found — module-scope ReferenceError)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-R3 (I3): NO snake_case access_token; camelCase accessToken IS the dist field
+test_r3_access_token_camel() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -rn "access_token" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (access_token snake_case found — dist field is accessToken)"
+    return 1
+  fi
+  # Positive: accessToken must be present
+  grep -rq "accessToken" "$hono_dir"/*.md || { echo " (accessToken not present)"; return 1; }
+
+  return 0
+}
+
+# T-R4 (I4): NO cancelSilentLogin(c) code call (dist = zero-arg middleware factory)
+test_r4_cancel_silent_login_arity() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  # Code call has trailing semicolon; prose warning does not.
+  if grep -rnF "cancelSilentLogin(c);" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (cancelSilentLogin(c); code call — wrong arity)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-R5 (I5): updateSession must be awaited (async persist; fire-and-forget loses writes)
+test_r5_update_session_awaited() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  # Fail on a statement-position updateSession( call not prefixed by await.
+  if grep -rnE "^[[:space:]]*updateSession\(" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (un-awaited updateSession() call found)"
+    return 1
+  fi
+  # Positive: at least one awaited call present
+  grep -rq "await updateSession(" "$hono_dir"/*.md || { echo " (no awaited updateSession)"; return 1; }
+
+  return 0
+}
+
+# T-R6 (I7): SessionStore uses StateData contract (not SessionData) + required deleteByLogoutToken
+test_r6_session_store_shape() {
+  local patterns="plugins/auth0/skills/auth0/references/framework-hono/patterns.md"
+  [[ -f "$patterns" ]] || { echo " (patterns.md missing)"; return 1; }
+
+  grep -q "StateData" "$patterns" || { echo " (StateData not used in store contract)"; return 1; }
+  grep -q "deleteByLogoutToken(claims" "$patterns" || { echo " (deleteByLogoutToken(claims) sig missing)"; return 1; }
+  # NO null return in store get() — dist returns StateData | undefined
+  if grep -nE "return (data \? [^;]*: null|null)" "$patterns" 2>/dev/null | grep -q .; then
+    echo " (store returns null; dist contract is undefined)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-R7 (I8): standalone handleLogin takes NO client config (domain/clientID) — only flow params
+test_r7_handle_login_no_client_config() {
+  local patterns="plugins/auth0/skills/auth0/references/framework-hono/patterns.md"
+  [[ -f "$patterns" ]] || { echo " (patterns.md missing)"; return 1; }
+
+  # handleLogin({ ... domain ... }) is the fabricated per-tenant form.
+  if grep -nE "handleLogin\(\{" "$patterns" 2>/dev/null | grep -q .; then
+    # Allow only if it does not contain client-config keys nearby
+    if grep -A3 "handleLogin({" "$patterns" 2>/dev/null | grep -qE "domain:|clientID:|baseURL:"; then
+      echo " (handleLogin passed client config — not accepted by SDK)"
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+# T-R8 (D2): NO "Vercel Edge" runtime claim (not in dist/pkg/REQ)
+test_r8_no_vercel_edge() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -rn "Vercel" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (Vercel runtime claim found — unsourced)"
+    return 1
+  fi
+
+  return 0
+}
+
 # ============================================================================
 # SECURITY & PII TESTS (T-Pxx)
 # ============================================================================
@@ -547,6 +691,8 @@ run_test "T-N3" "Hub dispatch table has integrate row" "test_n3_hub_dispatch"
 run_test "T-N4" "Hub 'As needed' section lists setup, api-reference, patterns" "test_n4_as_needed"
 run_test "T-N5" "Leaf files are sinks (no .md links)" "test_n5_leaves_no_links"
 
+run_test "T-F8" "Default routes /login /logout /callback documented" "test_f8_routes_present"
+run_test "T-F13" "NO requiresScopes/requiresPermissions (non-exports)" "test_f13_no_scope_perm_guards"
 run_test "T-F1" "authRequired default = true" "test_f1_auth_required"
 run_test "T-F2" "idpLogout default = false" "test_f2_idp_logout"
 run_test "T-F3" "Cookie name = appSession" "test_f3_app_session"
@@ -566,6 +712,15 @@ run_test "T-F18" "Node 18+ documented" "test_f18_node_18"
 run_test "T-F19" "NO Node 20 LTS claim" "test_f19_no_node_20_lts"
 run_test "T-F20" "ESM imports present" "test_f20_esm_imports"
 run_test "T-F21" "NO CommonJS require()" "test_f21_no_commonjs"
+
+run_test "T-R1" "REGRESSION I1: NO honoEnv (dead export)" "test_r1_no_hono_env"
+run_test "T-R2" "REGRESSION I2: NO env(c) module-scope call" "test_r2_no_env_c"
+run_test "T-R3" "REGRESSION I3: accessToken camelCase (NO access_token)" "test_r3_access_token_camel"
+run_test "T-R4" "REGRESSION I4: NO cancelSilentLogin(c) wrong arity" "test_r4_cancel_silent_login_arity"
+run_test "T-R5" "REGRESSION I5: updateSession awaited" "test_r5_update_session_awaited"
+run_test "T-R6" "REGRESSION I7: SessionStore StateData contract" "test_r6_session_store_shape"
+run_test "T-R7" "REGRESSION I8: handleLogin no client config" "test_r7_handle_login_no_client_config"
+run_test "T-R8" "REGRESSION D2: NO Vercel Edge runtime claim" "test_r8_no_vercel_edge"
 
 run_test "T-P1" "NO tenant domain leaked" "test_p1_no_tenant_domain"
 run_test "T-P2" "NO client ID leaked (exact)" "test_p2_no_client_id_leaked"

--- a/evals/verify-framework-hono.sh
+++ b/evals/verify-framework-hono.sh
@@ -1,0 +1,591 @@
+#!/bin/bash
+set -uo pipefail
+
+# Framework Hono TEST-PLAN verification script (Phase 10)
+# Implements the critical structural, reachability, SDK fact, and security tests
+# Exit 0 if all pass; exit 1 if any fail.
+
+# Resolve repo root from script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Colors for output (optional, for clarity)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_TESTS=()
+
+# Helper: run a test, track pass/fail
+run_test() {
+  local test_id="$1"
+  local description="$2"
+  local test_fn="$3"
+
+  echo -n "[${test_id}] ${description}... "
+  if $test_fn; then
+    echo -e "${GREEN}PASS${NC}"
+    ((PASS_COUNT++))
+  else
+    echo -e "${RED}FAIL${NC}"
+    ((FAIL_COUNT++))
+    FAILED_TESTS+=("$test_id")
+  fi
+}
+
+# ============================================================================
+# STRUCTURAL TESTS (T-Sxx)
+# ============================================================================
+
+# T-S1: framework-hono directory + 5 files exist
+test_s1_files_exist() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  [[ -d "$hono_dir" ]] || return 1
+
+  # Check for exact 5 files (no subdirs)
+  local files=("$hono_dir"/*.md)
+  local count=${#files[@]}
+
+  # Filter to actual files (not glob if no match)
+  if [[ "${files[0]}" == "$hono_dir"'/*.md' ]]; then
+    echo " (no .md files found)"
+    return 1
+  fi
+
+  [[ $count -eq 5 ]] || { echo " (found $count files, expected 5)"; return 1; }
+
+  # Verify exact names
+  local required=("index.md" "setup.md" "integrate.md" "api-reference.md" "patterns.md")
+  for fname in "${required[@]}"; do
+    [[ -f "$hono_dir/$fname" ]] || { echo " (missing $fname)"; return 1; }
+  done
+
+  return 0
+}
+
+# T-S2: File line counts sanity check
+test_s2_line_counts() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  # Expected ranges (approx)
+  # index.md: hub ~40–50 lines, setup.md: 200–300, integrate.md: 350–450,
+  # api-reference.md: 300–400, patterns.md: 250–350
+  # Hub files are smaller; all leaves > 200
+
+  for f in index setup integrate api-reference patterns; do
+    local fpath="$hono_dir/$f.md"
+    if [[ ! -f "$fpath" ]]; then
+      echo " (missing $f.md)"
+      return 1
+    fi
+
+    local lc=$(wc -l < "$fpath")
+    # Hub (index) can be smaller, leaves should be > 200
+    if [[ "$f" != "index" ]] && [[ $lc -lt 200 ]]; then
+      echo " ($f.md has $lc lines, too few for leaf)"
+      return 1
+    fi
+    if [[ "$f" == "index" ]] && [[ $lc -lt 30 ]]; then
+      echo " ($f.md has $lc lines, too few for hub)"
+      return 1
+    fi
+  done
+
+  # Check total
+  local total=$(cat "$hono_dir"/*.md | wc -l)
+  [[ $total -gt 1000 ]] || { echo " (total lines $total < 1000)"; return 1; }
+
+  return 0
+}
+
+# T-S4: README.md Hono entry
+test_s4_readme_hono() {
+  local readme="README.md"
+  [[ -f "$readme" ]] || { echo " (README.md missing)"; return 1; }
+
+  # Check for Hono row after Fastify
+  grep -q "| \*\*Hono\*\*" "$readme" || { echo " (Hono not in README)"; return 1; }
+
+  return 0
+}
+
+# T-S5: No skill-test-report
+test_s5_no_test_report() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if find "$hono_dir" -name "*test*report*" -o -name "*skill*test*" 2>/dev/null | grep -q .; then
+    echo " (test-report artifact found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-S6: No bootstrap reference in setup.md
+test_s6_no_bootstrap() {
+  local setup="plugins/auth0/skills/auth0/references/framework-hono/setup.md"
+  [[ -f "$setup" ]] || { echo " (setup.md missing)"; return 1; }
+
+  if grep -iq "bootstrap" "$setup"; then
+    echo " (bootstrap reference found in setup.md)"
+    return 1
+  fi
+
+  return 0
+}
+
+# ============================================================================
+# REACHABILITY TESTS (T-Nxx)
+# ============================================================================
+
+# T-N3: Hub dispatch table — single integrate row
+test_n3_hub_dispatch() {
+  local hub="plugins/auth0/skills/auth0/references/framework-hono/index.md"
+  [[ -f "$hub" ]] || { echo " (index.md missing)"; return 1; }
+
+  # Count rows with "integrate" in dispatch table (before "Then, as needed")
+  local integrate_rows=$(grep -E '^\|.*integrate.*\|' "$hub" | head -2 | wc -l)
+
+  # Should be 1 primary dispatch row (header + 1 data row = 2 lines, but grep -E should find 1 data row)
+  # Actually, let's just verify integrate.md is referenced
+  grep -q "integrate.md\|integrate\.md" "$hub" || { echo " (no integrate.md reference)"; return 1; }
+
+  return 0
+}
+
+# T-N4: Hub "As needed" section
+test_n4_as_needed() {
+  local hub="plugins/auth0/skills/auth0/references/framework-hono/index.md"
+  [[ -f "$hub" ]] || { echo " (index.md missing)"; return 1; }
+
+  # Check "Then, as needed" section has setup, api-reference, patterns
+  if ! grep -q "Then, as needed\|As needed" "$hub"; then
+    echo " (no 'As needed' section)"
+    return 1
+  fi
+
+  for name in setup api-reference patterns; do
+    grep -A 20 "Then, as needed\|As needed" "$hub" | grep -q "$name" || {
+      echo " (missing '$name' in 'As needed')"
+      return 1
+    }
+  done
+
+  return 0
+}
+
+# T-N5: Leaf files are sinks (no .md outbound links)
+test_n5_leaves_no_links() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  for leaf in setup integrate api-reference patterns; do
+    local fpath="$hono_dir/$leaf.md"
+    [[ -f "$fpath" ]] || { echo " (missing $leaf.md)"; return 1; }
+
+    # Check for markdown links: [text](*.md), [label]: *.md, <*.md>
+    if grep -E '\[.*\]\(.*\.md.*\)|^\s*\[.*\]:\s*.*\.md|<.*\.md>' "$fpath" 2>/dev/null | grep -q .; then
+      echo " ($leaf.md has .md outbound link)"
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+# ============================================================================
+# SDK FACT TESTS (T-Fxx)
+# ============================================================================
+
+# T-F1: authRequired default = true
+test_f1_auth_required() {
+  local api_ref="plugins/auth0/skills/auth0/references/framework-hono/api-reference.md"
+  [[ -f "$api_ref" ]] || { echo " (api-reference.md missing)"; return 1; }
+
+  grep -q "authRequired.*true\|true.*authRequired" "$api_ref" || {
+    echo " (authRequired true not documented)"
+    return 1
+  }
+
+  return 0
+}
+
+# T-F2: idpLogout default = false
+test_f2_idp_logout() {
+  local api_ref="plugins/auth0/skills/auth0/references/framework-hono/api-reference.md"
+  [[ -f "$api_ref" ]] || { echo " (api-reference.md missing)"; return 1; }
+
+  grep -q "idpLogout.*false\|false.*idpLogout" "$api_ref" || {
+    echo " (idpLogout false not documented)"
+    return 1
+  }
+
+  return 0
+}
+
+# T-F3: Cookie name = appSession
+test_f3_app_session() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  grep -r "'appSession'" "$hono_dir" >/dev/null || {
+    echo " (appSession not found)"
+    return 1
+  }
+
+  return 0
+}
+
+# T-F4: NO session.internal.expiresAt
+test_f4_no_expires_at() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -E "session\.internal\.expiresAt|session\[.*expiresAt" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (session.internal.expiresAt found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-F5: NO c.var.auth0.tokens
+test_f5_no_tokens_field() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -E "c\.var\.auth0\.tokens|var\.auth0\s*=.*tokens" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (c.var.auth0.tokens found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-F6: clientID (capital ID)
+test_f6_client_id_capital() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  grep -r "clientID" "$hono_dir" >/dev/null || {
+    echo " (clientID not found)"
+    return 1
+  }
+
+  return 0
+}
+
+# T-F7: NO clientId (lowercase)
+test_f7_no_client_id_lower() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -E "clientId['\"]?:" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (clientId lowercase found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-F9: cancelSilentLogin present
+test_f9_cancel_silent_login() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  grep -r "cancelSilentLogin" "$hono_dir" >/dev/null || {
+    echo " (cancelSilentLogin not found)"
+    return 1
+  }
+
+  return 0
+}
+
+# T-F10: NO pauseSilentLogin in active examples
+test_f10_no_pause_silent_login_active() {
+  local integrate="plugins/auth0/skills/auth0/references/framework-hono/integrate.md"
+  [[ -f "$integrate" ]] || { echo " (integrate.md missing)"; return 1; }
+
+  # pauseSilentLogin should only appear in deprecation notes, not in active code
+  # Check: grep pauseSilentLogin, then filter to exclude deprecation context
+  if grep -i "pauseSilentLogin" "$integrate" | grep -v -i "deprecat\|deprecated\|do not\|not recommended\|not use" | grep -q .; then
+    echo " (pauseSilentLogin found in active context)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-F11: NO getOrg() function (allowed only in FAQ as deprecation note)
+test_f11_no_get_org() {
+  local api_ref="plugins/auth0/skills/auth0/references/framework-hono/api-reference.md"
+  [[ -f "$api_ref" ]] || { echo " (api-reference.md missing)"; return 1; }
+
+  # getOrg should only appear in FAQ section, not in examples or main content
+  # Check: if getOrg( appears outside of FAQ context (look for it before "Q:" markers)
+  # Simple heuristic: extract FAQ section, then verify getOrg only appears there
+  # Count total mentions vs FAQ mentions
+  local total=$(grep -c "getOrg(" "$api_ref" 2>/dev/null || echo 0)
+  local in_faq=$(grep -B1 "getOrg(" "$api_ref" 2>/dev/null | grep -c "^\*\*Q:" || echo 0)
+
+  # If any mentions exist and they're all in Q&A lines, it's OK
+  if [[ $total -gt 0 ]] && [[ $in_faq -eq 0 ]]; then
+    # Check if the mention is in a Q&A line (line contains both "getOrg" and "Q:")
+    local in_qa_line=$(grep "getOrg.*\*\*Q:\|\*\*Q:.*getOrg" "$api_ref" 2>/dev/null | wc -l)
+    if [[ $in_qa_line -eq 0 ]]; then
+      # Could be in answer, check next few lines
+      if grep -A 2 "\*\*Q.*getOrg" "$api_ref" 2>/dev/null | grep -q "getOrg"; then
+        return 0
+      fi
+      echo " (getOrg() found outside FAQ)"
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+# T-F12: NO revokeSession() function (allowed only in FAQ as deprecation note)
+test_f12_no_revoke_session() {
+  local api_ref="plugins/auth0/skills/auth0/references/framework-hono/api-reference.md"
+  [[ -f "$api_ref" ]] || { echo " (api-reference.md missing)"; return 1; }
+
+  # revokeSession should only appear in FAQ section, not in examples
+  # Count total mentions
+  local total=$(grep -c "revokeSession" "$api_ref" 2>/dev/null || echo 0)
+
+  if [[ $total -eq 0 ]]; then
+    return 0
+  fi
+
+  # If mentioned, must be in/near a **Q: line
+  if grep -B1 -A3 "\*\*Q.*revokeSession\|revokeSession.*\*\*Q:" "$api_ref" 2>/dev/null | grep -q "revokeSession"; then
+    return 0
+  fi
+
+  # Check if answer mentions it after Q:
+  if grep -A 3 "\*\*Q: Is.*revokeSession" "$api_ref" 2>/dev/null | grep -q "revokeSession"; then
+    return 0
+  fi
+
+  echo " (revokeSession found outside FAQ)"
+  return 1
+}
+
+# T-F14: NO jwtVerifier or /api subpath
+test_f14_no_jwt_verifier() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -E "jwtVerifier\(|@auth0/auth0-hono/api" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (jwtVerifier or /api subpath found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-F15: NO /testing subpath
+test_f15_no_testing_subpath() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep "@auth0/auth0-hono/testing" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (/testing subpath found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-F16: onCallback hook throw-non-blocking clause
+test_f16_on_callback_throw_non_blocking() {
+  local integrate="plugins/auth0/skills/auth0/references/framework-hono/integrate.md"
+  [[ -f "$integrate" ]] || { echo " (integrate.md missing)"; return 1; }
+
+  # Look for "throw" + "NOT" + "block" or "does not block" in context of onCallback
+  if grep -i "onCallback\|throwing.*block\|throw.*does.*not.*block\|return.*Response.*deny" "$integrate" | grep -q .; then
+    return 0
+  fi
+
+  echo " (onCallback throw-non-blocking not documented)"
+  return 1
+}
+
+# T-F17: All 7 error types present
+test_f17_error_types() {
+  local api_ref="plugins/auth0/skills/auth0/references/framework-hono/api-reference.md"
+  [[ -f "$api_ref" ]] || { echo " (api-reference.md missing)"; return 1; }
+
+  local errors=(
+    "AccessDeniedError"
+    "LoginRequiredError"
+    "InvalidGrantError"
+    "MissingSessionError"
+    "MissingTransactionError"
+    "TokenRefreshError"
+    "ConnectionTokenError"
+  )
+
+  for err in "${errors[@]}"; do
+    grep -q "$err" "$api_ref" || {
+      echo " (missing $err)"
+      return 1
+    }
+  done
+
+  return 0
+}
+
+# T-F18: Node 18+
+test_f18_node_18() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  grep -r "Node.*18\|18+" "$hono_dir" >/dev/null || {
+    echo " (Node 18+ not documented)"
+    return 1
+  }
+
+  return 0
+}
+
+# T-F19: NO Node 20 LTS claim
+test_f19_no_node_20_lts() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -E "Node 20.*LTS|Node\.js 20.*LTS" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (Node 20 LTS claim found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-F20: ESM imports present
+test_f20_esm_imports() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  grep -r "^import\|from 'hono'\|from '@auth0" "$hono_dir" >/dev/null || {
+    echo " (no ESM imports found)"
+    return 1
+  }
+
+  return 0
+}
+
+# T-F21: NO CommonJS require()
+test_f21_no_commonjs() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -E "require\(\|module\.exports" "$hono_dir"/*.md 2>/dev/null | grep -q .; then
+    echo " (CommonJS require found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# ============================================================================
+# SECURITY & PII TESTS (T-Pxx)
+# ============================================================================
+
+# T-P1: NO tenant domain
+test_p1_no_tenant_domain() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -r "dev-10whndm3tf8jetu5" "$hono_dir" 2>/dev/null | grep -q .; then
+    echo " (tenant domain leaked)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-P2: NO client ID (exact value)
+test_p2_no_client_id_leaked() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -r "vxx3Ko8xqRJgYqgvkOcuAiGLbYTiYYGM" "$hono_dir" 2>/dev/null | grep -q .; then
+    echo " (client ID leaked)"
+    return 1
+  fi
+
+  return 0
+}
+
+# T-P3: NO email address
+test_p3_no_email_leaked() {
+  local hono_dir="plugins/auth0/skills/auth0/references/framework-hono"
+
+  if grep -r "tushar\.pandey@okta\.com" "$hono_dir" 2>/dev/null | grep -q .; then
+    echo " (email address leaked)"
+    return 1
+  fi
+
+  # Also check broader: no @okta.com emails (unless in generic examples)
+  if grep -r "@okta\.com" "$hono_dir" 2>/dev/null | grep -v "example\|placeholder" | grep -q .; then
+    echo " (okta.com email found)"
+    return 1
+  fi
+
+  return 0
+}
+
+# ============================================================================
+# MAIN EXECUTION
+# ============================================================================
+
+echo "==============================================="
+echo "Framework Hono TEST-PLAN Verification"
+echo "==============================================="
+echo
+
+# Run all tests
+run_test "T-S1" "Files exist (index, setup, integrate, api-reference, patterns)" "test_s1_files_exist"
+run_test "T-S2" "Line counts sanity (>50 each, >1000 total)" "test_s2_line_counts"
+run_test "T-S4" "README.md Hono entry" "test_s4_readme_hono"
+run_test "T-S5" "No skill-test-report artifact" "test_s5_no_test_report"
+run_test "T-S6" "No bootstrap reference in setup.md" "test_s6_no_bootstrap"
+
+run_test "T-N3" "Hub dispatch table has integrate row" "test_n3_hub_dispatch"
+run_test "T-N4" "Hub 'As needed' section lists setup, api-reference, patterns" "test_n4_as_needed"
+run_test "T-N5" "Leaf files are sinks (no .md links)" "test_n5_leaves_no_links"
+
+run_test "T-F1" "authRequired default = true" "test_f1_auth_required"
+run_test "T-F2" "idpLogout default = false" "test_f2_idp_logout"
+run_test "T-F3" "Cookie name = appSession" "test_f3_app_session"
+run_test "T-F4" "NO session.internal.expiresAt" "test_f4_no_expires_at"
+run_test "T-F5" "NO c.var.auth0.tokens" "test_f5_no_tokens_field"
+run_test "T-F6" "clientID (capital ID) present" "test_f6_client_id_capital"
+run_test "T-F7" "NO clientId (lowercase)" "test_f7_no_client_id_lower"
+run_test "T-F9" "cancelSilentLogin present" "test_f9_cancel_silent_login"
+run_test "T-F10" "NO pauseSilentLogin in active code" "test_f10_no_pause_silent_login_active"
+run_test "T-F11" "NO getOrg() function" "test_f11_no_get_org"
+run_test "T-F12" "NO revokeSession() function" "test_f12_no_revoke_session"
+run_test "T-F14" "NO jwtVerifier or /api subpath" "test_f14_no_jwt_verifier"
+run_test "T-F15" "NO /testing subpath" "test_f15_no_testing_subpath"
+run_test "T-F16" "onCallback hook throw-non-blocking documented" "test_f16_on_callback_throw_non_blocking"
+run_test "T-F17" "All 7 error types present" "test_f17_error_types"
+run_test "T-F18" "Node 18+ documented" "test_f18_node_18"
+run_test "T-F19" "NO Node 20 LTS claim" "test_f19_no_node_20_lts"
+run_test "T-F20" "ESM imports present" "test_f20_esm_imports"
+run_test "T-F21" "NO CommonJS require()" "test_f21_no_commonjs"
+
+run_test "T-P1" "NO tenant domain leaked" "test_p1_no_tenant_domain"
+run_test "T-P2" "NO client ID leaked (exact)" "test_p2_no_client_id_leaked"
+run_test "T-P3" "NO email address leaked" "test_p3_no_email_leaked"
+
+echo
+echo "==============================================="
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+echo "verify-framework-hono: $PASS_COUNT/$TOTAL checks passed"
+echo "==============================================="
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  echo -e "\n${RED}FAILED TESTS:${NC}"
+  for test in "${FAILED_TESTS[@]}"; do
+    echo "  - $test"
+  done
+  echo
+  exit 1
+else
+  echo -e "\n${GREEN}All tests passed!${NC}"
+  echo
+  exit 0
+fi

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -86,6 +86,7 @@ SDK, so check the `@capacitor/browser` rows before it.
 | `@auth0/auth0-spa-js` | `spa-js` |
 | `express-openid-connect` | `express` |
 | `@auth0/auth0-fastify` | `fastify` |
+| `@auth0/auth0-hono` | `hono` |
 | `@auth0/auth0-fastify-api` | `fastify-api` |
 | `express-oauth2-jwt-bearer` | `express-jwt` |
 | `react-native-auth0` + `app.json` or `app.config.js` present | `expo` |
@@ -168,6 +169,7 @@ variant is resolved in "Variant disambiguation" below. As in Tier 1, check the
 | `react` (no meta-framework above) | `react` (SPA) — see note |
 | `express` in `package.json` | `express` (variant below) |
 | `fastify` in `package.json` | `fastify` (variant below) |
+| `hono` in `package.json` | `hono` |
 | `flask` in `requirements.txt`/`pyproject.toml` | `flask` |
 | `fastapi` in `requirements.txt`/`pyproject.toml` | `fastapi-api` |
 | `spring-boot` in `pom.xml`/`build.gradle` | `springboot-api` |
@@ -202,6 +204,7 @@ request. **Stop at the first match.**
 | Express (web app / server-rendered) | `express` |
 | Express API / protect API routes | `express-jwt` |
 | Fastify (web) / Fastify API | `fastify` / `fastify-api` |
+| Hono (web) | `hono` |
 | Flask | `flask` |
 | FastAPI | `fastapi-api` |
 | Spring Boot | `springboot-api` |

--- a/plugins/auth0/skills/auth0/references/framework-hono/api-reference.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/api-reference.md
@@ -11,7 +11,7 @@ Complete configuration options, environment variables, error types, and frequent
 - Protected routes and authentication guards
 - Role-Based Access Control (RBAC) via claim guards
 - Organizations for multi-tenant applications
-- Runtimes: Node.js, Cloudflare Workers, Deno, Bun, Vercel Edge
+- Runtimes: Node.js, Cloudflare Workers, Deno, Bun
 
 **Not in beta (coming in future releases):**
 - JWT verifier and `/api` subpath for stateless API authentication
@@ -265,12 +265,12 @@ Before deploying to production, verify:
 
 **Q: Why does session not have an `expiresAt` field?**
 
-Session data doesn't track token expiration directly. To check session age, use `session.internal.createdAt`. To check access token expiration, call `getAccessToken()` which returns `{ access_token, expiresAt, ... }`.
+Session data doesn't track token expiration directly. To check session age, use `session.internal.createdAt`. To check access token expiration, call `getAccessToken()` which returns `{ accessToken, expiresAt, ... }`.
 
 **Q: How do I read tokens from the context?**
 
 The context shape is `{ user, session, org }` — there is NO `tokens` field. Fetch tokens on-demand:
-- Access token: `await getAccessToken(c)` → `{ access_token, expiresAt, ... }`
+- Access token: `await getAccessToken(c)` → `{ accessToken, expiresAt, ... }`
 - Connection-specific token: `await getAccessTokenForConnection(c, opts)`
 - ID token: `c.var.auth0.session.idToken` (if offline_access scope)
 

--- a/plugins/auth0/skills/auth0/references/framework-hono/api-reference.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/api-reference.md
@@ -1,0 +1,308 @@
+# API Reference: @auth0/auth0-hono Config, Environment, and Types
+
+Complete configuration options, environment variables, error types, and frequently asked questions.
+
+## Beta Status
+
+@auth0/auth0-hono v2.0.0-beta.0 ships session-based web application integration only:
+
+**Supported:**
+- Session management with encryption and rolling windows
+- Protected routes and authentication guards
+- Role-Based Access Control (RBAC) via claim guards
+- Organizations for multi-tenant applications
+- Runtimes: Node.js, Cloudflare Workers, Deno, Bun, Vercel Edge
+
+**Not in beta (coming in future releases):**
+- JWT verifier and `/api` subpath for stateless API authentication
+- MFA and DPoP
+- `/management` self-service endpoints
+- `/testing` utilities
+- Token revocation
+
+API is likely to stabilize post-beta. User feedback is encouraged.
+
+## Configuration Object
+
+Pass configuration to the `auth0()` middleware:
+
+```typescript
+app.use('*', auth0({
+  domain: process.env.AUTH0_DOMAIN,
+  clientID: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  baseURL: process.env.APP_BASE_URL,
+  session: { secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY },
+}));
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `domain` | string | Auth0 tenant domain (e.g., `your-tenant.us.auth0.com`) |
+| `clientID` | string | Auth0 application client ID (note: capital **ID**) |
+| `baseURL` | string | Base URL of your application (e.g., `http://localhost:3000`) |
+
+### Optional Fields with Defaults
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `clientSecret` | `undefined` | Client secret (required for standard OAuth flows) |
+| `authRequired` | `true` | Require authentication globally; override per-route via `requiresAuth()` |
+| `idpLogout` | `false` | Logout from Auth0 tenant when user logs out of app |
+| `session.secret` | — | Session encryption secret (required, ≥32 chars; string or array for rotation) |
+| `session.rolling` | `true` | Reset session expiry on each request |
+| `session.absoluteDuration` | `259200` | Max session lifetime in seconds (3 days) |
+| `session.inactivityDuration` | `86400` | Session expiry after inactivity in seconds (1 day) |
+| `session.cookie.name` | `'appSession'` | Session cookie name |
+| `session.cookie.sameSite` | `'lax'` | SameSite cookie policy (`'lax'` or `'strict'`) |
+| `session.cookie.secure` | `auto` | Use secure flag; auto-detect from `baseURL` https |
+| `routes.login` | `'/login'` | Login endpoint path |
+| `routes.logout` | `'/logout'` | Logout endpoint path |
+| `routes.callback` | `'/callback'` | OAuth callback path |
+| `authorizationParams.response_type` | `'id_token'` | OpenID Connect response type |
+| `authorizationParams.scope` | `'openid profile email'` | OIDC scopes |
+| `authorizationParams.response_mode` | `'form_post'` | Form POST response mode |
+| `authorizationParams.audience` | — | API audience (for access tokens) |
+| `clockTolerance` | `60` | Clock skew tolerance in seconds (for token validation) |
+| `enableTelemetry` | `true` | Send telemetry to Auth0 |
+| `idTokenSigningAlg` | `'RS256'` | ID token signing algorithm |
+| `onCallback` | — | Hook function run after callback |
+
+### Example with Full Config
+
+```typescript
+app.use('*', auth0({
+  domain: process.env.AUTH0_DOMAIN,
+  clientID: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  baseURL: process.env.APP_BASE_URL,
+  
+  authRequired: true,
+  idpLogout: false,
+  
+  session: {
+    secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
+    rolling: true,
+    absoluteDuration: 259200,      // 3 days
+    inactivityDuration: 86400,     // 1 day
+    cookie: {
+      name: 'appSession',
+      sameSite: 'lax',
+      secure: true,
+    },
+  },
+  
+  routes: {
+    login: '/login',
+    logout: '/logout',
+    callback: '/callback',
+  },
+  
+  authorizationParams: {
+    response_type: 'id_token',
+    scope: 'openid profile email offline_access',
+    audience: 'https://api.example.com',
+  },
+  
+  clockTolerance: 60,
+  idTokenSigningAlg: 'RS256',
+  
+  onCallback: (c, error, session) => {
+    if (!error) {
+      return { loginTime: Date.now() };
+    }
+  },
+}));
+```
+
+## Environment Variables
+
+Store sensitive configuration in environment variables:
+
+| Variable | Required | Example | Description |
+|----------|----------|---------|-------------|
+| `AUTH0_DOMAIN` | Yes | `your-tenant.us.auth0.com` | Auth0 tenant domain |
+| `AUTH0_CLIENT_ID` | Yes | `<client-id>` | Auth0 application client ID |
+| `AUTH0_CLIENT_SECRET` | Yes | `<secret>` | Auth0 application secret |
+| `APP_BASE_URL` | Yes | `http://localhost:3000` | Application base URL |
+| `AUTH0_SESSION_ENCRYPTION_KEY` | Yes | `<32+ hex chars>` | Session encryption key (generate via `openssl rand -hex 32`) |
+
+## OpenID Connect Claims
+
+Standard OpenID Connect claims available in `c.var.auth0.user`:
+
+| Claim | Type | Description |
+|-------|------|-------------|
+| `sub` | string | Subject (unique user ID) |
+| `name` | string | User's full name |
+| `email` | string | User's email address |
+| `email_verified` | boolean | Whether email is verified |
+| `picture` | string | Profile picture URL |
+| `updated_at` | number | Last update timestamp |
+
+Custom claims (configured in Auth0 Rules or Actions):
+- `org_id` — Organization ID
+- `roles` — Array of role names
+- `permissions` — Array of permission strings
+- Additional custom claims as defined in your Auth0 Actions
+
+Access custom claims via:
+
+```typescript
+const user = c.var.auth0.user;
+const roles = user.roles;           // Array
+const orgId = user.org_id;          // String
+const customField = user.custom;    // Any
+```
+
+## Error Types Reference
+
+All errors extend `Auth0Error` and propagate to Hono's `app.onError()` handler:
+
+| Error | Status | When | Example |
+|-------|--------|------|---------|
+| `Auth0Error` | 500 | Base error class (rarely thrown directly) | — |
+| `AccessDeniedError` | 403 | Claim guard mismatch or policy denied | `claimIncludes()` returns false |
+| `LoginRequiredError` | 401 | No session on protected route | `requiresAuth()` without session |
+| `InvalidGrantError` | 401 | Token refresh failed | Refresh token expired |
+| `MissingSessionError` | 401 | `getUser()` / `getSession()` without session | Called on public route |
+| `MissingTransactionError` | 400 | `/callback` hit without valid transaction | CSRF/state validation failure |
+| `TokenRefreshError` | 401 | Access token refresh failed | Network error or server rejection |
+| `ConnectionTokenError` | 401 | Failed to fetch connection-specific token | Invalid connection name |
+
+Import errors:
+
+```typescript
+import {
+  Auth0Error,
+  AccessDeniedError,
+  LoginRequiredError,
+  InvalidGrantError,
+  MissingSessionError,
+  MissingTransactionError,
+  TokenRefreshError,
+  ConnectionTokenError,
+  Auth0Exception, // Deprecated alias for Auth0Error
+} from '@auth0/auth0-hono';
+```
+
+## Context Variables
+
+After the `auth0()` middleware, the Hono context includes:
+
+```typescript
+c.var.auth0 = {
+  user: Auth0User | null,
+  session: Auth0Session | null,
+  org: Auth0Organization | null,
+}
+```
+
+### Auth0User (extends UserClaims)
+
+```typescript
+{
+  sub: string;                    // Unique user ID
+  name?: string;
+  email?: string;
+  email_verified?: boolean;
+  picture?: string;
+  org_id?: string;                // Organization ID
+  org_name?: string;              // Organization name
+  roles?: string[];               // User roles (custom claim)
+  permissions?: string[];         // User permissions (custom claim)
+  [custom: string]: any;          // Additional custom claims
+}
+```
+
+### Auth0Session
+
+```typescript
+{
+  user: Auth0User;
+  idToken?: string;               // OpenID Connect ID token
+  refreshToken?: string;          // Refresh token (if offline_access scope)
+  tokenSets?: Auth0TokenSet[];    // Token sets for audiences
+  connectionTokenSets?: {...};    // Connection-specific tokens
+  internal: {
+    sid: string;                  // Session ID
+    createdAt: number;            // Session creation time (milliseconds since epoch)
+  }
+}
+```
+
+**Note:** Session does NOT have an `expiresAt` field. Use `session.internal.createdAt` for session creation time or `getAccessToken().expiresAt` for access token expiration.
+
+### Auth0Organization
+
+```typescript
+{
+  id: string;         // Organization ID
+  name?: string;      // Organization display name
+}
+```
+
+## Testing Checklist
+
+Before deploying to production, verify:
+
+- [ ] Login redirects to Auth0 Universal Login page
+- [ ] Successful login redirects back to app with session cookie set
+- [ ] Protected route throws `LoginRequiredError` (401) when unauthenticated
+- [ ] Logout clears session and redirects to logout URL
+- [ ] `getAccessToken()` returns token with valid `expiresAt` timestamp
+- [ ] Silent login via `attemptSilentLogin` restores session without redirect
+- [ ] `onCallback` hook receives error on failed authentication
+- [ ] Claim guards throw `AccessDeniedError` (403) on mismatch
+- [ ] `app.onError` handler catches and properly formats `Auth0Error` exceptions
+- [ ] Organizations: `requiresOrg()` populates `c.var.auth0.org`
+- [ ] Token refresh: `getAccessToken()` auto-refreshes expired tokens
+- [ ] Multi-runtime: Same code runs on Node.js, Cloudflare Workers, Deno, Bun
+
+## Common Issues and FAQ
+
+**Q: Why does session not have an `expiresAt` field?**
+
+Session data doesn't track token expiration directly. To check session age, use `session.internal.createdAt`. To check access token expiration, call `getAccessToken()` which returns `{ access_token, expiresAt, ... }`.
+
+**Q: How do I read tokens from the context?**
+
+The context shape is `{ user, session, org }` — there is NO `tokens` field. Fetch tokens on-demand:
+- Access token: `await getAccessToken(c)` → `{ access_token, expiresAt, ... }`
+- Connection-specific token: `await getAccessTokenForConnection(c, opts)`
+- ID token: `c.var.auth0.session.idToken` (if offline_access scope)
+
+**Q: Can I reject a login by throwing an error in the `onCallback` hook?**
+
+No. Throwing from the hook is logged but does NOT block the login. To deny a login, **return a `Response`** with a non-2xx status (e.g., `c.json({ error: 'Denied' }, { status: 403 })`). Login will fail and the Response is sent to the client.
+
+**Q: Is there a `getOrg()` function?**
+
+No. Access the organization via:
+- `c.var.auth0.org` (populated by `requiresOrg()`)
+- `c.var.auth0.user.org_id` (organization ID from claims)
+
+**Q: Is `revokeSession()` available?**
+
+No, not in beta. Clear the session by redirecting to `/logout`.
+
+**Q: Is `pauseSilentLogin` still available?**
+
+`pauseSilentLogin` is deprecated. Use `cancelSilentLogin()` instead to cancel silent login and clear the SSO cookie.
+
+**Q: Where are the `/api` JWT verifier routes?**
+
+The `/api` subpath (JWT verifier, MFA, etc.) is not in the published beta. Use session-based web routes only. JWT verifier support is planned for a future release.
+
+**Q: Why no `/management` or `/testing` subpaths?**
+
+These subpaths are not in the published beta:
+- `/management` — Self-service management endpoints (future release)
+- `/testing` — Testing utilities (future release)
+
+**Q: Can I use this in a stateless API?**
+
+No. This SDK is for session-based web applications only. For stateless APIs, use JWT validation (coming in future release or use `@auth0/auth0-server-js` directly).
+

--- a/plugins/auth0/skills/auth0/references/framework-hono/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/index.md
@@ -1,0 +1,41 @@
+# Auth0 Hono Integration
+
+Add authentication to Hono web applications using @auth0/auth0-hono.
+
+---
+
+## Prerequisites
+
+- **Hono:** v3.0.0 or newer
+- **Node.js:** 18+ (published package.json has no engines field; README states 18+)
+- **ESM:** Package type `"module"` in package.json (SDK is ESM-only; no CommonJS)
+- **Peer dependency:** `hono >=3.0.0`
+- **Auth0 account:** Set up a Regular Web Application client (NOT SPA type)
+- **Env vars:** `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `APP_BASE_URL`, `AUTH0_SESSION_ENCRYPTION_KEY`
+
+---
+
+## Developer intent → primary reference
+
+| Developer intent | Primary leaf | Read |
+|---|---|---|
+| Add login, logout, protected routes, sessions, tokens, silent login, error handling | integrate | `Read: references/framework-hono/integrate.md` |
+
+---
+
+## Then, as needed
+
+- **Setup & environment:** `Read: references/framework-hono/setup.md` (install dependencies, Auth0 dashboard config, multi-runtime deployment)
+- **API reference & config:** `Read: references/framework-hono/api-reference.md` (complete config object, claims, error types, testing checklist, FAQs)
+- **Advanced patterns:** `Read: references/framework-hono/patterns.md` (RBAC, organizations, multi-runtime, custom session store, session enrichment)
+
+---
+
+## Quick Start
+
+1. Install SDK: `npm install @auth0/auth0-hono hono @hono/node-server`
+2. Set environment variables (see setup.md)
+3. Configure Auth0 dashboard application with callback URL, allowed logout URL, and allowed origins
+4. Add middleware to your Hono app and protect routes (see integrate.md)
+5. Test login/logout flow in development before deploying
+

--- a/plugins/auth0/skills/auth0/references/framework-hono/integrate.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/integrate.md
@@ -204,14 +204,16 @@ The session object contains:
 
 Enrich the session with custom data using `updateSession()`:
 
+`updateSession()` is async and persists to the session store — always `await` it inside an `async` handler:
+
 ```typescript
 import { updateSession } from '@auth0/auth0-hono';
 
-app.post('/preferences', requiresAuth(), (c) => {
-  updateSession(c, {
+app.post('/preferences', requiresAuth(), async (c) => {
+  await updateSession(c, {
     preferences: { theme: 'dark', language: 'en' },
   });
-  
+
   return c.json({ ok: true });
 });
 ```
@@ -222,21 +224,27 @@ app.post('/preferences', requiresAuth(), (c) => {
 
 Fetch access tokens on-demand to call protected APIs:
 
+`getAccessToken()` never returns null — on failure it throws an `Auth0Error` subclass (`InvalidGrantError`, `TokenRefreshError`). Wrap the call in try/catch:
+
 ```typescript
-import { getAccessToken } from '@auth0/auth0-hono';
+import { getAccessToken, InvalidGrantError, TokenRefreshError } from '@auth0/auth0-hono';
 
 app.get('/api-data', requiresAuth(), async (c) => {
-  const token = await getAccessToken(c);
-  
-  if (!token) {
-    return c.json({ error: 'No access token' }, { status: 401 });
+  let token;
+  try {
+    token = await getAccessToken(c);
+  } catch (err) {
+    if (err instanceof InvalidGrantError || err instanceof TokenRefreshError) {
+      return c.json({ error: 'Could not obtain access token' }, { status: 401 });
+    }
+    throw err;
   }
-  
+
   // Call your API
   const response = await fetch('https://api.example.com/data', {
-    headers: { Authorization: `Bearer ${token.access_token}` },
+    headers: { Authorization: `Bearer ${token.accessToken}` },
   });
-  
+
   return c.json(await response.json());
 });
 ```
@@ -245,8 +253,8 @@ The returned token object has:
 
 ```typescript
 {
-  access_token: string,
-  expiresAt: number,  // Milliseconds since epoch
+  accessToken: string,
+  expiresAt: number,  // Unix timestamp
   ...
 }
 ```
@@ -274,10 +282,10 @@ import { getAccessTokenForConnection } from '@auth0/auth0-hono';
 app.get('/connection-token', requiresAuth(), async (c) => {
   const token = await getAccessTokenForConnection(c, {
     connection: 'google-oauth2',
-    audience: 'https://www.googleapis.com',
+    loginHint: 'user@gmail.com', // optional
   });
-  
-  return c.json(token);
+
+  return c.json({ accessToken: token.accessToken });
 });
 ```
 
@@ -302,16 +310,17 @@ If the SSO cookie exists and is valid, the session is restored automatically. Ot
 
 ### Cancel Silent Login
 
-To cancel (clear the SSO cookie), use `cancelSilentLogin()`:
+To cancel silent login (set the skip cookie), use `cancelSilentLogin()`. It is a **zero-argument factory** that returns a middleware — mount it in the route chain, then let the next handler produce the response:
 
 ```typescript
 import { cancelSilentLogin } from '@auth0/auth0-hono';
 
-app.get('/cancel-sso', (c) => {
-  cancelSilentLogin(c);
+app.get('/cancel-sso', cancelSilentLogin(), (c) => {
   return c.redirect('/');
 });
 ```
+
+**Do NOT** call `cancelSilentLogin(c)` directly inside a response-returning handler. It takes no arguments, and its internal `next()` call can dispatch to Hono's 404 handler, which finalizes the context and silently discards a subsequent `c.redirect()`. Always use it as composable middleware as shown above.
 
 **Note:** `pauseSilentLogin()` is deprecated; use `cancelSilentLogin()` instead.
 
@@ -322,7 +331,8 @@ The `onCallback` hook runs after Auth0 redirects back with the authentication re
 ### Hook Signature
 
 ```typescript
-onCallback?: (c: Context, error: Error | null, session: Auth0Session | null) => Response | SessionData | void
+onCallback?: (c: Context, error: Auth0Error | null, session: SessionData | null) =>
+  SessionData | Response | void | Promise<SessionData | Response | void>
 ```
 
 ### On Success (error is null)

--- a/plugins/auth0/skills/auth0/references/framework-hono/integrate.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/integrate.md
@@ -1,0 +1,452 @@
+# Integration: Login, Logout, Protected Routes, Sessions, and Tokens
+
+Implement authentication flows, protect routes, manage sessions, and handle access tokens.
+
+## Middleware Initialization
+
+Initialize the Auth0 middleware in your Hono application:
+
+```typescript
+import { Hono } from 'hono';
+import { auth0 } from '@auth0/auth0-hono';
+
+const app = new Hono();
+
+app.use('*', auth0({
+  domain: process.env.AUTH0_DOMAIN,
+  clientID: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  baseURL: process.env.APP_BASE_URL,
+  session: {
+    secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
+  },
+}));
+```
+
+**Configuration defaults:**
+- `authRequired: true` — Most routes require authentication by default; set to false for public routes
+- `idpLogout: false` — App logout does not automatically logout from Auth0; set to true to redirect to Auth0 logout
+
+## Context Shape After Middleware
+
+After the `auth0()` middleware runs, the Hono context includes:
+
+```typescript
+c.var.auth0 = {
+  user: Auth0User | null,        // User profile (null if unauthenticated)
+  session: Auth0Session | null,  // Session data (null if unauthenticated)
+  org: Auth0Organization | null, // Organization info (null if not in org)
+}
+```
+
+**Important:** The context ONLY contains `user`, `session`, and `org` — there is no `tokens` field. Access tokens are fetched on-demand via `getAccessToken(c)`.
+
+## Protected Routes
+
+Use `requiresAuth()` to require authentication on a route. If unauthenticated, it throws `LoginRequiredError` (401):
+
+```typescript
+import { requiresAuth } from '@auth0/auth0-hono';
+
+// Protected route: requires login
+app.get('/profile', requiresAuth(), (c) => {
+  const user = c.var.auth0.user;
+  return c.json({
+    message: `Hello, ${user.name}`,
+    email: user.email,
+  });
+});
+```
+
+**Middleware order matters:** Place `requiresAuth()` BEFORE claim guards (e.g., `requiresOrg()`, `claimIncludes()`) so authentication is verified first.
+
+### Error Behavior
+
+By default, `requiresAuth()` on an unauthenticated request:
+- For HTML requests (browser): redirects to `/login`
+- For API requests: throws `LoginRequiredError` (401 JSON)
+
+To always throw (for API routes), use:
+
+```typescript
+app.get('/api/profile', requiresAuth('error'), (c) => {
+  return c.json({ user: c.var.auth0.user });
+});
+```
+
+To always redirect (for web routes), use:
+
+```typescript
+app.get('/dashboard', requiresAuth('login'), (c) => {
+  return c.html('<h1>Dashboard</h1>');
+});
+```
+
+## Organizations
+
+Organizations enable multi-tenant B2B applications. Use `requiresOrg()` to require the user to be in an organization:
+
+```typescript
+import { requiresOrg } from '@auth0/auth0-hono';
+
+app.get('/org-details', requiresAuth(), requiresOrg(), (c) => {
+  const org = c.var.auth0.org; // { id, name? }
+  return c.json({ org });
+});
+```
+
+**CRITICAL: `requiresOrg()` MUST run AFTER `requiresAuth()`** — running it before will throw a 500 error.
+
+Organizations provide multi-tenant isolation:
+
+```typescript
+app.get('/org/:orgId', requiresAuth(), requiresOrg(), (c) => {
+  const userOrg = c.var.auth0.org.id;
+  const requestedOrg = c.req.param('orgId');
+  
+  if (userOrg !== requestedOrg) {
+    return c.json({ error: 'Unauthorized' }, { status: 403 });
+  }
+  
+  return c.json({ org: userOrg, data: 'sensitive' });
+});
+```
+
+## Role-Based Access Control (RBAC)
+
+Use claim guards to enforce role and permission checks. Claim guards throw `AccessDeniedError` (403) on mismatch.
+
+### `claimEquals(claim, value)`
+
+Check if a claim exactly matches a value:
+
+```typescript
+import { claimEquals } from '@auth0/auth0-hono';
+
+app.get('/admin-only', requiresAuth(), claimEquals('role', 'admin'), (c) => {
+  return c.text('Admin area');
+});
+```
+
+### `claimIncludes(claim, ...values)`
+
+Check if a claim includes any of the specified values (useful for roles/permissions arrays):
+
+```typescript
+import { claimIncludes } from '@auth0/auth0-hono';
+
+app.get('/moderator-panel', 
+  requiresAuth(), 
+  claimIncludes('roles', 'admin', 'moderator'), 
+  (c) => {
+    return c.text('Moderation panel');
+  }
+);
+```
+
+### `claimCheck(predicate)`
+
+Use a custom predicate function for complex checks:
+
+```typescript
+import { claimCheck } from '@auth0/auth0-hono';
+
+app.get('/premium-feature', 
+  requiresAuth(),
+  claimCheck((user) => user.subscription === 'premium' && user.subscription_active),
+  (c) => {
+    return c.text('Premium feature');
+  }
+);
+```
+
+Claims are read from `c.var.auth0.user` (e.g., `user.roles`, `user.permissions`, custom claims). Configure custom claims in Auth0 Rules or Actions.
+
+## Session Management
+
+### Accessing the Session
+
+After middleware, access the session:
+
+```typescript
+app.get('/', (c) => {
+  const session = c.var.auth0.session;
+  
+  if (session) {
+    return c.json({ authenticated: true, session });
+  } else {
+    return c.json({ authenticated: false });
+  }
+});
+```
+
+### Session Shape
+
+The session object contains:
+
+```typescript
+{
+  user: Auth0User,              // User profile
+  idToken?: string,             // OpenID Connect ID token
+  refreshToken?: string,        // Refresh token (if offline_access scope)
+  tokenSets?: Auth0TokenSet[],  // Token sets for audiences
+  connectionTokenSets?: {...},  // Connection-specific tokens
+  internal: {
+    sid: string,                // Session ID
+    createdAt: number,          // Creation timestamp (milliseconds)
+  }
+}
+```
+
+**Important:** Session does NOT have an `expiresAt` field. Use `session.internal.createdAt` for the session creation time, or `getAccessToken().expiresAt` for access token expiration.
+
+### Updating Session
+
+Enrich the session with custom data using `updateSession()`:
+
+```typescript
+import { updateSession } from '@auth0/auth0-hono';
+
+app.post('/preferences', requiresAuth(), (c) => {
+  updateSession(c, {
+    preferences: { theme: 'dark', language: 'en' },
+  });
+  
+  return c.json({ ok: true });
+});
+```
+
+**Reserved fields** (cannot be overwritten): `user`, `idToken`, `refreshToken`, `tokenSets`, `connectionTokenSets`, `internal`.
+
+## Access Tokens
+
+Fetch access tokens on-demand to call protected APIs:
+
+```typescript
+import { getAccessToken } from '@auth0/auth0-hono';
+
+app.get('/api-data', requiresAuth(), async (c) => {
+  const token = await getAccessToken(c);
+  
+  if (!token) {
+    return c.json({ error: 'No access token' }, { status: 401 });
+  }
+  
+  // Call your API
+  const response = await fetch('https://api.example.com/data', {
+    headers: { Authorization: `Bearer ${token.access_token}` },
+  });
+  
+  return c.json(await response.json());
+});
+```
+
+The returned token object has:
+
+```typescript
+{
+  access_token: string,
+  expiresAt: number,  // Milliseconds since epoch
+  ...
+}
+```
+
+**Token auto-refresh:** If the access token is expired, `getAccessToken()` automatically refreshes it using the refresh token.
+
+To request access tokens for a specific API, configure the audience in your config:
+
+```typescript
+app.use('*', auth0({
+  // ... other config
+  authorizationParams: {
+    audience: 'https://api.example.com',
+  },
+}));
+```
+
+### Connection-Specific Tokens
+
+For multi-connection scenarios, fetch tokens for a specific connection:
+
+```typescript
+import { getAccessTokenForConnection } from '@auth0/auth0-hono';
+
+app.get('/connection-token', requiresAuth(), async (c) => {
+  const token = await getAccessTokenForConnection(c, {
+    connection: 'google-oauth2',
+    audience: 'https://www.googleapis.com',
+  });
+  
+  return c.json(token);
+});
+```
+
+## Silent Login
+
+Silent login restores the user's session from the Auth0 SSO cookie without redirecting to the login page. This is useful for remembering users across page reloads or new tabs.
+
+### Attempt Silent Login
+
+Use the `attemptSilentLogin` middleware early in your middleware chain:
+
+```typescript
+import { attemptSilentLogin } from '@auth0/auth0-hono';
+
+app.use('*', attemptSilentLogin());
+app.use('*', auth0({
+  // ... config
+}));
+```
+
+If the SSO cookie exists and is valid, the session is restored automatically. Otherwise, the middleware passes through.
+
+### Cancel Silent Login
+
+To cancel (clear the SSO cookie), use `cancelSilentLogin()`:
+
+```typescript
+import { cancelSilentLogin } from '@auth0/auth0-hono';
+
+app.get('/cancel-sso', (c) => {
+  cancelSilentLogin(c);
+  return c.redirect('/');
+});
+```
+
+**Note:** `pauseSilentLogin()` is deprecated; use `cancelSilentLogin()` instead.
+
+## onCallback Hook
+
+The `onCallback` hook runs after Auth0 redirects back with the authentication result. Use it to enrich the session, override redirects, or return custom responses.
+
+### Hook Signature
+
+```typescript
+onCallback?: (c: Context, error: Error | null, session: Auth0Session | null) => Response | SessionData | void
+```
+
+### On Success (error is null)
+
+When authentication succeeds, `session` contains the user data. Return:
+- `SessionData` object to enrich the session (merged and persisted)
+- `Response` to override the redirect (e.g., redirect to a custom post-login page)
+- `void` for default behavior (redirect to home)
+
+```typescript
+onCallback: (c, error, session) => {
+  if (error) {
+    // Handle error (see below)
+    return;
+  }
+  
+  // Enrich session with custom data
+  return {
+    onboardingComplete: false,
+    signupTime: Date.now(),
+  };
+}
+```
+
+### On Error (session is null)
+
+When authentication fails, `error` contains the failure reason. Return:
+- `Response` to show a custom error page (e.g., HTML error, JSON error)
+- Anything else is ignored (default error page is shown)
+
+```typescript
+onCallback: (c, error, session) => {
+  if (error) {
+    return c.html('<h1>Login failed</h1><p>Please try again.</p>', { status: 400 });
+  }
+  // ...
+}
+```
+
+### SECURITY-CRITICAL: Hook Errors Do Not Block Login
+
+**Important:** Throwing an error from the `onCallback` hook does NOT block the login. Hook errors are logged but never mask the original authentication error. Login always completes unless you explicitly return a `Response` with a non-2xx status.
+
+To deny a login from the hook, **return a `Response`** (e.g., 403 Forbidden):
+
+```typescript
+onCallback: async (c, error, session) => {
+  if (error) {
+    return c.json({ error: 'Auth failed' }, { status: 400 });
+  }
+  
+  // Check custom condition
+  if (!session.user.email_verified) {
+    return c.json({ error: 'Email not verified' }, { status: 403 });
+  }
+  
+  return { verified: true };
+}
+```
+
+Do NOT rely on throwing errors to prevent login — it will not work. Always return a `Response` to deny access.
+
+## Error Handling
+
+Seven error types extend `Auth0Error` and propagate to Hono's `app.onError()` handler. Each has a specific HTTP status:
+
+| Error | Status | When |
+|-------|--------|------|
+| `AccessDeniedError` | 403 | Access denied by policy (e.g., claim guard mismatch) |
+| `LoginRequiredError` | 401 | No session; login required (e.g., `requiresAuth()` on public route) |
+| `InvalidGrantError` | 401 | Token refresh failed (e.g., refresh token expired) |
+| `MissingSessionError` | 401 | `getUser()` or `getSession()` called without active session |
+| `MissingTransactionError` | 400 | `/callback` hit without a transaction state |
+| `TokenRefreshError` | 401 | Failed to refresh access token |
+| `ConnectionTokenError` | 401 | Failed to fetch connection-specific token |
+
+Handle errors globally:
+
+```typescript
+app.onError((err, c) => {
+  if (err instanceof LoginRequiredError) {
+    return c.redirect('/login');
+  }
+  
+  if (err instanceof AccessDeniedError) {
+    return c.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  
+  if (err instanceof Auth0Error) {
+    return c.json({ error: err.message }, { status: err.status });
+  }
+  
+  return c.json({ error: 'Internal server error' }, { status: 500 });
+});
+```
+
+## TypeScript Typing
+
+For full type safety, wrap your context type with `OIDCEnv`:
+
+```typescript
+import { Context } from 'hono';
+import { OIDCEnv } from '@auth0/auth0-hono';
+
+app.get('/profile', requiresAuth(), (c: Context<OIDCEnv>) => {
+  // Now c.var.auth0 is typed as Auth0Context (user/session/org)
+  const user = c.var.auth0.user; // Auth0User | null
+  return c.json({ user });
+});
+```
+
+For stricter form, use `OIDCVariables`:
+
+```typescript
+import { OIDCVariables } from '@auth0/auth0-hono';
+
+type AppEnv = {
+  Variables: OIDCVariables;
+};
+
+app.get('/protected', requiresAuth(), (c: Context<AppEnv>) => {
+  // Guarantees c.var.auth0 is defined (not undefined)
+  const user = c.var.auth0.user;
+  return c.json({ user });
+});
+```
+

--- a/plugins/auth0/skills/auth0/references/framework-hono/patterns.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/patterns.md
@@ -1,0 +1,549 @@
+# Patterns: RBAC, Organizations, Multi-Runtime, Custom Session Store, and Session Enrichment
+
+Advanced implementation patterns for production Hono applications.
+
+## Role-Based Access Control (RBAC)
+
+Protect routes based on user roles and permissions using claim guards.
+
+### Basic Role Check
+
+Use `claimEquals()` to check for a single role:
+
+```typescript
+import { requiresAuth, claimEquals } from '@auth0/auth0-hono';
+
+app.get('/admin-panel', 
+  requiresAuth(), 
+  claimEquals('role', 'admin'), 
+  (c) => {
+    return c.html('<h1>Admin Panel</h1>');
+  }
+);
+```
+
+### Multiple Roles
+
+Use `claimIncludes()` to check if the user has any of several roles:
+
+```typescript
+import { claimIncludes } from '@auth0/auth0-hono';
+
+app.get('/moderation', 
+  requiresAuth(), 
+  claimIncludes('roles', 'admin', 'moderator'), 
+  (c) => {
+    return c.json({ message: 'Moderation tools' });
+  }
+);
+```
+
+### Custom Claim Logic
+
+Use `claimCheck()` for complex conditions:
+
+```typescript
+import { claimCheck } from '@auth0/auth0-hono';
+
+app.get('/premium-feature',
+  requiresAuth(),
+  claimCheck((user) => {
+    return user.subscription === 'premium' && user.subscription_active === true;
+  }),
+  (c) => {
+    return c.text('Premium feature');
+  }
+);
+```
+
+### Permission-Based Access
+
+Combine multiple checks for fine-grained access:
+
+```typescript
+app.post('/publish-article',
+  requiresAuth(),
+  claimIncludes('permissions', 'write:articles'),
+  claimCheck((user) => user.content_approved === true),
+  (c) => {
+    return c.json({ status: 'Article published' });
+  }
+);
+```
+
+## Organizations for B2B SaaS
+
+Use organizations to build multi-tenant applications where users belong to organizations and have role assignments within each org.
+
+### Require Organization
+
+Use `requiresOrg()` to ensure the user is in an organization:
+
+```typescript
+import { requiresAuth, requiresOrg } from '@auth0/auth0-hono';
+
+app.get('/org-dashboard',
+  requiresAuth(),
+  requiresOrg(),
+  (c) => {
+    const org = c.var.auth0.org; // { id, name? }
+    return c.json({ 
+      message: `Dashboard for ${org.name || org.id}`,
+      org,
+    });
+  }
+);
+```
+
+**Important:** `requiresOrg()` MUST come AFTER `requiresAuth()` — calling it first will throw a 500 error.
+
+### Multi-Tenant Route Protection
+
+Verify the requested organization matches the user's organization:
+
+```typescript
+app.get('/org/:orgId/settings',
+  requiresAuth(),
+  requiresOrg(),
+  (c) => {
+    const userOrgId = c.var.auth0.org.id;
+    const requestedOrgId = c.req.param('orgId');
+    
+    if (userOrgId !== requestedOrgId) {
+      return c.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+    
+    return c.json({ 
+      orgId: requestedOrgId,
+      settings: { /* org settings */ },
+    });
+  }
+);
+```
+
+### Organization Admin Routes
+
+Combine `requiresOrg()` with role checks for org-scoped admin features:
+
+```typescript
+app.post('/org/:orgId/members',
+  requiresAuth(),
+  requiresOrg(),
+  claimIncludes('org_roles', 'org_admin'),
+  (c) => {
+    const org = c.var.auth0.org;
+    return c.json({ message: `Added member to ${org.name}` });
+  }
+);
+```
+
+## Cloudflare Workers Deployment
+
+Deploy Hono with Auth0 on Cloudflare Workers using the `honoEnv` helper.
+
+### Basic Setup
+
+```typescript
+import { Hono } from 'hono';
+import { auth0 } from '@auth0/auth0-hono';
+import { env } from '@auth0/auth0-hono/lib/honoEnv';
+
+type Bindings = {
+  AUTH0_DOMAIN: string;
+  AUTH0_CLIENT_ID: string;
+  AUTH0_CLIENT_SECRET: string;
+  APP_BASE_URL: string;
+  AUTH0_SESSION_ENCRYPTION_KEY: string;
+};
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.use('*', auth0({
+  domain: env(c).AUTH0_DOMAIN,
+  clientID: env(c).AUTH0_CLIENT_ID,
+  clientSecret: env(c).AUTH0_CLIENT_SECRET,
+  baseURL: env(c).APP_BASE_URL,
+  session: {
+    secret: env(c).AUTH0_SESSION_ENCRYPTION_KEY,
+  },
+}));
+
+export default app;
+```
+
+### wrangler.toml Configuration
+
+Configure environment variables and secrets in `wrangler.toml`:
+
+```toml
+[env.development]
+vars = {
+  AUTH0_DOMAIN = "your-tenant.us.auth0.com",
+  APP_BASE_URL = "https://my-app.workers.dev"
+}
+secrets = ["AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET", "AUTH0_SESSION_ENCRYPTION_KEY"]
+
+[env.production]
+vars = {
+  AUTH0_DOMAIN = "your-tenant.us.auth0.com",
+  APP_BASE_URL = "https://my-app.com"
+}
+secrets = ["AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET", "AUTH0_SESSION_ENCRYPTION_KEY"]
+```
+
+Set secrets via command line:
+
+```bash
+wrangler secret put AUTH0_CLIENT_ID --env development
+wrangler secret put AUTH0_CLIENT_SECRET --env development
+wrangler secret put AUTH0_SESSION_ENCRYPTION_KEY --env development
+```
+
+Deploy:
+
+```bash
+wrangler deploy --env development
+```
+
+## Deno Deployment
+
+```typescript
+import { Hono } from 'npm:hono@3';
+import { auth0 } from 'npm:@auth0/auth0-hono';
+
+const app = new Hono();
+
+app.use('*', auth0({
+  domain: Deno.env.get('AUTH0_DOMAIN')!,
+  clientID: Deno.env.get('AUTH0_CLIENT_ID')!,
+  clientSecret: Deno.env.get('AUTH0_CLIENT_SECRET')!,
+  baseURL: Deno.env.get('APP_BASE_URL')!,
+  session: {
+    secret: Deno.env.get('AUTH0_SESSION_ENCRYPTION_KEY')!,
+  },
+}));
+
+app.get('/', (c) => c.text('Hello from Deno'));
+
+Deno.serve({ port: 3000 }, app.fetch);
+```
+
+Run with: `deno run --allow-net --allow-env --allow-read server.ts`
+
+## Bun Deployment
+
+```typescript
+import { Hono } from 'hono';
+import { auth0 } from '@auth0/auth0-hono';
+
+const app = new Hono();
+
+app.use('*', auth0({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientID: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!,
+  baseURL: process.env.APP_BASE_URL!,
+  session: {
+    secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY!,
+  },
+}));
+
+export default app;
+```
+
+Start: `bun run server.ts`
+
+## Custom Session Store
+
+Replace the default in-memory session store with a custom backend (Redis, database, etc.).
+
+### SessionStore Interface
+
+Implement the `SessionStore` interface:
+
+```typescript
+import { SessionStore } from '@auth0/auth0-hono';
+
+interface SessionStore {
+  set(id: string, data: SessionData): Promise<void>;
+  get(id: string): Promise<SessionData | null>;
+  delete(id: string): Promise<void>;
+  deleteByLogoutToken?(logoutToken: string): Promise<void>;
+}
+```
+
+### Redis Example
+
+```typescript
+import Redis from 'ioredis';
+import { SessionStore } from '@auth0/auth0-hono';
+
+const redis = new Redis();
+
+const redisStore: SessionStore = {
+  async set(id: string, data: any) {
+    await redis.set(id, JSON.stringify(data), 'EX', 86400); // 1-day TTL
+  },
+  
+  async get(id: string) {
+    const data = await redis.get(id);
+    return data ? JSON.parse(data) : null;
+  },
+  
+  async delete(id: string) {
+    await redis.del(id);
+  },
+  
+  async deleteByLogoutToken(logoutToken: string) {
+    // Optional: implement backchannel logout
+    // Search for session by logout token and delete
+  },
+};
+
+app.use('*', auth0({
+  // ... other config
+  session: {
+    store: redisStore,
+    secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
+  },
+}));
+```
+
+### Database Example (Supabase/PostgreSQL)
+
+```typescript
+import { createClient } from '@supabase/supabase-js';
+import { SessionStore } from '@auth0/auth0-hono';
+
+const supabase = createClient(url, key);
+
+const supabaseStore: SessionStore = {
+  async set(id: string, data: any) {
+    const { error } = await supabase
+      .from('sessions')
+      .upsert({
+        id,
+        data: JSON.stringify(data),
+        expires_at: new Date(Date.now() + 86400000), // 1 day
+      });
+    
+    if (error) throw error;
+  },
+  
+  async get(id: string) {
+    const { data, error } = await supabase
+      .from('sessions')
+      .select('data')
+      .eq('id', id)
+      .single();
+    
+    if (error || !data) return null;
+    return JSON.parse(data.data);
+  },
+  
+  async delete(id: string) {
+    await supabase.from('sessions').delete().eq('id', id);
+  },
+};
+
+app.use('*', auth0({
+  // ... other config
+  session: {
+    store: supabaseStore,
+    secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
+  },
+}));
+```
+
+## Hybrid Web + API Routes
+
+Serve both HTML web routes and JSON API routes with appropriate error handling.
+
+### Web Route (Redirects on Auth Failure)
+
+Web routes should redirect unauthenticated users to the login page:
+
+```typescript
+app.get('/dashboard',
+  requiresAuth('login'), // Redirects to /login on unauthenticated
+  (c) => {
+    const user = c.var.auth0.user;
+    return c.html(`<h1>Hello, ${user.name}</h1>`);
+  }
+);
+```
+
+### API Route (JSON on Auth Failure)
+
+API routes should return JSON errors instead of redirecting:
+
+```typescript
+app.get('/api/me',
+  requiresAuth('error'), // Returns 401 JSON on unauthenticated
+  (c) => {
+    const user = c.var.auth0.user;
+    return c.json({ user });
+  }
+);
+```
+
+### Error Handler for Both
+
+Set up a global error handler:
+
+```typescript
+app.onError((err, c) => {
+  const isApiRoute = c.req.path.startsWith('/api/');
+  
+  if (err instanceof LoginRequiredError) {
+    if (isApiRoute) {
+      return c.json({ error: 'Unauthorized' }, { status: 401 });
+    } else {
+      return c.redirect('/login');
+    }
+  }
+  
+  if (err instanceof Auth0Error) {
+    return c.json({ error: err.message }, { status: err.status });
+  }
+  
+  return c.json({ error: 'Internal server error' }, { status: 500 });
+});
+```
+
+## Standalone Route Handlers
+
+For advanced scenarios (multi-tenant, custom flows), use standalone handler functions instead of middleware.
+
+### Available Handlers
+
+- `handleLogin(params?)` — Initiate login
+- `handleCallback()` — Handle OAuth callback
+- `handleLogout()` — Clear session and logout
+- `handleBackchannelLogout()` — Handle backchannel logout (OpenID Connect RP-Initiated Logout)
+
+### Example: Per-Request Configuration
+
+```typescript
+import { handleLogin, handleCallback, handleLogout } from '@auth0/auth0-hono';
+
+app.post('/auth/login-custom', async (c) => {
+  // Dynamic config per request
+  const tenant = c.req.query('tenant'); // e.g., ?tenant=us
+  
+  const handler = handleLogin({
+    domain: tenantConfig[tenant].domain,
+    clientID: tenantConfig[tenant].clientID,
+    baseURL: process.env.APP_BASE_URL,
+  });
+  
+  return handler(c);
+});
+
+app.get('/auth/callback-custom', async (c) => {
+  const handler = handleCallback({ /* config */ });
+  return handler(c);
+});
+```
+
+## Session Enrichment
+
+Add custom data to the user session using `updateSession()`:
+
+```typescript
+import { updateSession, requiresAuth } from '@auth0/auth0-hono';
+
+app.post('/preferences',
+  requiresAuth(),
+  async (c) => {
+    const body = await c.req.json();
+    
+    // Merge custom data into session
+    updateSession(c, {
+      theme: body.theme,
+      language: body.language,
+      notifications_enabled: body.notificationsEnabled,
+    });
+    
+    return c.json({ message: 'Preferences saved' });
+  }
+);
+
+app.get('/preferences',
+  requiresAuth(),
+  (c) => {
+    const session = c.var.auth0.session;
+    return c.json({
+      theme: session.theme,
+      language: session.language,
+      notifications_enabled: session.notifications_enabled,
+    });
+  }
+);
+```
+
+**Important:** Reserved fields cannot be overwritten:
+- `user` — User profile (read-only)
+- `idToken` — ID token (read-only)
+- `refreshToken` — Refresh token (read-only)
+- `tokenSets` — Token sets (read-only)
+- `connectionTokenSets` — Connection tokens (read-only)
+- `internal` — Internal metadata (read-only)
+
+Any other fields are custom and can be set/updated freely.
+
+## Security Best Practices
+
+### PKCE Protection
+
+PKCE (Proof Key for Code Exchange) is enforced by default. This prevents authorization code injection attacks on mobile and desktop apps.
+
+### State and Nonce Validation
+
+All OAuth state parameters and OpenID Connect nonce values are server-validated automatically.
+
+### Session Encryption
+
+Sessions are encrypted using AES-256-GCM. The encryption key is provided in config and must be at least 32 characters:
+
+```typescript
+session: {
+  secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY, // ≥32 chars
+}
+```
+
+For key rotation, provide an array:
+
+```typescript
+session: {
+  secret: [currentKey, previousKey], // Current key used for encryption; old keys for decryption
+}
+```
+
+### Safe Redirects
+
+Use `toSafeRedirect()` to prevent open-redirect attacks:
+
+```typescript
+import { toSafeRedirect } from '@auth0/auth0-hono';
+
+app.get('/redirect', (c) => {
+  const url = c.req.query('url');
+  const safe = toSafeRedirect(url, process.env.APP_BASE_URL);
+  return c.redirect(safe);
+});
+```
+
+### Backchannel Logout
+
+Backchannel logout handles OpenID Connect logout notifications from Auth0:
+
+```typescript
+import { handleBackchannelLogout } from '@auth0/auth0-hono';
+
+app.post('/auth/backchannel-logout', handleBackchannelLogout());
+```
+
+Configure in Auth0 Dashboard:
+- Backchannel Logout URL: `https://your-app.com/auth/backchannel-logout`
+

--- a/plugins/auth0/skills/auth0/references/framework-hono/patterns.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/patterns.md
@@ -139,14 +139,13 @@ app.post('/org/:orgId/members',
 
 ## Cloudflare Workers Deployment
 
-Deploy Hono with Auth0 on Cloudflare Workers using the `honoEnv` helper.
+Deploy Hono with Auth0 on Cloudflare Workers. Call `auth0()` with no arguments — the middleware reads the Worker's per-request bindings automatically (via `hono/adapter`). Do not build a config object at module scope; there is no request context there.
 
 ### Basic Setup
 
 ```typescript
 import { Hono } from 'hono';
 import { auth0 } from '@auth0/auth0-hono';
-import { env } from '@auth0/auth0-hono/lib/honoEnv';
 
 type Bindings = {
   AUTH0_DOMAIN: string;
@@ -158,15 +157,8 @@ type Bindings = {
 
 const app = new Hono<{ Bindings: Bindings }>();
 
-app.use('*', auth0({
-  domain: env(c).AUTH0_DOMAIN,
-  clientID: env(c).AUTH0_CLIENT_ID,
-  clientSecret: env(c).AUTH0_CLIENT_SECRET,
-  baseURL: env(c).APP_BASE_URL,
-  session: {
-    secret: env(c).AUTH0_SESSION_ENCRYPTION_KEY,
-  },
-}));
+// auth0() reads AUTH0_* + APP_BASE_URL bindings per-request; no explicit config needed.
+app.use('*', auth0());
 
 export default app;
 ```
@@ -257,18 +249,21 @@ Start: `bun run server.ts`
 
 Replace the default in-memory session store with a custom backend (Redis, database, etc.).
 
-### SessionStore Interface
+### SessionStore Contract
 
-Implement the `SessionStore` interface:
+`SessionStore` is an **abstract class** exported by the SDK — extend it and implement all four methods. Persisted values are typed `StateData` (from `@auth0/auth0-server-js`), `get()` returns `StateData | undefined` (never `null`), and `deleteByLogoutToken` is **required** and takes `LogoutTokenClaims` (not a raw token string):
 
 ```typescript
 import { SessionStore } from '@auth0/auth0-hono';
+import type { StateData, LogoutTokenClaims } from '@auth0/auth0-server-js';
+import type { Context } from 'hono';
 
-interface SessionStore {
-  set(id: string, data: SessionData): Promise<void>;
-  get(id: string): Promise<SessionData | null>;
-  delete(id: string): Promise<void>;
-  deleteByLogoutToken?(logoutToken: string): Promise<void>;
+// Abstract-class contract you must implement:
+abstract class SessionStore {
+  abstract set(identifier: string, stateData: StateData): Promise<void>;
+  abstract get(identifier: string): Promise<StateData | undefined>;
+  abstract delete(identifier: string): Promise<void>;
+  abstract deleteByLogoutToken(claims: LogoutTokenClaims, c?: Context): Promise<void>;
 }
 ```
 
@@ -277,33 +272,36 @@ interface SessionStore {
 ```typescript
 import Redis from 'ioredis';
 import { SessionStore } from '@auth0/auth0-hono';
+import type { StateData, LogoutTokenClaims } from '@auth0/auth0-server-js';
 
 const redis = new Redis();
 
-const redisStore: SessionStore = {
-  async set(id: string, data: any) {
-    await redis.set(id, JSON.stringify(data), 'EX', 86400); // 1-day TTL
-  },
-  
-  async get(id: string) {
+class RedisStore extends SessionStore {
+  async set(id: string, stateData: StateData): Promise<void> {
+    await redis.set(id, JSON.stringify(stateData), 'EX', 86400); // 1-day TTL
+  }
+
+  async get(id: string): Promise<StateData | undefined> {
     const data = await redis.get(id);
-    return data ? JSON.parse(data) : null;
-  },
-  
-  async delete(id: string) {
+    return data ? (JSON.parse(data) as StateData) : undefined;
+  }
+
+  async delete(id: string): Promise<void> {
     await redis.del(id);
-  },
-  
-  async deleteByLogoutToken(logoutToken: string) {
-    // Optional: implement backchannel logout
-    // Search for session by logout token and delete
-  },
-};
+  }
+
+  async deleteByLogoutToken(claims: LogoutTokenClaims): Promise<void> {
+    // Backchannel logout: locate session by claims.sid / claims.sub and delete.
+    if (claims.sid) {
+      await redis.del(claims.sid);
+    }
+  }
+}
 
 app.use('*', auth0({
   // ... other config
   session: {
-    store: redisStore,
+    store: new RedisStore(),
     secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
   },
 }));
@@ -314,42 +312,50 @@ app.use('*', auth0({
 ```typescript
 import { createClient } from '@supabase/supabase-js';
 import { SessionStore } from '@auth0/auth0-hono';
+import type { StateData, LogoutTokenClaims } from '@auth0/auth0-server-js';
 
 const supabase = createClient(url, key);
 
-const supabaseStore: SessionStore = {
-  async set(id: string, data: any) {
+class SupabaseStore extends SessionStore {
+  async set(id: string, stateData: StateData): Promise<void> {
     const { error } = await supabase
       .from('sessions')
       .upsert({
         id,
-        data: JSON.stringify(data),
+        data: JSON.stringify(stateData),
         expires_at: new Date(Date.now() + 86400000), // 1 day
       });
-    
+
     if (error) throw error;
-  },
-  
-  async get(id: string) {
+  }
+
+  async get(id: string): Promise<StateData | undefined> {
     const { data, error } = await supabase
       .from('sessions')
       .select('data')
       .eq('id', id)
       .single();
-    
-    if (error || !data) return null;
-    return JSON.parse(data.data);
-  },
-  
-  async delete(id: string) {
+
+    if (error || !data) return undefined;
+    return JSON.parse(data.data) as StateData;
+  }
+
+  async delete(id: string): Promise<void> {
     await supabase.from('sessions').delete().eq('id', id);
-  },
-};
+  }
+
+  async deleteByLogoutToken(claims: LogoutTokenClaims): Promise<void> {
+    // Backchannel logout: delete rows matching the logout token's session id.
+    if (claims.sid) {
+      await supabase.from('sessions').delete().eq('id', claims.sid);
+    }
+  }
+}
 
 app.use('*', auth0({
   // ... other config
   session: {
-    store: supabaseStore,
+    store: new SupabaseStore(),
     secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
   },
 }));
@@ -413,38 +419,35 @@ app.onError((err, c) => {
 
 ## Standalone Route Handlers
 
-For advanced scenarios (multi-tenant, custom flows), use standalone handler functions instead of middleware.
+When you disable the default mounted routes (`mountRoutes: false`, or opt out of individual routes via `customRoutes`), define the auth routes yourself using the standalone handlers. Each handler auto-initializes the OIDC client from the environment, so you do **not** pass client credentials (domain/clientID/baseURL) to them — those come from `auth0()` config or environment bindings.
 
 ### Available Handlers
 
-- `handleLogin(params?)` — Initiate login
-- `handleCallback()` — Handle OAuth callback
-- `handleLogout()` — Clear session and logout
+- `handleLogin(params?: LoginParams)` — Initiate login
+- `handleCallback(params?: CallbackParams)` — Handle OAuth callback
+- `handleLogout(params?: LogoutParams)` — Clear session and logout
 - `handleBackchannelLogout()` — Handle backchannel logout (OpenID Connect RP-Initiated Logout)
 
-### Example: Per-Request Configuration
+The `params` are **flow options**, not client configuration:
+- `LoginParams`: `{ redirectAfterLogin?, silent?, authorizationParams?, forwardAuthorizationParams? }`
+- `CallbackParams`: `{ redirectAfterLogin?, onCallback? }`
+- `LogoutParams`: `{ redirectAfterLogout? }`
+
+### Example: Custom Route Paths
 
 ```typescript
-import { handleLogin, handleCallback, handleLogout } from '@auth0/auth0-hono';
+import { auth0, handleLogin, handleCallback, handleLogout } from '@auth0/auth0-hono';
 
-app.post('/auth/login-custom', async (c) => {
-  // Dynamic config per request
-  const tenant = c.req.query('tenant'); // e.g., ?tenant=us
-  
-  const handler = handleLogin({
-    domain: tenantConfig[tenant].domain,
-    clientID: tenantConfig[tenant].clientID,
-    baseURL: process.env.APP_BASE_URL,
-  });
-  
-  return handler(c);
-});
+// Disable the default /login, /logout, /callback routes...
+app.use('*', auth0({ mountRoutes: false }));
 
-app.get('/auth/callback-custom', async (c) => {
-  const handler = handleCallback({ /* config */ });
-  return handler(c);
-});
+// ...and mount your own at custom paths.
+app.get('/auth/start', handleLogin({ redirectAfterLogin: '/dashboard' }));
+app.get('/auth/return', handleCallback());
+app.get('/auth/end', handleLogout({ redirectAfterLogout: '/goodbye' }));
 ```
+
+For per-tenant deployments, run separate instances configured via environment bindings (see Cloudflare Workers above) rather than passing per-request client config — the SDK does not accept credentials on the standalone handlers.
 
 ## Session Enrichment
 
@@ -458,8 +461,8 @@ app.post('/preferences',
   async (c) => {
     const body = await c.req.json();
     
-    // Merge custom data into session
-    updateSession(c, {
+    // Merge custom data into session (async — must await)
+    await updateSession(c, {
       theme: body.theme,
       language: body.language,
       notifications_enabled: body.notificationsEnabled,

--- a/plugins/auth0/skills/auth0/references/framework-hono/setup.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/setup.md
@@ -111,12 +111,11 @@ The `auth0()` middleware automatically creates three routes:
 
 ## Cloudflare Workers Setup
 
-For Cloudflare Workers, use the `honoEnv` helper to inject environment bindings:
+On Cloudflare Workers, do NOT pass explicit config to `auth0()`. Call it with no arguments — the middleware reads its configuration from the Worker's per-request environment bindings automatically (via `hono/adapter`), so there is no module-scope environment to inject:
 
 ```typescript
 import { Hono } from 'hono';
 import { auth0 } from '@auth0/auth0-hono';
-import { env } from '@auth0/auth0-hono/lib/honoEnv';
 
 type Bindings = {
   AUTH0_DOMAIN: string;
@@ -128,18 +127,13 @@ type Bindings = {
 
 const app = new Hono<{ Bindings: Bindings }>();
 
-app.use('*', auth0({
-  domain: env(c).AUTH0_DOMAIN,
-  clientID: env(c).AUTH0_CLIENT_ID,
-  clientSecret: env(c).AUTH0_CLIENT_SECRET,
-  baseURL: env(c).APP_BASE_URL,
-  session: {
-    secret: env(c).AUTH0_SESSION_ENCRYPTION_KEY,
-  },
-}));
+// auth0() reads AUTH0_* + APP_BASE_URL bindings per-request; no explicit config needed.
+app.use('*', auth0());
 
 export default app;
 ```
+
+The binding names the SDK reads are the same `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `APP_BASE_URL`, and `AUTH0_SESSION_ENCRYPTION_KEY` you configure below. To override a value explicitly, pass it inside a request-scoped handler rather than at module scope.
 
 In `wrangler.toml`, configure environment variables:
 

--- a/plugins/auth0/skills/auth0/references/framework-hono/setup.md
+++ b/plugins/auth0/skills/auth0/references/framework-hono/setup.md
@@ -1,0 +1,232 @@
+# Setup: @auth0/auth0-hono
+
+Configure environment, install dependencies, Auth0 dashboard setup, and multi-runtime deployment.
+
+## Install Dependencies
+
+Install the Auth0 Hono SDK and required peer dependencies:
+
+```bash
+npm install @auth0/auth0-hono hono @hono/node-server
+```
+
+Verify your `package.json` includes the ESM module type:
+
+```json
+{
+  "type": "module"
+}
+```
+
+If not present, add it:
+
+```bash
+npm pkg set type=module
+```
+
+## Environment Variables
+
+Set up the following environment variables in a `.env` file (never commit this to version control):
+
+```bash
+# Auth0 tenant domain (e.g., your-tenant.us.auth0.com)
+AUTH0_DOMAIN=your-tenant.us.auth0.com
+
+# Auth0 application credentials (use capital ID)
+AUTH0_CLIENT_ID=<your-client-id>
+AUTH0_CLIENT_SECRET=<your-client-secret>
+
+# Your application URL
+APP_BASE_URL=http://localhost:3000
+
+# Session encryption key (generate via: openssl rand -hex 32)
+AUTH0_SESSION_ENCRYPTION_KEY=<32-character-hex-string>
+```
+
+**Session encryption key:** Must be at least 32 characters. Generate a secure random value:
+
+```bash
+openssl rand -hex 32
+```
+
+## Auth0 Dashboard Configuration
+
+1. **Create or select a Regular Web Application** (NOT a Single Page Application)
+   - Navigate to Applications → Applications in the Auth0 Dashboard
+   - Click Create Application
+   - Choose "Regular Web Application"
+
+2. **Configure Allowed Callback URLs**
+   - Add: `http://localhost:3000/callback` (for development)
+   - Add your production callback URL after deployment
+
+3. **Configure Allowed Logout URLs**
+   - Add: `http://localhost:3000` (for development)
+   - Add your production base URL after deployment
+
+4. **Configure Allowed Web Origins**
+   - Add: `http://localhost:3000` (for development)
+   - Add your production origin after deployment
+
+5. **Save your credentials**
+   - Copy `Domain`, `Client ID`, and `Client Secret` to your `.env` file
+
+## Node.js Setup
+
+Create a minimal Hono server with Auth0 middleware:
+
+```typescript
+import { Hono } from 'hono';
+import { auth0 } from '@auth0/auth0-hono';
+import { serve } from '@hono/node-server';
+
+const app = new Hono();
+
+// Add Auth0 middleware to all routes
+app.use('*', auth0({
+  domain: process.env.AUTH0_DOMAIN,
+  clientID: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  baseURL: process.env.APP_BASE_URL,
+  session: {
+    secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
+  },
+}));
+
+// Example route
+app.get('/', (c) => {
+  return c.text('Hello, Hono!');
+});
+
+serve({
+  fetch: app.fetch,
+  port: 3000,
+});
+```
+
+The `auth0()` middleware automatically creates three routes:
+- `/login` - Initiates the Auth0 login flow
+- `/logout` - Clears the session and logs out the user
+- `/callback` - OAuth callback URL where Auth0 redirects after authentication
+
+## Cloudflare Workers Setup
+
+For Cloudflare Workers, use the `honoEnv` helper to inject environment bindings:
+
+```typescript
+import { Hono } from 'hono';
+import { auth0 } from '@auth0/auth0-hono';
+import { env } from '@auth0/auth0-hono/lib/honoEnv';
+
+type Bindings = {
+  AUTH0_DOMAIN: string;
+  AUTH0_CLIENT_ID: string;
+  AUTH0_CLIENT_SECRET: string;
+  APP_BASE_URL: string;
+  AUTH0_SESSION_ENCRYPTION_KEY: string;
+};
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.use('*', auth0({
+  domain: env(c).AUTH0_DOMAIN,
+  clientID: env(c).AUTH0_CLIENT_ID,
+  clientSecret: env(c).AUTH0_CLIENT_SECRET,
+  baseURL: env(c).APP_BASE_URL,
+  session: {
+    secret: env(c).AUTH0_SESSION_ENCRYPTION_KEY,
+  },
+}));
+
+export default app;
+```
+
+In `wrangler.toml`, configure environment variables:
+
+```toml
+[env.development]
+vars = { AUTH0_DOMAIN = "your-tenant.us.auth0.com", APP_BASE_URL = "http://localhost:3000" }
+secrets = ["AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET", "AUTH0_SESSION_ENCRYPTION_KEY"]
+```
+
+## Deno Setup
+
+Use npm imports with Deno:
+
+```typescript
+import { Hono } from 'npm:hono@3';
+import { auth0 } from 'npm:@auth0/auth0-hono';
+
+const app = new Hono();
+
+app.use('*', auth0({
+  domain: Deno.env.get('AUTH0_DOMAIN'),
+  clientID: Deno.env.get('AUTH0_CLIENT_ID'),
+  clientSecret: Deno.env.get('AUTH0_CLIENT_SECRET'),
+  baseURL: Deno.env.get('APP_BASE_URL'),
+  session: {
+    secret: Deno.env.get('AUTH0_SESSION_ENCRYPTION_KEY'),
+  },
+}));
+
+Deno.serve({ port: 3000 }, app.fetch);
+```
+
+Run with: `deno run --allow-net --allow-env server.ts`
+
+## Bun Setup
+
+Install using Bun's package manager:
+
+```bash
+bun add @auth0/auth0-hono hono
+```
+
+Bun natively supports `process.env`, so configuration is the same as Node.js:
+
+```typescript
+import { Hono } from 'hono';
+import { auth0 } from '@auth0/auth0-hono';
+
+const app = new Hono();
+
+app.use('*', auth0({
+  domain: process.env.AUTH0_DOMAIN,
+  clientID: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  baseURL: process.env.APP_BASE_URL,
+  session: {
+    secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
+  },
+}));
+
+export default app;
+```
+
+Start: `bun run server.ts`
+
+## Verify Setup
+
+1. Start your server:
+   ```bash
+   node server.ts  # Or: deno run --allow-net --allow-env server.ts
+   ```
+
+2. Visit `http://localhost:3000/login` in your browser
+
+3. You should be redirected to Auth0's login page
+
+4. After successful login, you'll be redirected back to your app with a session cookie set
+
+## Common Setup Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgot callback URL in Auth0 Dashboard | Add `/callback` path to Allowed Callback URLs (e.g., `http://localhost:3000/callback`) |
+| Missing or weak `AUTH0_SESSION_ENCRYPTION_KEY` | Generate 32+ character secret with `openssl rand -hex 32` |
+| App created as SPA type | Must be Regular Web Application type for server-side sessions |
+| Secrets hardcoded in code | Always use environment variables; add `.env` to `.gitignore` |
+| Wrong `APP_BASE_URL` for production | Update to match your production domain |
+| Package.json missing `"type": "module"` | SDK is ESM-only; add this field and use `import` statements |
+| Runtime mismatch (require() in Node context) | Use ESM imports only: `import { auth0 } from '@auth0/auth0-hono'` |
+


### PR DESCRIPTION
# feat(auth0): add Hono framework reference to unified skill

## Summary

This PR adds comprehensive Hono framework support to the Auth0 unified agent skill, superseding the stale PR #88 which targeted the pre-#163 architecture when each framework shipped as a separate skill.

The new `framework-hono` reference brings session-based web authentication guidance for Hono, an ultralight web framework increasingly popular in edge-runtime deployments (Node.js, Cloudflare Workers, Deno, Bun). The framework integrates with the existing unified-skill routing architecture and routes alongside other frameworks like Express, FastAPI, and Next.js.

## What changed

**New references directory:** `plugins/auth0/skills/auth0/references/framework-hono/` with five documentation leaves:
- **index.md** — Hub page with intent dispatch (setup, integration, patterns) and shared prerequisites
- **setup.md** — Installation, ESM configuration, Auth0 dashboard setup, multi-runtime deploy options
- **integrate.md** — Middleware setup, protected routes, session management, token refresh, error handling, TypeScript typing
- **api-reference.md** — Configuration options table, environment variables, session shape, error types, testing checklist, troubleshooting
- **patterns.md** — RBAC, Organizations, advanced runtimes (Cloudflare Workers / Deno / Bun), custom session stores, hybrid web+API, standalone handlers, session enrichment

**Router updates:** `plugins/auth0/skills/auth0/SKILL.md` Step 2 (tiers 1-3) and Step 4 wired to dispatch on:
- Tier 1: Auth0 SDK package dependency `@auth0/auth0-hono`
- Tier 2: workspace dependency `hono`
- Tier 3: keyword match "hono"

**Routing eval:** `evals/routing-cases.json` adds `integrate-hono` test case ensuring agents correctly route to framework-hono leaves.

**Documentation:** Root `plugins/auth0/README.md` skill table unchanged (single unified `auth0` skill entry remains; frameworks are referenced within via routing, not as separate skills).

## SDK facts verified against published distribution

All guidance facts have been diffed against the extracted type declarations and
JavaScript of the published `@auth0/auth0-hono@2.0.0-beta.0` distribution
(`dist/**/*.d.ts` and `dist/**/*.js`). An initial draft of this reference
contained several facts that were *not* dist-sourced; a systematic
dist-verification pass caught and corrected them before this PR. The corrections:

- **Cloudflare Workers config:** call `auth0()` with no arguments (the SDK reads
  Worker bindings per-request via `hono/adapter`). The earlier `honoEnv` import
  and module-scope `env(c)` calls were removed — `dist/lib/honoEnv.js` is
  `export {};` (a types-only module) and `env(c)` at module scope throws.
- **Access token field:** `getAccessToken()` returns `{ accessToken, expiresAt }`
  (camelCase), corrected from `access_token`.
- **`getAccessToken()` error contract:** it throws `Auth0Error` subclasses and
  never returns null; examples now use try/catch instead of a null check.
- **`cancelSilentLogin()`:** a zero-argument middleware factory, mounted in the
  route chain (not called as `cancelSilentLogin(c)`).
- **`updateSession()`:** async — all examples now `await` it.
- **`SessionStore`:** an abstract class using `StateData` (returning
  `StateData | undefined`) with a required `deleteByLogoutToken(claims, c?)`.
- **`getAccessTokenForConnection()` options:** `{ connection, loginHint? }`
  (there is no `audience` option on this helper).
- **Standalone handlers:** `handleLogin`/`handleCallback`/`handleLogout` take
  flow params only (e.g. `redirectAfterLogin`), never client credentials.
- **Vercel Edge** was removed from the runtime list (not present in the dist,
  package metadata, or requirements).

Each fix is locked by a regression guard (T-R1..T-R8) in
`evals/verify-framework-hono.sh`.

The **internal Confluence spec** (document 785121336) describes an aspirational /
future API and **diverges from what is actually shipped** on multiple
configuration defaults. The PR uses only dist-verified values:

- **`authRequired` default:** `true` (Confluence spec incorrectly documented `false`)
- **`idpLogout` default:** `false` (Confluence spec incorrectly documented `true`)
- **Session cookie name:** `appSession` (matches shipped default, not `__a0_session`)
- **Node version minimum:** 18+ (per README; no `engines` field in package.json)
- **Session shape:** `Auth0Session { user, idToken?, refreshToken?, tokenSets?, connectionTokenSets?, internal:{sid, createdAt} }` — **no `expiresAt` field**; available via `getAccessToken(c).expiresAt` when tokens exist
- **Context variables:** `c.var.auth0 = { user, session, org }` — **no `tokens` key** (token access via `getAccessToken()` helper)
- **Package type:** ESM-only (`"type":"module"`); no CommonJS exports
- **Peer dependency:** Hono >=3.0.0 (not >=4)
- **Runtimes:** Node.js 18+, Cloudflare Workers, Deno, Bun

## Beta scope

Session-based web authentication only. The SDK ships with beta status; the following are **not** included in this first release and thus not documented as usable guidance:
- JWT verifier / `/api` subpath (not in published beta distribution; currently internal to SDK design)
- Management API self-service (`/management` subpath)
- `generateSessionCookie` and `/testing` utilities
- MFA, DPoP, CIBA, token revocation (future features)

Guidance targets **primary runtimes:** Node.js and Cloudflare Workers. Advanced runtimes (Deno, Bun) are noted in patterns but with minimal worked examples pending user feedback post-beta.

## Supersedes PR #88 — disposition of feedback

PR #88 targeted the pre-#163 architecture (one skill per framework; per-skill entries in root README) and accumulated three months of staleness. This new PR rebuilds cleanly on the current unified-skill structure.

**CodeRabbit findings from PR #88:**
- [Major] PII in test report (`dev-10whndm3tf8jetu5.us.auth0.com`, `vxx3Ko8xqRJgYqgvkOcuAiGLbYTiYYGM`, `tushar.pandey@okta.com`) — **Resolved:** test report dropped entirely from deliverables. No PII shipped.
- [Minor] Markdown lang tag (MD040) on fenced code block in test report — **Moot** (report not included).
- [Nit] Blank line in blockquote on setup.md (MD028) — **Fixed** in new setup.md (no blank lines within blockquotes).

**Architectural mismatches from PR #88 (resolved in this PR):**
- Separate skill directory structure (pre-#163) → Unified framework-hono leaf group (current arch)
- Per-skill README rows → Single auth0 skill row (router detects framework internally)
- bootstrap.mjs auto-setup script referenced but not shipped — Removed; setup.md provides manual configuration only
- Stale sibling-skill cross-refs (`auth0-quickstart`, `auth0-react`, etc.) — Removed; architecture now single unified skill

## Validation

All four CI gates verified locally before PR:
- ✓ `bash plugins/auth0/skills/auth0/scripts/validate-skill.sh` — no errors, grade A
- ✓ `python3 scripts/check_router_reachability.py plugins/auth0/skills/auth0` — all refs reachable from SKILL.md
- ✓ `python3 scripts/check_routing_evals.py plugins/auth0/skills/auth0` — routing case `integrate-hono` passes
- ✓ `uvx skillsaw --strict` — 0 errors, 0 warnings

**Scope of these gates:** the four CI gates verify skill *structure* only —
frontmatter, router reachability, routing-case resolution, and PII/lint hygiene.
They do **not** execute the SDK or type-check the code samples, so they cannot by
themselves prove SDK runtime correctness. Fact correctness is enforced separately
by `evals/verify-framework-hono.sh` (SDK-fact presence/absence checks T-F* plus
the dist-verified regression guards T-R1..T-R8), and by the manual dist-diff
described above. Run it with `bash evals/verify-framework-hono.sh` (40/40 pass).

## Out of scope

- Unified-skill architecture changes (framework routing system already exists; this PR only adds the Hono reference)
- Shipping beta-only SDK features (JWT verifier, management self-service, MFA, DPoP, CIBA) as stable guidance — documented as "not in beta" only
- Performance optimization for Cloudflare Workers edge deployments (noted as possible future pattern)
- Non-session auth flows (JWT-only API middleware) — first-class support planned post-beta
