### PR TITLE
feat(auth0): add Universal Portals guidance

### DIFF
--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -80,6 +80,13 @@
       "expect_refs": ["feature-acul/index.md", "tooling-cli/index.md"]
     },
     {
+      "id": "feature-universal-portals",
+      "intent": "feature:universal-portals",
+      "framework": null,
+      "tooling": "cli",
+      "expect_refs": ["feature-universal-portals/index.md", "tooling-cli/index.md"]
+    },
+    {
       "id": "feature-dpop-spa-combo",
       "intent": "feature:dpop",
       "framework": "vue",

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -28,7 +28,7 @@ npx skills add auth0/agent-skills/plugins/auth0
 
 | Skill | Description | Documentation |
 |-------|-------------|---------------|
-| [auth0](skills/auth0) | Adds Auth0 authentication to any app. Covers 35+ frameworks (React, Next.js, Vue, Angular, Express, Flask, FastAPI, Spring Boot, Swift, Android, Flutter, Laravel, Go, PHP, .NET MAUI, ASP.NET Core, React Native, Expo, Ionic, and more), MFA, Organizations, custom domains, ACUL screen generation, branding, debugging auth errors, security best practices, running a tenant security & configuration audit (CheckMate), a plan-aware tenant health check, and migration from other providers. | [SKILL.md](skills/auth0/SKILL.md) |
+| [auth0](skills/auth0) | Adds Auth0 authentication to any app. Covers 35+ frameworks (React, Next.js, Vue, Angular, Express, Flask, FastAPI, Spring Boot, Swift, Android, Flutter, Laravel, Go, PHP, .NET MAUI, ASP.NET Core, React Native, Expo, Ionic, and more), MFA, Organizations, Universal Portals for hosted account and organization self-service, custom domains, ACUL screen generation, branding, debugging auth errors, security best practices, running a tenant security & configuration audit (CheckMate), a plan-aware tenant health check, and migration from other providers. | [SKILL.md](skills/auth0/SKILL.md) |
 
 ## Forcing the skill with `/auth0`
 

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -278,7 +278,8 @@ If multi-tenant architecture / B2B SaaS design question: also Read references/pa
 ```
 
 ### feature:universal-portals
-```
+
+```text
 Read: references/feature-universal-portals/index.md
 Read: references/tooling-{tooling}/index.md
 Universal Portals is beta and non-production only. Use the hosted portal and its Management API; do not build the portal UI with an application SDK.

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auth0
-description: Use when adding, fixing, or improving Auth0 authentication or tenant configuration — login, MFA, passkeys, Organizations, Universal Portals, custom domains, ACUL, API protection, debugging, health checks, audits, or provider migration. Use even if Auth0 is not named.
+description: Use when adding, fixing, or improving authentication in any app — login, logout, signup, route protection, JWT/access token validation, refresh token rotation, MFA, passkeys, step-up auth, SSO, RBAC, Organizations for B2B SaaS, Universal Portals for hosted account and organization self-service, custom login domains, ACUL, or Universal Login branding. Use to audit a tenant (CheckMate), check tenant health and plan fit, or fix findings. Use even if Auth0 isn't mentioned — whenever a developer asks how to authenticate users, secure an API, debug a 401, CORS, callback mismatch, redirect loop, or 429, or migrate from Clerk, NextAuth.js, Firebase, Supabase, Cognito, or Passport.js. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, FastAPI, Spring Boot, Go, Swift, Android, Flutter, PHP, Laravel, ASP.NET Core, React Native, Expo, Ionic, and all Auth0 SDKs.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
@@ -30,10 +30,11 @@ Detect intent → detect framework → detect tooling → load 2–3 reference f
 
 ## Step 1: Detect intent
 
-Match the request to the goal in **What the developer wants**; it uses plain
-language, not just Auth0 terms. The **Intent** is a lookup key: in **Step 4** it
-appears verbatim as a section heading (`### feature:mfa`) listing references to
-load.
+Match the request against the **What the developer wants** column — it describes
+the goal in plain language, not just the Auth0 term (someone who says *"make
+users confirm with a code from their phone"* lands on `feature:mfa`). The
+**Intent** you pick is a lookup key: in **Step 4** it appears verbatim as a
+section heading (`### feature:mfa`) listing which reference files to load.
 
 | What the developer wants (plain language + Auth0 term) | Intent |
 |---|---|

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -41,7 +41,7 @@ section heading (`### feature:mfa`) listing which reference files to load.
 | Add login, signup, sign-in, or "let users log in / create accounts" to an app | **integrate** |
 | Require a second step after the password — a one-time code, SMS or email code, authenticator app, passkey, fingerprint/face (biometric), or security key; or re-confirm identity before a sensitive action. *Auth0: multi-factor authentication (MFA), two-factor (2FA), two-step verification, step-up authentication.* | **feature:mfa** |
 | Let separate companies, teams, workspaces, or tenants each have their own users, members, roles, and login — typically a product sold to businesses. *Auth0: Organizations, multi-org, B2B SaaS.* | **feature:organizations** |
-| Deploy a hosted self-service account or organization portal — profile updates, passkeys, MFA enrollment, organization details, domains, or portal pages — instead of building a “My Account” or “My Organization” UI. *Auth0: Universal Portals, My Account portal, My Organization portal.* | **feature:universal-portals** |
+| Deploy a hosted self-service portal for profile, passkeys, MFA, or organization details instead of building a “My Account” or “My Organization” UI. *Auth0: Universal Portals, My Account portal, My Organization portal.* | **feature:universal-portals** |
 | Serve the login page from your own web address (e.g. `login.example.com`, `auth.company.com`) instead of the default Auth0 URL. *Auth0: custom domain.* | **feature:custom-domains** |
 | Build fully custom login/signup screens with your own code or framework, beyond what theme settings allow. *Auth0: Advanced Customization for Universal Login (ACUL).* | **feature:acul** |
 | Change how the login page looks — logo, colors, fonts, background, overall theme. *Auth0: branding, Universal Login customization.* | **feature:branding** |
@@ -67,12 +67,10 @@ Work top-down. **Stop at the first tier that yields a framework.**
 
 ### Tier 1 — Auth0 SDK already installed (strongest signal)
 
-Read the project files. **Stop at the first match.**
-
 ### Node.js / JavaScript / TypeScript — check `package.json` → `dependencies`
 
-Rows are most-specific first — an Ionic/Capacitor project also carries
-`@auth0/auth0-angular` (etc.), so check the `@capacitor/browser` rows first.
+Rows are most-specific first: an Ionic/Capacitor project also carries the base
+SDK, so check the `@capacitor/browser` rows before it.
 
 | Package | Framework |
 |---|---|
@@ -120,9 +118,8 @@ Rows are most-specific first — an Ionic/Capacitor project also carries
 
 ### PHP — check `composer.json`
 
-`auth0/auth0-php` powers both PHP web apps and APIs; the mode is set via
-`SdkConfiguration`'s `strategy`. The `STRATEGY_API` row is more specific — check
-it first.
+`auth0/auth0-php` powers both PHP web apps and APIs via `SdkConfiguration`'s
+`strategy`. The `STRATEGY_API` row is more specific — check it first.
 
 | Package | Framework |
 |---|---|
@@ -132,8 +129,7 @@ it first.
 | `auth0/login` + `AuthorizationGuard` | `laravel-api` |
 
 > If `auth0/auth0-php` is installed but no `SdkConfiguration` strategy is set
-> yet (fresh project), fall through to variant disambiguation below (intent:
-> building/protecting an API → `php-api`, else `php`).
+> yet (fresh project), fall through to variant disambiguation below.
 
 ### Go — check `go.mod`
 
@@ -153,10 +149,9 @@ it first.
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
 If no Auth0 SDK matched, detect the framework from ordinary (non-Auth0)
-dependencies. **Stop at the first match.** For a web-vs-API split, the base is
-chosen here; the variant is resolved in "Variant disambiguation" below. Rows are
-most-specific first — an Ionic project also carries `@angular/core` / `vue` /
-`react`, so check the `@ionic/*` rows first (as in Tier 1).
+dependencies. **Stop at the first match.** This picks the base; any web-vs-API
+variant is resolved in "Variant disambiguation" below. As in Tier 1, check the
+`@ionic/*` rows before their base framework.
 
 | Signal | Base framework |
 |---|---|
@@ -192,8 +187,8 @@ most-specific first — an Ionic project also carries `@angular/core` / `vue` /
 
 ### Tier 3 — Framework from the prompt
 
-If no workspace signal matched, read the developer's request for a framework or
-language name and map it here. **Stop at the first match.**
+If no workspace signal matched, map the framework or language named in the
+request. **Stop at the first match.**
 
 | Developer mentions... | Framework |
 |---|---|
@@ -252,7 +247,7 @@ present and consistent.
 
 ## Step 3: Detect tooling
 
-Read the project file tree. This is a project-context decision, not a product preference.
+Read the project file tree — a project-context decision, not a product preference.
 
 | Project has... | Load |
 |---|---|
@@ -291,11 +286,9 @@ If multi-tenant architecture / B2B SaaS design question: also Read references/pa
 ```
 
 ### feature:universal-portals
-
-```text
+```
 Read: references/feature-universal-portals/index.md
 Read: references/tooling-{tooling}/index.md
-Universal Portals is beta and non-production only. Use the hosted portal and its Management API; do not build the portal UI with an application SDK.
 ```
 
 ### feature:custom-domains

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auth0
-description: Use when adding, fixing, or improving authentication in any app — login, logout, signup, route protection, JWT/access token validation, refresh token rotation, MFA, passkeys, step-up auth, SSO, RBAC, Organizations for B2B SaaS, Universal Portals for hosted account and organization self-service, custom login domains, ACUL, or Universal Login branding. Use to audit a tenant (CheckMate), check tenant health and plan fit, or fix findings. Use even if Auth0 isn't mentioned — whenever a developer asks how to authenticate users, secure an API, debug a 401, CORS, callback mismatch, redirect loop, or 429, or migrate from Clerk, NextAuth.js, Firebase, Supabase, Cognito, or Passport.js. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, FastAPI, Spring Boot, Go, Swift, Android, Flutter, PHP, Laravel, ASP.NET Core, React Native, Expo, Ionic, and all Auth0 SDKs.
+description: Use for adding, fixing, or improving authentication — login, logout, signup, route protection, JWT/access-token validation, refresh-token rotation, MFA, passkeys, step-up auth, SSO, RBAC, Organizations for B2B SaaS, Universal Portals for hosted account and organization self-service, custom domains, ACUL, or Universal Login branding. Audit tenants (CheckMate), check health and plan fit, or fix findings. Use even if Auth0 isn't mentioned — authenticate users, secure an API, debug 401, CORS, callback mismatch, redirect loop, or 429, or migrate from Clerk, NextAuth.js, Firebase, Supabase, Cognito, or Passport.js. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, FastAPI, Spring Boot, Go, Swift, Android, Flutter, PHP, Laravel, ASP.NET Core, React Native, Expo, Ionic, and all Auth0 SDKs.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
@@ -59,20 +59,16 @@ section heading (`### feature:mfa`) listing which reference files to load.
 
 ## Step 2: Detect framework
 
-> **Skip this step for the `tooling` intent** — a CLI-first request has no
-> framework. Go to Step 3, load the tooling reference; only ask about a
-> framework if the developer later pivots to integrating auth into an app.
+> **Skip this step for `tooling`.** Load tooling in Step 3; ask about a
+> framework only if the developer pivots to application integration.
 
-Work top-down. **Stop at the first tier that yields a framework.**
+Inspect project files and use the first matching tier and row.
 
 ### Tier 1 — Auth0 SDK already installed (strongest signal)
 
-Read the project files. **Stop at the first match.**
-
 ### Node.js / JavaScript / TypeScript — check `package.json` → `dependencies`
 
-Rows are most-specific first — an Ionic/Capacitor project also carries
-`@auth0/auth0-angular` (etc.), so check the `@capacitor/browser` rows first.
+Check Capacitor rows before their base SDK rows.
 
 | Package | Framework |
 |---|---|
@@ -120,9 +116,8 @@ Rows are most-specific first — an Ionic/Capacitor project also carries
 
 ### PHP — check `composer.json`
 
-`auth0/auth0-php` powers both PHP web apps and APIs; the mode is set via
-`SdkConfiguration`'s `strategy`. The `STRATEGY_API` row is more specific — check
-it first.
+`auth0/auth0-php` serves PHP web apps and APIs. Its `SdkConfiguration`
+`STRATEGY_API` row is more specific; check it first.
 
 | Package | Framework |
 |---|---|
@@ -131,9 +126,8 @@ it first.
 | `auth0/login` (laravel, no `AuthorizationGuard`) | `laravel` |
 | `auth0/login` + `AuthorizationGuard` | `laravel-api` |
 
-> If `auth0/auth0-php` is installed but no `SdkConfiguration` strategy is set
-> yet (fresh project), fall through to variant disambiguation below (intent:
-> building/protecting an API → `php-api`, else `php`).
+> If no `SdkConfiguration` strategy is set, use `php-api` for an API-only
+> project; otherwise use `php`.
 
 ### Go — check `go.mod`
 
@@ -152,11 +146,9 @@ it first.
 
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
-If no Auth0 SDK matched, detect the framework from ordinary (non-Auth0)
-dependencies. **Stop at the first match.** For a web-vs-API split, the base is
-chosen here; the variant is resolved in "Variant disambiguation" below. Rows are
-most-specific first — an Ionic project also carries `@angular/core` / `vue` /
-`react`, so check the `@ionic/*` rows first (as in Tier 1).
+If no Auth0 SDK matched, detect the framework from standard dependencies.
+Stop at the first match, resolve web/API variants below, and check Ionic before
+its base framework.
 
 | Signal | Base framework |
 |---|---|
@@ -186,14 +178,13 @@ most-specific first — an Ionic project also carries `@angular/core` / `vue` /
 | `*.csproj` (WPF) | `wpf` |
 | `*.csproj` ASP.NET (web app or API) | `aspnetcore` (variant below) |
 
-> **`react` note:** a plain React project maps to `react` for an SPA using the
-> React SDK, or `spa-js` if the app is framework-agnostic vanilla JS. If unclear,
-> ask before loading.
+> **`react` note:** use `react` for a React SPA and `spa-js` for
+> framework-agnostic vanilla JavaScript. Ask if unclear.
 
 ### Tier 3 — Framework from the prompt
 
-If no workspace signal matched, read the developer's request for a framework or
-language name and map it here. **Stop at the first match.**
+If workspace signals do not match, map the prompt's framework or language.
+Stop at the first match.
 
 | Developer mentions... | Framework |
 |---|---|
@@ -223,8 +214,7 @@ language name and map it here. **Stop at the first match.**
 
 ### Variant disambiguation (web app vs API)
 
-Some frameworks have separate web-app and API references. When Tier 1 did not
-pin the variant, choose **intent-first**:
+For frameworks with web-app and API references, choose intent-first:
 
 | Base | Web-app variant | API variant | Choose API when… |
 |---|---|---|---|
@@ -234,8 +224,8 @@ pin the variant, choose **intent-first**:
 | laravel | `laravel` | `laravel-api` | API-only (token guard), no Blade UI |
 | aspnetcore | `aspnetcore-auth` | `aspnetcore-api` | Web API / JWT bearer, no cookie login UI |
 
-If intent is still ambiguous (both a UI and protected endpoints, or unclear),
-**state what you detected and ask the developer** web app vs API before loading.
+If UI and API intent are both present or unclear, state the signal and ask
+whether the project is a web app or API.
 
 ### If nothing matched
 
@@ -243,16 +233,14 @@ Ask the developer what framework/language they are using. Do not guess.
 
 ### Conflicts
 
-If Tier 2 (workspace) and Tier 3 (prompt) disagree materially (e.g. the prompt
-says "Next.js" but `package.json` has no `next`), **state the conflict and ask**
-rather than silently picking. Workspace signals outrank the prompt when both are
-present and consistent.
+If workspace and prompt signals conflict, state the conflict and ask. Use
+workspace signals when both are consistent.
 
 ---
 
 ## Step 3: Detect tooling
 
-Read the project file tree. This is a project-context decision, not a product preference.
+Inspect the project file tree.
 
 | Project has... | Load |
 |---|---|
@@ -264,8 +252,7 @@ Read the project file tree. This is a project-context decision, not a product pr
 
 ## Step 4: Load reference files
 
-Find the section below whose heading matches the **Intent** you picked in
-Step 1, then read the reference files it lists.
+Read the references listed under the selected **Intent**.
 
 ### integrate
 ```

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auth0
-description: Use when adding, fixing, or improving authentication in any app — login, logout, signup, route protection, JWT/access token validation, refresh token rotation, MFA, passkeys, step-up auth, SSO, RBAC, Organizations for B2B SaaS, custom login domains, ACUL, or Universal Login branding. Use to audit a tenant (CheckMate), check tenant health and plan fit, or fix findings. Use even if Auth0 isn't mentioned — whenever a developer asks how to authenticate users, secure an API, debug a 401, CORS, callback mismatch, redirect loop, or 429, or migrate from Clerk, NextAuth.js, Firebase, Supabase, Cognito, or Passport.js. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, FastAPI, Spring Boot, Go, Swift, Android, Flutter, PHP, Laravel, ASP.NET Core, React Native, Expo, Ionic, and all Auth0 SDKs.
+description: Use when adding, fixing, or improving Auth0 authentication or tenant configuration — login, MFA, passkeys, Organizations, Universal Portals, custom domains, ACUL, API protection, debugging, health checks, audits, or provider migration. Use even if Auth0 is not named.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
@@ -30,17 +30,17 @@ Detect intent → detect framework → detect tooling → load 2–3 reference f
 
 ## Step 1: Detect intent
 
-Match the request against the **What the developer wants** column — it describes
-the goal in plain language, not just the Auth0 term (someone who says *"make
-users confirm with a code from their phone"* lands on `feature:mfa`). The
-**Intent** you pick is a lookup key: in **Step 4** it appears verbatim as a
-section heading (`### feature:mfa`) listing which reference files to load.
+Match the request to the goal in **What the developer wants**; it uses plain
+language, not just Auth0 terms. The **Intent** is a lookup key: in **Step 4** it
+appears verbatim as a section heading (`### feature:mfa`) listing references to
+load.
 
 | What the developer wants (plain language + Auth0 term) | Intent |
 |---|---|
 | Add login, signup, sign-in, or "let users log in / create accounts" to an app | **integrate** |
 | Require a second step after the password — a one-time code, SMS or email code, authenticator app, passkey, fingerprint/face (biometric), or security key; or re-confirm identity before a sensitive action. *Auth0: multi-factor authentication (MFA), two-factor (2FA), two-step verification, step-up authentication.* | **feature:mfa** |
 | Let separate companies, teams, workspaces, or tenants each have their own users, members, roles, and login — typically a product sold to businesses. *Auth0: Organizations, multi-org, B2B SaaS.* | **feature:organizations** |
+| Deploy a hosted self-service account or organization portal — profile updates, passkeys, MFA enrollment, organization details, domains, or portal pages — instead of building a “My Account” or “My Organization” UI. *Auth0: Universal Portals, My Account portal, My Organization portal.* | **feature:universal-portals** |
 | Serve the login page from your own web address (e.g. `login.example.com`, `auth.company.com`) instead of the default Auth0 URL. *Auth0: custom domain.* | **feature:custom-domains** |
 | Build fully custom login/signup screens with your own code or framework, beyond what theme settings allow. *Auth0: Advanced Customization for Universal Login (ACUL).* | **feature:acul** |
 | Change how the login page looks — logo, colors, fonts, background, overall theme. *Auth0: branding, Universal Login customization.* | **feature:branding** |
@@ -287,6 +287,13 @@ Read: references/feature-organizations/index.md
 Read: references/tooling-{tooling}/index.md
 If framework detected: Read references/framework-{framework}/index.md
 If multi-tenant architecture / B2B SaaS design question: also Read references/pattern-multi-tenant/index.md
+```
+
+### feature:universal-portals
+```
+Read: references/feature-universal-portals/index.md
+Read: references/tooling-{tooling}/index.md
+Universal Portals is beta and non-production only. Use the hosted portal and its Management API; do not build the portal UI with an application SDK.
 ```
 
 ### feature:custom-domains

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auth0
-description: Use for adding, fixing, or improving authentication — login, logout, signup, route protection, JWT/access-token validation, refresh-token rotation, MFA, passkeys, step-up auth, SSO, RBAC, Organizations for B2B SaaS, Universal Portals for hosted account and organization self-service, custom domains, ACUL, or Universal Login branding. Audit tenants (CheckMate), check health and plan fit, or fix findings. Use even if Auth0 isn't mentioned — authenticate users, secure an API, debug 401, CORS, callback mismatch, redirect loop, or 429, or migrate from Clerk, NextAuth.js, Firebase, Supabase, Cognito, or Passport.js. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, FastAPI, Spring Boot, Go, Swift, Android, Flutter, PHP, Laravel, ASP.NET Core, React Native, Expo, Ionic, and all Auth0 SDKs.
+description: Use when adding, fixing, or improving how an app authenticates users or protects an API, or when using or configuring any Auth0 feature — signing users in and out, sessions and tokens, guarding routes and endpoints, MFA, SSO, Organizations, RBAC, custom domains, Universal Portals for hosted account and organization self-service, or Universal Login branding. Also use to audit a tenant's health, security, and plan fit (CheckMate), to debug why an auth flow fails, or to migrate from another auth provider. Covers any web, mobile, or backend framework and every Auth0 SDK, tool, and API. Use even if the user never mentions Auth0.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
@@ -59,16 +59,20 @@ section heading (`### feature:mfa`) listing which reference files to load.
 
 ## Step 2: Detect framework
 
-> **Skip this step for `tooling`.** Load tooling in Step 3; ask about a
-> framework only if the developer pivots to application integration.
+> **Skip this step for the `tooling` intent** — a CLI-first request has no
+> framework. Go to Step 3, load the tooling reference; only ask about a
+> framework if the developer later pivots to integrating auth into an app.
 
-Inspect project files and use the first matching tier and row.
+Work top-down. **Stop at the first tier that yields a framework.**
 
 ### Tier 1 — Auth0 SDK already installed (strongest signal)
 
+Read the project files. **Stop at the first match.**
+
 ### Node.js / JavaScript / TypeScript — check `package.json` → `dependencies`
 
-Check Capacitor rows before their base SDK rows.
+Rows are most-specific first — an Ionic/Capacitor project also carries
+`@auth0/auth0-angular` (etc.), so check the `@capacitor/browser` rows first.
 
 | Package | Framework |
 |---|---|
@@ -116,8 +120,9 @@ Check Capacitor rows before their base SDK rows.
 
 ### PHP — check `composer.json`
 
-`auth0/auth0-php` serves PHP web apps and APIs. Its `SdkConfiguration`
-`STRATEGY_API` row is more specific; check it first.
+`auth0/auth0-php` powers both PHP web apps and APIs; the mode is set via
+`SdkConfiguration`'s `strategy`. The `STRATEGY_API` row is more specific — check
+it first.
 
 | Package | Framework |
 |---|---|
@@ -126,8 +131,9 @@ Check Capacitor rows before their base SDK rows.
 | `auth0/login` (laravel, no `AuthorizationGuard`) | `laravel` |
 | `auth0/login` + `AuthorizationGuard` | `laravel-api` |
 
-> If no `SdkConfiguration` strategy is set, use `php-api` for an API-only
-> project; otherwise use `php`.
+> If `auth0/auth0-php` is installed but no `SdkConfiguration` strategy is set
+> yet (fresh project), fall through to variant disambiguation below (intent:
+> building/protecting an API → `php-api`, else `php`).
 
 ### Go — check `go.mod`
 
@@ -146,9 +152,11 @@ Check Capacitor rows before their base SDK rows.
 
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
-If no Auth0 SDK matched, detect the framework from standard dependencies.
-Stop at the first match, resolve web/API variants below, and check Ionic before
-its base framework.
+If no Auth0 SDK matched, detect the framework from ordinary (non-Auth0)
+dependencies. **Stop at the first match.** For a web-vs-API split, the base is
+chosen here; the variant is resolved in "Variant disambiguation" below. Rows are
+most-specific first — an Ionic project also carries `@angular/core` / `vue` /
+`react`, so check the `@ionic/*` rows first (as in Tier 1).
 
 | Signal | Base framework |
 |---|---|
@@ -178,13 +186,14 @@ its base framework.
 | `*.csproj` (WPF) | `wpf` |
 | `*.csproj` ASP.NET (web app or API) | `aspnetcore` (variant below) |
 
-> **`react` note:** use `react` for a React SPA and `spa-js` for
-> framework-agnostic vanilla JavaScript. Ask if unclear.
+> **`react` note:** a plain React project maps to `react` for an SPA using the
+> React SDK, or `spa-js` if the app is framework-agnostic vanilla JS. If unclear,
+> ask before loading.
 
 ### Tier 3 — Framework from the prompt
 
-If workspace signals do not match, map the prompt's framework or language.
-Stop at the first match.
+If no workspace signal matched, read the developer's request for a framework or
+language name and map it here. **Stop at the first match.**
 
 | Developer mentions... | Framework |
 |---|---|
@@ -214,7 +223,8 @@ Stop at the first match.
 
 ### Variant disambiguation (web app vs API)
 
-For frameworks with web-app and API references, choose intent-first:
+Some frameworks have separate web-app and API references. When Tier 1 did not
+pin the variant, choose **intent-first**:
 
 | Base | Web-app variant | API variant | Choose API when… |
 |---|---|---|---|
@@ -224,8 +234,8 @@ For frameworks with web-app and API references, choose intent-first:
 | laravel | `laravel` | `laravel-api` | API-only (token guard), no Blade UI |
 | aspnetcore | `aspnetcore-auth` | `aspnetcore-api` | Web API / JWT bearer, no cookie login UI |
 
-If UI and API intent are both present or unclear, state the signal and ask
-whether the project is a web app or API.
+If intent is still ambiguous (both a UI and protected endpoints, or unclear),
+**state what you detected and ask the developer** web app vs API before loading.
 
 ### If nothing matched
 
@@ -233,14 +243,16 @@ Ask the developer what framework/language they are using. Do not guess.
 
 ### Conflicts
 
-If workspace and prompt signals conflict, state the conflict and ask. Use
-workspace signals when both are consistent.
+If Tier 2 (workspace) and Tier 3 (prompt) disagree materially (e.g. the prompt
+says "Next.js" but `package.json` has no `next`), **state the conflict and ask**
+rather than silently picking. Workspace signals outrank the prompt when both are
+present and consistent.
 
 ---
 
 ## Step 3: Detect tooling
 
-Inspect the project file tree.
+Read the project file tree. This is a project-context decision, not a product preference.
 
 | Project has... | Load |
 |---|---|
@@ -252,7 +264,8 @@ Inspect the project file tree.
 
 ## Step 4: Load reference files
 
-Read the references listed under the selected **Intent**.
+Find the section below whose heading matches the **Intent** you picked in
+Step 1, then read the reference files it lists.
 
 ### integrate
 ```

--- a/plugins/auth0/skills/auth0/references/feature-universal-portals/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-universal-portals/index.md
@@ -1,0 +1,303 @@
+# Auth0 Universal Portals
+
+Auth0 Universal Portals is a hosted identity experience platform. It provides managed consumer and business self-service portals instead of an application-owned “My Account” or “My Organization” UI.
+
+> **Beta — non-production only.** Universal Portals is available only in enabled non-production tenants. Do not configure, test, or suggest it for a production tenant. If the feature is not enabled, direct the developer to Auth0 Support.
+
+A portal is backed by a Regular Web Application. The portal server uses that application's credentials for SSO, keeps tokens server-side, and sets browser session cookies. It requests section-specific access tokens and refreshes them through a multi-resource refresh token. Do not build a browser-side token exchange or expose the portal application's client secret.
+
+## Choose the right workflow
+
+| Developer goal | Use |
+|---|---|
+| Get a test portal, resource servers, grants, and a Regular Web App quickly | `auth0-beta universal-portals setup` |
+| Configure a portal visually | Dashboard → **Portals** → create or open a portal → visual editor |
+| Script portal creation, reads, updates, or deletion | Management API `/api/v2/portals`, preferably through `auth0 api` |
+| Build tenant configuration as Terraform | Use Terraform for the surrounding application and APIs, then use the Management API for the portal. Do not invent an `auth0_portal` resource. |
+
+Universal Portals is a hosted surface, not an SDK integration. Do not add a React, Next.js, or mobile SDK to render portal components. An application may link users to the hosted portal, but the portal's pages and navigation are configured in Auth0.
+
+## Gather the minimum design input
+
+Before changing the tenant, establish:
+
+1. **Tenant and rollout boundary** — confirm that it is a non-production tenant with Universal Portals enabled.
+2. **Portal type** — consumer self-service, organization self-service, or both.
+3. **Portal name and unique slug** — use a URL-safe kebab-case slug such as `my-account`; the slug is unique within a tenant.
+4. **Sections and ownership** — choose Profile/forms, passkeys, MFA, organization details, organization domains, or informational content. Confirm which Auth0 Forms IDs already exist before adding form components.
+5. **Portal application** — use the Regular Web App created by setup, or identify an existing Regular Web App and obtain its client ID and secret through a secure path.
+
+If the developer asks to create Forms, use the available tenant tooling to create the Forms resource first, then insert the resulting ID in the portal payload. A `form_id` is not a label and cannot be fabricated.
+
+## Fast setup: Auth0 Beta CLI
+
+The setup command provisions the baseline in one step:
+
+```bash
+auth0-beta login
+auth0-beta universal-portals setup
+# alias: auth0-beta up setup
+```
+
+It creates:
+
+- My Account API for user account operations;
+- My Organization API for organization operations;
+- a Regular Web App linked to the portal;
+- client grants for My Account, My Organization, and Management API operations; and
+- a default portal and its URL.
+
+Open the URL that the command prints and test it with a test user. Treat the generated application credentials as secrets; do not commit them or include them in browser code.
+
+## Manual portal prerequisites
+
+When setup is not used, configure the Regular Web App before creating a portal:
+
+1. In **Applications → Applications**, create a **Regular Web Application**.
+2. Set its callback URL to `https://YOUR_AUTH0_DOMAIN/portals/auth/callback`.
+3. Set its logout URL to `https://YOUR_AUTH0_DOMAIN/portals/YOUR_PORTAL_SLUG`.
+4. In **Advanced Settings → Grant Types**, enable Authorization Code, Refresh Token, Client Credentials, and MFA.
+5. In **API Access**, grant the user-delegated My Account and My Organization API scopes needed by the selected components. Enable multi-resource refresh tokens for those same user-delegated API scopes.
+6. Grant the client access to the Management API scopes needed by the portal. A basic portal requires `read:branding` and `read:organizations`; add only the scopes required by the selected experience.
+
+For API-driven portal administration, pre-authorize these Management API scopes on the application that will administer portals:
+
+| Scope | Allows |
+|---|---|
+| `create:portals` | Create a portal |
+| `read:portals` | List and read portals |
+| `update:portals` | Update a portal |
+| `delete:portals` | Delete a portal |
+
+With `client_credentials`, these scopes are granted in **Application → API Access → Auth0 Management API**. They are not requested in the token request. A `403` generally means that the administration application lacks a required pre-authorized scope or the feature is not enabled.
+
+## Portal API operations
+
+The portal endpoints are part of Management API v2. Prefer `auth0 api` when it is available because it uses the active Auth0 CLI session; use a direct Management API request in CI or another non-interactive context.
+
+| Operation | Command | Success |
+|---|---|---|
+| Create | `auth0 api post /api/v2/portals --data '<payload>'` | 201 |
+| List | `auth0 api get /api/v2/portals` | 200 |
+| Read | `auth0 api get /api/v2/portals/{id}` | 200 |
+| Update | `auth0 api patch /api/v2/portals/{id} --data '<payload>'` | 200 |
+| Delete | `auth0 api delete /api/v2/portals/{id}` | 204 |
+
+The list endpoint returns at most 50 `PortalSummary` objects: `id`, `name`, `slug`, `created_at`, and `updated_at`. Create, read, and update return a full Portal object containing those fields plus `client`, `navigation`, and `pages`. The client secret is write-only and is never returned.
+
+### Create a minimal portal
+
+Use `client_secret_post` exactly as shown. The portal API currently supports no other token endpoint authentication method.
+
+```bash
+auth0 api post /api/v2/portals --data '{
+  "slug": "my-account",
+  "name": "My Account",
+  "client": {
+    "token_endpoint_auth_method": "client_secret_post",
+    "client_id": "YOUR_REGULAR_WEB_APP_CLIENT_ID",
+    "client_secret": "YOUR_REGULAR_WEB_APP_CLIENT_SECRET"
+  }
+}'
+```
+
+Keep real secrets in the user's secret manager or environment. Do not place a client secret in a source-controlled JSON example, a frontend variable, or chat output.
+
+A create request requires `slug`, `name`, and `client`:
+
+| Field | Constraints |
+|---|---|
+| `slug` | Unique URL-safe kebab-case portal slug |
+| `name` | 1–150 characters |
+| `client.token_endpoint_auth_method` | Literal `client_secret_post` |
+| `client.client_id` | Regular Web App client ID |
+| `client.client_secret` | 1–256 characters; write-only |
+| `navigation` | Optional sidebar definition |
+| `pages` | Optional page definition; a portal with no pages is valid |
+
+A duplicate slug returns `409 Conflict`. Read the portal list, choose a different slug, or update the existing portal after confirming it is the intended resource; do not delete an existing portal merely to reuse its slug.
+
+### Read, patch, and delete safely
+
+Read the portal before a change and re-read it after the change:
+
+```bash
+auth0 api get /api/v2/portals/PORTAL_ID
+
+auth0 api patch /api/v2/portals/PORTAL_ID --data '{
+  "name": "Customer Account"
+}'
+
+auth0 api get /api/v2/portals/PORTAL_ID
+```
+
+PATCH has true patch semantics:
+
+- omit `navigation` or `pages` to leave that field unchanged;
+- send `"navigation": null` or `"pages": null` to remove the entire field; and
+- send a complete replacement value when changing navigation or pages.
+
+Deletion is destructive. First list or read the portal, name the target ID and slug to the developer, obtain confirmation, then call delete. Expect HTTP 204 with no response body.
+
+## Compose navigation and pages
+
+A portal may have a sidebar and a set of pages:
+
+```json
+{
+  "navigation": {
+    "sidebar": {
+      "components": []
+    }
+  },
+  "pages": {
+    "default": "profile",
+    "content": []
+  }
+}
+```
+
+`pages.default` and `pages.content` are individually optional. When a default is specified, make it the slug of a page in `content`.
+
+### Sidebar components
+
+| Type | Required config | Optional config |
+|---|---|---|
+| `sidebar:component:auth0:internal_link` | `label` (1–50) | `to` (page slug, 1–50), `icon` |
+| `sidebar:component:auth0:external_link` | `label` (1–50), `url` (1–200) | `icon` |
+
+Icons are Lucide icon names in kebab-case, such as `user`, `shield`, `file-text`, `building-2`, and `lock-keyhole`.
+
+### Page components
+
+Each page has `title` (1–150 characters), a slug, and optional `components`.
+
+| Type | Required config | Optional config |
+|---|---|---|
+| `page:component:auth0:form` | `form_id` (1–50), `completion_message` (1–200) | — |
+| `page:component:auth0:typography:heading` | `title` (1–50) | `description` (1–200) |
+| `page:component:auth0:typography:rich_text` | `content` (1–10000 HTML) | — |
+| `page:component:auth0:structure:section` | `variant` (`card` or `none`), `children` (0–20) | `title` (1–50), `description` (1–200) |
+| `page:component:auth0:structure:separator` | — | `variant` (`dashed`, `none`, or `solid`), `text` (1–50) |
+| `page:component:auth0:my_account:passkey_management` | — | — |
+| `page:component:auth0:my_account:mfa_management` | — | — |
+| `page:component:auth0:my_organization:details_edit` | — | — |
+| `page:component:auth0:my_organization:domain_table` | — | — |
+
+A section's `children` can contain any page component except another section. Do not nest sections. Rich text supports headings, bold, italics, underline, links, alignment, and lists; use `<em>` for italic placeholder text.
+
+### Starter consumer portal payload
+
+This creates Profile and Security pages using a pre-existing Form. Replace the placeholder values only through a secure input path.
+
+```json
+{
+  "slug": "my-account",
+  "name": "My Account",
+  "client": {
+    "token_endpoint_auth_method": "client_secret_post",
+    "client_id": "YOUR_REGULAR_WEB_APP_CLIENT_ID",
+    "client_secret": "YOUR_REGULAR_WEB_APP_CLIENT_SECRET"
+  },
+  "navigation": {
+    "sidebar": {
+      "components": [
+        {
+          "type": "sidebar:component:auth0:internal_link",
+          "config": { "label": "Profile", "to": "profile", "icon": "user" }
+        },
+        {
+          "type": "sidebar:component:auth0:internal_link",
+          "config": { "label": "Security", "to": "security", "icon": "shield" }
+        }
+      ]
+    }
+  },
+  "pages": {
+    "default": "profile",
+    "content": [
+      {
+        "title": "Profile",
+        "slug": "profile",
+        "components": [
+          {
+            "type": "page:component:auth0:structure:section",
+            "config": {
+              "title": "Personal information",
+              "description": "Update the information you use across our services.",
+              "variant": "card",
+              "children": [
+                {
+                  "type": "page:component:auth0:form",
+                  "config": {
+                    "form_id": "YOUR_PERSONAL_INFO_FORM_ID",
+                    "completion_message": "Your personal information has been updated."
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "page:component:auth0:structure:section",
+            "config": {
+              "title": "Passkeys",
+              "description": "Manage passwordless sign-in methods for this account.",
+              "variant": "card",
+              "children": [
+                { "type": "page:component:auth0:my_account:passkey_management" }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "title": "Security",
+        "slug": "security",
+        "components": [
+          {
+            "type": "page:component:auth0:structure:section",
+            "config": {
+              "title": "Multi-factor authentication",
+              "description": "Manage the additional verification methods for this account.",
+              "variant": "card",
+              "children": [
+                { "type": "page:component:auth0:my_account:mfa_management" }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+For a business portal, add a page whose section children include `page:component:auth0:my_organization:details_edit` or `page:component:auth0:my_organization:domain_table`. Only include organization controls when the chosen portal experience and application grants support them.
+
+## Validate the portal
+
+1. Read the portal through `auth0 api get /api/v2/portals/PORTAL_ID` and check the stored name, slug, sidebar targets, default page, and component types.
+2. Open the portal URL in a private browser session with a test user.
+3. Test each included capability: form submission, passkey management, MFA management, and organization editing or domain viewing as applicable.
+4. Confirm logout returns to the configured logout URL and that the callback completes.
+5. In the Dashboard, use Preview before Publish when working through the visual editor.
+
+## Troubleshooting
+
+| Symptom | Cause and next action |
+|---|---|
+| Feature or endpoint is unavailable | Confirm a non-production tenant and Universal Portals enablement. Request beta access through Auth0 Support. |
+| `403 Forbidden` from portal API | Pre-authorize the required `*:portals` scope on the administration application. Check that the active CLI session or client credentials use that application. |
+| `409 Conflict` on create | The slug already exists in this tenant. List portals, then choose another slug or intentionally patch the existing portal. |
+| Portal cannot finish login or logout | Verify the portal application's callback and logout URLs, grant types, API access, and multi-resource refresh token configuration. |
+| Form fails to render | Verify that `form_id` refers to an existing Auth0 Forms resource and that the portal application can use the required API access. |
+| Passkey, MFA, or organization component fails | Confirm its underlying Auth0 capability and the matching My Account or My Organization scopes. Do not replace the managed component with a browser-side implementation. |
+| Secret disappears after reading a portal | Expected behavior: `client_secret` is write-only. Keep the source secret in an approved secret store and supply it only when creating or changing the portal client. |
+
+## Sources
+
+- https://auth0.com/docs/customize/portals/overview
+- https://auth0.com/docs/customize/portals/quickstart
+- https://auth0.com/docs/api/management/v2
+- https://auth0.github.io/auth0-cli/auth0_api.html
+- https://lucide.dev/icons/

--- a/plugins/auth0/skills/auth0/references/feature-universal-portals/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-universal-portals/index.md
@@ -12,7 +12,7 @@ A portal is backed by a Regular Web Application. The portal server uses that app
 |---|---|
 | Get a test portal, resource servers, grants, and a Regular Web App quickly | `auth0-beta universal-portals setup` |
 | Configure a portal visually | Dashboard → **Portals** → create or open a portal → visual editor |
-| Script portal creation, reads, updates, or deletion | Management API `/api/v2/portals`, preferably through `auth0 api` |
+| Script portal creation, reads, updates, or deletion | Management API `portals` endpoints, preferably through `auth0 api` |
 | Build tenant configuration as Terraform | Use Terraform for the surrounding application and APIs, then use the Management API for the portal. Do not invent an `auth0_portal` resource. |
 
 Universal Portals is a hosted surface, not an SDK integration. Do not add a React, Next.js, or mobile SDK to render portal components. An application may link users to the hosted portal, but the portal's pages and navigation are configured in Auth0.

--- a/plugins/auth0/skills/auth0/references/feature-universal-portals/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-universal-portals/index.md
@@ -76,11 +76,11 @@ The portal endpoints are part of Management API v2. Prefer `auth0 api` when it i
 
 | Operation | Command | Success |
 |---|---|---|
-| Create | `auth0 api post /api/v2/portals --data '<payload>'` | 201 |
-| List | `auth0 api get /api/v2/portals` | 200 |
-| Read | `auth0 api get /api/v2/portals/{id}` | 200 |
-| Update | `auth0 api patch /api/v2/portals/{id} --data '<payload>'` | 200 |
-| Delete | `auth0 api delete /api/v2/portals/{id}` | 204 |
+| Create | `auth0 api post portals --data '<payload>'` | 201 |
+| List | `auth0 api get portals` | 200 |
+| Read | `auth0 api get portals/{id}` | 200 |
+| Update | `auth0 api patch portals/{id} --data '<payload>'` | 200 |
+| Delete | `auth0 api delete portals/{id}` | 204 |
 
 The list endpoint returns at most 50 `PortalSummary` objects: `id`, `name`, `slug`, `created_at`, and `updated_at`. Create, read, and update return a full Portal object containing those fields plus `client`, `navigation`, and `pages`. The client secret is write-only and is never returned.
 
@@ -89,7 +89,7 @@ The list endpoint returns at most 50 `PortalSummary` objects: `id`, `name`, `slu
 Use `client_secret_post` exactly as shown. The portal API currently supports no other token endpoint authentication method.
 
 ```bash
-auth0 api post /api/v2/portals --data '{
+auth0 api post portals --data '{
   "slug": "my-account",
   "name": "My Account",
   "client": {
@@ -121,13 +121,13 @@ A duplicate slug returns `409 Conflict`. Read the portal list, choose a differen
 Read the portal before a change and re-read it after the change:
 
 ```bash
-auth0 api get /api/v2/portals/PORTAL_ID
+auth0 api get portals/PORTAL_ID
 
-auth0 api patch /api/v2/portals/PORTAL_ID --data '{
+auth0 api patch portals/PORTAL_ID --data '{
   "name": "Customer Account"
 }'
 
-auth0 api get /api/v2/portals/PORTAL_ID
+auth0 api get portals/PORTAL_ID
 ```
 
 PATCH has true patch semantics:
@@ -275,7 +275,7 @@ For a business portal, add a page whose section children include `page:component
 
 ## Validate the portal
 
-1. Read the portal through `auth0 api get /api/v2/portals/PORTAL_ID` and check the stored name, slug, sidebar targets, default page, and component types.
+1. Read the portal through `auth0 api get portals/PORTAL_ID` and check the stored name, slug, sidebar targets, default page, and component types.
 2. Open the portal URL in a private browser session with a test user.
 3. Test each included capability: form submission, passkey management, MFA management, and organization editing or domain viewing as applicable.
 4. Confirm logout returns to the configured logout URL and that the callback completes.

--- a/plugins/auth0/skills/auth0/references/feature-universal-portals/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-universal-portals/index.md
@@ -22,10 +22,9 @@ Universal Portals is a hosted surface, not an SDK integration. Do not add a Reac
 Before changing the tenant, establish:
 
 1. **Tenant and rollout boundary** — confirm that it is a non-production tenant with Universal Portals enabled.
-2. **Portal type** — consumer self-service, organization self-service, or both.
-3. **Portal name and unique slug** — use a URL-safe kebab-case slug such as `my-account`; the slug is unique within a tenant.
-4. **Sections and ownership** — choose Profile/forms, passkeys, MFA, organization details, organization domains, or informational content. Confirm which Auth0 Forms IDs already exist before adding form components.
-5. **Portal application** — use the Regular Web App created by setup, or identify an existing Regular Web App and obtain its client ID and secret through a secure path.
+2. **Portal name and unique slug** — use a URL-safe kebab-case slug such as `my-account`; the slug is unique within a tenant.
+3. **Components** — choose which components to include: Profile/forms, passkeys, and MFA for a consumer self-service experience; organization details and organization domains for a business self-service experience. Confirm which Auth0 Forms IDs already exist before adding form components.
+4. **Portal application** — use the Regular Web App created by setup, or identify an existing Regular Web App and obtain its client ID and secret through a secure path.
 
 If the developer asks to create Forms, use the available tenant tooling to create the Forms resource first, then insert the resulting ID in the portal payload. A `form_id` is not a label and cannot be fabricated.
 


### PR DESCRIPTION
## Summary
- add a routed Universal Portals feature reference for hosted account and organization self-service
- cover the beta-only guard, Beta CLI setup, manual prerequisites, Management API CRUD, component composition, validation, and troubleshooting
- add a routing eval and document the new capability in the plugin README

## Safety
Universal Portals guidance explicitly restricts use to enabled non-production tenants and keeps portal application client secrets out of browser code and source control.

## Validation
- `bash plugins/auth0/skills/auth0/scripts/validate-skill.sh`
- `python3 scripts/check_router_reachability.py plugins/auth0/skills/auth0`
- `python3 scripts/check_routing_evals.py plugins/auth0/skills/auth0`
- `uvx skillsaw --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Auth0 Universal Portals, enabling hosted account and organization self-service experiences.
  * Added CLI tooling guidance for setting up and managing Universal Portals.

* **Documentation**
  * Added guidance for portal workflows, application configuration, content management, validation, permissions, secret handling, troubleshooting, and API operations.
  * Documented beta and non-production limitations, prerequisites, portal components, and consumer and organization examples.
  * Improved guidance for framework detection, tooling requests, and PHP API-only projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->