### PR TITLE
docs: direct contributors to author-auth0-skill

### DIFF
--- a/.snyk-agent-scan-ignore.json
+++ b/.snyk-agent-scan-ignore.json
@@ -1,6 +1,12 @@
 [
   {
     "code": "W012",
+    "skills": ["auth0"],
+    "url": "https://auth0.com/pricing.md",
+    "reason": "First-party Auth0 pricing page; the skill retrieves current published prices instead of hardcoding pricing data"
+  },
+  {
+    "code": "W012",
     "url": "https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh",
     "reason": "First-party Auth0 CLI install script from Auth0-owned repository"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,9 @@ evals/                  # Repo-root eval harness (NOT inside the skill dir):
 Key top-level docs:
 
 - [`CONTRIBUTING.md`](./CONTRIBUTING.md) — **authoritative** rules for adding or
-  editing a skill: required frontmatter, directory structure, naming, and the
-  validation command. Read this before changing any skill.
+  editing Auth0 guidance: reference structure, router wiring, naming, and the
+  validation gate. Read this before changing the skill. Frontmatter requirements
+  are below.
 - [`PLUGIN.md`](./PLUGIN.md) — plugin/marketplace architecture.
 - [`README.md`](./README.md) — user-facing install and skill catalog.
 
@@ -75,8 +76,8 @@ The `requires`, `os`, and `install` fields under `metadata.openclaw` are
 [ClawHub](https://clawhub.ai) metadata used when a skill is installed via
 `npx clawhub install`. If a skill's workflow invokes `auth0` CLI commands,
 declare `requires.bins: [auth0]` (and the matching `install` block) so ClawHub
-can prompt the user to install the CLI. See `CONTRIBUTING.md` for the full
-example.
+can prompt the user to install the CLI. The frontmatter of
+`plugins/auth0/skills/auth0/SKILL.md` is a working example of all three fields.
 
 ## Validating your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,90 +4,42 @@ We appreciate feedback and contribution to this repo! Before you get started, pl
 
 ## How to Contribute
 
-### Adding a New Skill
+### Add or edit Auth0 guidance
 
-1. Create a new directory under `plugins/auth0/skills/`
-2. Add a `SKILL.md` file following the [Agent Skills specification](https://agentskills.io/specification)
-3. Optionally add additional reference files
-4. Update the README.md to list your skill in the appropriate table
-5. Submit a pull request
+This repository ships one consolidated `auth0` skill. **Do not add a separate
+skill directory** under `plugins/auth0/skills/`. Add a reference to
+`plugins/auth0/skills/auth0/references/` and wire it into the router instead.
+See [Architecture](./docs/architecture.md) for the model.
 
-### Skill Structure
-
-Per the Agent Skills specification, **only `SKILL.md` may live in the skill root**. All other content must go in one of these subdirectories:
+When working in Claude Code, invoke the
+[`author-auth0-skill`](./.claude/skills/author-auth0-skill/SKILL.md)
+contributor skill before changing Auth0 guidance. It classifies the change
+(framework, feature, tooling, pattern, or existing reference), identifies the
+exact router and eval changes, and lists the validation gate. For example:
 
 ```
-plugins/auth0/skills/my-skill/
-├── SKILL.md           # Required: Main skill file (the ONLY file allowed in root)
-├── references/        # Optional: Additional documentation (kebab-case .md files)
-│   ├── setup.md
-│   ├── integration.md
-│   └── api.md
-├── scripts/           # Optional: Executable helper code
-│   └── helper.js
-├── assets/            # Optional: Static resources (templates, images, data files)
-└── tests/             # Optional: Validation artifacts (test transcripts, fixtures)
+/author-auth0-skill Add support for <framework or capability>
 ```
 
-Markdown files in subdirectories must be **kebab-case** (e.g. `route-protection.md`). Framework integration skills conventionally split their reference docs into `setup.md`, `integration.md`, and `api.md` — follow that naming so skills stay consistent.
+The detailed, authoritative requirements are in [Adding a Capability to the
+Unified Skill](#adding-a-capability-to-the-unified-skill) below. Contributors
+working without Claude Code should follow that section directly.
 
-### SKILL.md Requirements
+### Editing the unified skill
 
-Your `SKILL.md` must include:
+1. Fork the repository and make your change in `plugins/auth0/skills/auth0/`.
+2. Keep every reference reachable from the router and follow the depth-3 tree
+   rules below.
+3. Ensure examples are correct and test them where practical.
+4. Update `plugins/auth0/README.md` when the change adds visible coverage.
+5. Run the validation commands before opening a pull request.
 
-1. **YAML Frontmatter** with the following fields. `name`, `description`, `license`, `metadata.author`, and the full `metadata.openclaw` block (with `emoji` and `homepage`) are **required and enforced by the linter** — a skill missing any of them will fail validation:
+### Code style
 
-   ```yaml
-   ---
-   name: my-skill
-   description: Brief description of what this skill does and when to use it.
-   license: Apache-2.0
-   metadata:
-     author: Auth0 <support@auth0.com>   # required, must be "Name <email>" format
-     version: '1.0.0'                      # recommended; most skills pin this
-     openclaw:                             # required block
-       emoji: "\U0001F510"
-       homepage: https://github.com/auth0/agent-skills
-       requires:                           # optional: declare external dependencies
-         bins:
-           - auth0                         # declare `auth0` if the skill runs CLI commands
-       os:                                 # optional: darwin, linux, win32
-         - darwin
-         - linux
-       install:                            # optional: how to install required bins
-         - id: brew
-           kind: brew
-           formula: auth0/auth0-cli/auth0
-           bins: [auth0]
-           label: 'Install Auth0 CLI (brew)'
-   ---
-   ```
-
-   Notes:
-   - `license` must be `Apache-2.0` unless a specific package requires otherwise (matches the repository `LICENSE`).
-   - `metadata.author` must follow `Name <email>`; separate multiple authors with commas, not semicolons.
-   - The `requires`, `os`, and `install` fields under `metadata.openclaw` are [ClawHub](https://clawhub.ai) metadata used when installing the skill via `npx clawhub install`. If your skill's workflow invokes `auth0` CLI commands, declare `requires.bins: [auth0]` (and the matching `install` block) so ClawHub can prompt the user to install the CLI. Apply this consistently.
-
-2. **Clear Instructions**: Step-by-step guidance for the AI agent
-
-3. **Code Examples**: Working code samples for each SDK where applicable
-
-4. **Error Handling**: Common errors and how to handle them
-
-### Code Style
-
-- Use TypeScript for examples where applicable
-- Include comments explaining complex logic
-- Follow Auth0's coding conventions
-- Test code examples before submitting
-
-### Updating Existing Skills
-
-1. Fork the repository
-2. Make your changes
-3. Ensure all code examples are correct
-4. Update version in metadata if significant changes
-5. Submit a pull request with clear description of changes
+- Use TypeScript for examples where applicable.
+- Include comments that clarify non-obvious logic.
+- Follow Auth0 coding conventions.
+- Test code examples before submitting.
 
 ## Local Development
 
@@ -111,8 +63,8 @@ Test your skills work correctly with AI assistants:
    # Install entire plugin
    npx skills add ./plugins/auth0
 
-   # Or copy to Claude skills directory
-   cp -r ./plugins/auth0/skills/my-skill ~/.claude/skills/
+   # Or copy the unified skill to Claude's local skills directory
+   cp -r ./plugins/auth0/skills/auth0 ~/.claude/skills/
    ```
 2. Ask an AI assistant to use the skill
 3. Verify the generated code is correct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,13 +149,16 @@ Rules are configured in [`.skillsaw.yaml`](./.skillsaw.yaml), with repository-sp
 Test your skills work correctly with AI assistants:
 
 1. Install the plugin/skill locally:
+
    ```bash
    # Install entire plugin
    npx skills add ./plugins/auth0
 
    # Or copy the unified skill to Claude's local skills directory
+   mkdir -p ~/.claude/skills
    cp -r ./plugins/auth0/skills/auth0 ~/.claude/skills/
    ```
+
 2. Ask an AI assistant to use the skill
 3. Verify the generated code is correct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,50 +41,6 @@ working without Claude Code should follow that section directly.
 - Follow Auth0 coding conventions.
 - Test code examples before submitting.
 
-## Local Development
-
-### Validating Skills
-
-This repository uses [skillsaw](https://github.com/stbenjam/skillsaw) to enforce frontmatter and structure conventions. The same check runs in CI (`.github/workflows/skillsaw.yml`) and **must pass before a PR can merge**, so run it locally first:
-
-```bash
-# Validate the whole repository in strict mode (matches CI)
-uvx skillsaw --strict
-```
-
-Rules are configured in [`.skillsaw.yaml`](./.skillsaw.yaml), with repository-specific custom rules in [`.skillsaw/rules.py`](./.skillsaw/rules.py).
-
-### Testing with AI Assistants
-
-Test your skills work correctly with AI assistants:
-
-1. Install the plugin/skill locally:
-   ```bash
-   # Install entire plugin
-   npx skills add ./plugins/auth0
-
-   # Or copy the unified skill to Claude's local skills directory
-   cp -r ./plugins/auth0/skills/auth0 ~/.claude/skills/
-   ```
-2. Ask an AI assistant to use the skill
-3. Verify the generated code is correct
-
-## Pull Request Process
-
-1. Ensure your changes follow the contribution guidelines
-2. Update documentation as needed
-3. Add your changes to CHANGELOG.md (if applicable)
-4. Request review from maintainers
-5. Address any feedback
-
-## Code of Conduct
-
-Please follow [Auth0's Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
-
-## Questions?
-
-If you have questions about contributing, please [open an issue](https://github.com/auth0/agent-skills/issues/new) with the "question" label.
-
 ## Adding a Capability to the Unified Skill
 
 All Auth0 guidance ships in the single `auth0` skill
@@ -174,3 +130,47 @@ python3 scripts/check_router_reachability.py plugins/auth0/skills/auth0
 python3 scripts/check_routing_evals.py plugins/auth0/skills/auth0
 uvx skillsaw --strict
 ```
+
+## Local Development
+
+### Validating Skills
+
+This repository uses [skillsaw](https://github.com/stbenjam/skillsaw) to enforce frontmatter and structure conventions. The same check runs in CI (`.github/workflows/skillsaw.yml`) and **must pass before a PR can merge**, so run it locally first:
+
+```bash
+# Validate the whole repository in strict mode (matches CI)
+uvx skillsaw --strict
+```
+
+Rules are configured in [`.skillsaw.yaml`](./.skillsaw.yaml), with repository-specific custom rules in [`.skillsaw/rules.py`](./.skillsaw/rules.py).
+
+### Testing with AI Assistants
+
+Test your skills work correctly with AI assistants:
+
+1. Install the plugin/skill locally:
+   ```bash
+   # Install entire plugin
+   npx skills add ./plugins/auth0
+
+   # Or copy the unified skill to Claude's local skills directory
+   cp -r ./plugins/auth0/skills/auth0 ~/.claude/skills/
+   ```
+2. Ask an AI assistant to use the skill
+3. Verify the generated code is correct
+
+## Pull Request Process
+
+1. Ensure your changes follow the contribution guidelines
+2. Update documentation as needed
+3. Add your changes to CHANGELOG.md (if applicable)
+4. Request review from maintainers
+5. Address any feedback
+
+## Code of Conduct
+
+Please follow [Auth0's Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+
+## Questions?
+
+If you have questions about contributing, please [open an issue](https://github.com/auth0/agent-skills/issues/new) with the "question" label.


### PR DESCRIPTION
## Summary
- direct contributors to `author-auth0-skill` before changing unified Auth0 guidance
- remove obsolete instructions for creating standalone skills
- update the local testing example to copy the unified `auth0` skill
- allowlist Auth0's own pricing page, which the unified skill reads for current published prices

## Validation
- `python3 -m json.tool .snyk-agent-scan-ignore.json`
- `scripts/check_snyk_findings.py` against the failed scan artifact
- `uvx skillsaw --strict`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance for the consolidated Auth0 skill, including router references, editing workflows, code style, validation, and installation instructions.
  * Clarified that `CONTRIBUTING.md` is the authoritative guide for Auth0 guidance updates.
  * Updated metadata and reference-structure guidance to use the current unified skill example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->