### PR TITLE
feat(auth0): add Vercel integration reference

### DIFF
--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -98,12 +98,12 @@ rules:
   # and check_router_reachability.py, so its token budget is intentionally large
   # and can't be trimmed without dropping routes. Each intent adds a table row +
   # a Step 4 loader block, so the body grows as intents are added. Warn limit is
-  # 4100 (still catches real bloat) with the 6000 error ceiling unchanged. The
+  # 4300 (still catches real bloat) with the 6000 error ceiling unchanged. The
   # skill-description budget (200) is unchanged and enforced separately.
   context-budget:
     limits:
       skill:
-        warn: 4100
+        warn: 4300
         error: 6000
 
   # feature-audit.md and feature-healthcheck.md express Auth0 feature-gap severity

--- a/.snyk-agent-scan-ignore.json
+++ b/.snyk-agent-scan-ignore.json
@@ -1,6 +1,24 @@
 [
   {
     "code": "W012",
+    "skills": ["auth0"],
+    "url": "https://auth0.com/pricing.md",
+    "reason": "First-party Auth0 pricing page; the skill retrieves current published prices instead of hardcoding pricing data"
+  },
+  {
+    "code": "W012",
+    "skills": ["auth0"],
+    "url": "https://github.com/auth0/auth0-oidc-client-net",
+    "reason": "First-party Auth0 OIDC client repository; the WinForms guidance resolves its current release version"
+  },
+  {
+    "code": "W012",
+    "skills": ["auth0"],
+    "url": "https://github.com/auth0/auth0-java-mvc-common",
+    "reason": "First-party Auth0 Java MVC repository; the Java guidance resolves its current release version"
+  },
+  {
+    "code": "W012",
     "url": "https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh",
     "reason": "First-party Auth0 CLI install script from Auth0-owned repository"
   },

--- a/.snyk-agent-scan-ignore.json
+++ b/.snyk-agent-scan-ignore.json
@@ -1,24 +1,6 @@
 [
   {
     "code": "W012",
-    "skills": ["auth0"],
-    "url": "https://auth0.com/pricing.md",
-    "reason": "First-party Auth0 pricing page; the skill retrieves current published prices instead of hardcoding pricing data"
-  },
-  {
-    "code": "W012",
-    "skills": ["auth0"],
-    "url": "https://github.com/auth0/auth0-oidc-client-net",
-    "reason": "First-party Auth0 OIDC client repository; the WinForms guidance resolves its current release version"
-  },
-  {
-    "code": "W012",
-    "skills": ["auth0"],
-    "url": "https://github.com/auth0/auth0-java-mvc-common",
-    "reason": "First-party Auth0 Java MVC repository; the Java guidance resolves its current release version"
-  },
-  {
-    "code": "W012",
     "url": "https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh",
     "reason": "First-party Auth0 CLI install script from Auth0-owned repository"
   },

--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -16,6 +16,20 @@
       "expect_refs": ["framework-nextjs/index.md", "tooling-cli/index.md"]
     },
     {
+      "id": "integrate-nextjs-vercel",
+      "intent": "integrate",
+      "framework": "nextjs",
+      "tooling": "vercel",
+      "expect_refs": ["framework-nextjs/index.md", "tooling-vercel/index.md"]
+    },
+    {
+      "id": "tooling-vercel-native-integration",
+      "intent": "tooling",
+      "framework": null,
+      "tooling": "vercel",
+      "expect_refs": ["tooling-vercel/index.md"]
+    },
+    {
       "id": "integrate-express-api",
       "intent": "integrate",
       "framework": "express-jwt",

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -28,7 +28,7 @@ npx skills add auth0/agent-skills/plugins/auth0
 
 | Skill | Description | Documentation |
 |-------|-------------|---------------|
-| [auth0](skills/auth0) | Adds Auth0 authentication to any app. Covers 35+ frameworks (React, Next.js, Vue, Angular, Express, Flask, FastAPI, Spring Boot, Swift, Android, Flutter, Laravel, Go, PHP, .NET MAUI, ASP.NET Core, React Native, Expo, Ionic, and more), MFA, Organizations, custom domains, ACUL screen generation, branding, debugging auth errors, security best practices, running a tenant security & configuration audit (CheckMate), a plan-aware tenant health check, and migration from other providers. | [SKILL.md](skills/auth0/SKILL.md) |
+| [auth0](skills/auth0) | Adds Auth0 authentication to any app. Covers 35+ frameworks (React, Next.js, Vue, Angular, Express, Flask, FastAPI, Spring Boot, Swift, Android, Flutter, Laravel, Go, PHP, .NET MAUI, ASP.NET Core, React Native, Expo, Ionic, and more), MFA, Organizations, Vercel native integration, custom domains, ACUL screen generation, branding, debugging auth errors, security best practices, running a tenant security & configuration audit (CheckMate), a plan-aware tenant health check, and migration from other providers. | [SKILL.md](skills/auth0/SKILL.md) |
 
 ## Forcing the skill with `/auth0`
 

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -52,6 +52,7 @@ section heading (`### feature:mfa`) listing which reference files to load.
 | Hit rate limiting: 429 Too Many Requests, quota exceeded. *Auth0: rate limits.* | **debug:rate-limit** |
 | Move an existing app off Clerk, NextAuth.js, Firebase, Cognito, Okta, Supabase, Passport.js, or another auth provider. *Auth0: provider migration.* | **migrate** |
 | Upgrade the Auth0 SDK itself to a new major version (e.g. Auth0.swift v2→v3, Auth0.Android v3→v4) — breaking changes, deprecated APIs, "update to the latest SDK". *Auth0: SDK major-version upgrade.* | **upgrade-sdk** |
+| Install Auth0's Vercel Marketplace integration, connect Auth0 to a Vercel project, or sync Auth0 configuration into a Vercel-hosted Next.js app. *Auth0: Vercel native integration.* | **integrate** |
 | Use the Auth0 CLI directly — "create an app/API with the `auth0` CLI", script tenant setup, or automate Auth0 config in CI — with no application framework in play. *Auth0: CLI / tooling-only.* | **tooling** |
 
 ---
@@ -251,10 +252,11 @@ present and consistent.
 
 ## Step 3: Detect tooling
 
-Read the project file tree. This is a project-context decision, not a product preference.
+Read the project file tree and the request. This is a project-context decision, not a product preference.
 
 | Project has... | Load |
 |---|---|
+| `vercel.json`, `.vercel/`, or a request for the Auth0 Vercel Marketplace/native integration | `tooling-vercel/index.md` |
 | `terraform/` directory OR any `*.tf` files | `tooling-terraform/index.md` |
 | Auth0 MCP server active in this agent session | `tooling-mcp/index.md` |
 | Anything else (default) | `tooling-cli/index.md` |

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -256,9 +256,9 @@ Read the project file tree and the request. This is a project-context decision, 
 
 | Project has... | Load |
 |---|---|
-| `vercel.json`, `.vercel/`, or a request for the Auth0 Vercel Marketplace/native integration | `tooling-vercel/index.md` |
 | `terraform/` directory OR any `*.tf` files | `tooling-terraform/index.md` |
 | Auth0 MCP server active in this agent session | `tooling-mcp/index.md` |
+| A request for the Auth0 Vercel Marketplace/native integration, or to connect Auth0 to a Vercel project | `tooling-vercel/index.md` |
 | Anything else (default) | `tooling-cli/index.md` |
 
 ---

--- a/plugins/auth0/skills/auth0/references/tooling-vercel/index.md
+++ b/plugins/auth0/skills/auth0/references/tooling-vercel/index.md
@@ -58,10 +58,13 @@ variable conventions with a marketplace-specific variant.
 5. Open the integration's **Getting Started** page and follow its generated
    quickstart.
 
-The Vercel CLI can start the same provisioning flow from the project directory:
+The Vercel CLI can start the same provisioning flow from the project directory.
+Pass `--no-env-pull` so the CLI does not run `vercel env pull` automatically
+after provisioning — pulling secrets is a separate, deliberate step below, run
+only after confirming `.env.local` is ignored:
 
 ```bash
-vc i auth0
+vc i auth0 --no-env-pull
 ```
 
 Do not treat `vc i auth0` as read-only. It provisions a resource, so run it
@@ -81,12 +84,17 @@ Prefer connecting with no prefix. If a prefix is required, map the prefixed
 values back to the standard names in your app before constructing `Auth0Client`
 (or pass them explicitly to the constructor).
 
-First confirm `.env.local` is ignored by Git so the pull cannot write real
-client secrets into a tracked file. Then link the checkout and pull the values:
+First confirm `.env.local` is both untracked and git-ignored so the pull cannot
+write real client secrets into a tracked file. Stop if either check fails. Then
+link the checkout and pull the values:
 
 ```bash
-# Confirm .env.local is git-ignored BEFORE pulling any secrets.
-git check-ignore .env.local
+# BEFORE pulling any secrets: fail if .env.local is tracked or not ignored.
+if git ls-files --error-unmatch -- .env.local >/dev/null 2>&1 \
+   || ! git check-ignore --no-index --quiet -- .env.local; then
+  echo ".env.local must be untracked and git-ignored before pulling secrets"
+  exit 1
+fi
 
 # Link the local checkout to the intended Vercel project, then pull local-only values.
 vercel link
@@ -116,8 +124,9 @@ or scope variables before testing those environments.
    changes.
 3. Deploy to the selected Vercel Production environment and complete login,
    callback, session, protected-route, and logout checks on the deployed URL.
-4. Enable iframe embedding in the Auth0 tenant after installation. If login
-   fails in Vercel's embedded experience, check this setting before changing
+4. If login fails in Vercel's embedded experience, enable iframe embedding in
+   the Auth0 tenant — but first restrict the allowed iframe origins to the
+   intended Vercel URLs, then enable the setting. Check this before changing
    callback URLs or SDK code.
 
 ## Manage the integration

--- a/plugins/auth0/skills/auth0/references/tooling-vercel/index.md
+++ b/plugins/auth0/skills/auth0/references/tooling-vercel/index.md
@@ -19,10 +19,14 @@ Before installing, state what will happen and get confirmation:
   print, commit, or copy their values into source control.
 - Removing the integration removes the connected Auth0 account and downgrades
   the installation to Vercel's Free plan.
+- An installation plan is selected during setup. Paid plans are billed through
+  Vercel via the integration's Settings page; state the selected plan and its
+  billing impact.
 
-Confirm the Vercel team, project, environments, application name, and optional
-environment-variable prefix. If the developer wants an existing Auth0 tenant,
-stop this workflow and use the normal tenant/application configuration path.
+Confirm the Vercel team, project, environments, application name, selected
+installation plan, and optional environment-variable prefix. If the developer
+wants an existing Auth0 tenant, stop this workflow and use the normal
+tenant/application configuration path.
 
 ## Prerequisites
 
@@ -31,7 +35,9 @@ stop this workflow and use the normal tenant/application configuration path.
 - Permission to install integrations for the intended Vercel team and create
   the connected Auth0 account.
 - Iframe embedding enabled after installation, so Universal Login or Classic
-  Login can load in the iframe required by Vercel.
+  Login can load in the iframe required by Vercel. This relaxes the default
+  framing protection for Universal Login, so enable it only for this
+  integration and confirm the developer accepts the tradeoff.
 
 The router co-loads the Next.js reference for the SDK implementation. Do not
 replace its Auth0 routes, middleware/proxy, session handling, or environment
@@ -68,15 +74,32 @@ quickstart exposes values such as `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`,
 `AUTH0_DOMAIN`, and `AUTH0_SECRET`; retrieve them through Vercel rather than
 copying secrets from a dashboard or committing a `.env.local` file.
 
+If you set a variable prefix when connecting the project, Vercel names the
+managed values `[prefix]_AUTH0_DOMAIN`, `[prefix]_AUTH0_CLIENT_ID`, and so on,
+but the `@auth0/nextjs-auth0` SDK only reads the unprefixed default names.
+Prefer connecting with no prefix. If a prefix is required, map the prefixed
+values back to the standard names in your app before constructing `Auth0Client`
+(or pass them explicitly to the constructor).
+
+First confirm `.env.local` is ignored by Git so the pull cannot write real
+client secrets into a tracked file. Then link the checkout and pull the values:
+
 ```bash
+# Confirm .env.local is git-ignored BEFORE pulling any secrets.
+git check-ignore .env.local
+
 # Link the local checkout to the intended Vercel project, then pull local-only values.
 vercel link
-vercel env pull .env.local
+# The native integration stores credentials in Production; pull that environment
+# explicitly (env pull defaults to Development, which has no credentials).
+vercel env pull .env.local --environment=production
 ```
 
-Verify `.env.local` is ignored by Git. The current Next.js SDK also needs
-`APP_BASE_URL`; set it to the canonical production URL if it is not populated
-by the integration. Do not derive it from an untrusted request header.
+For local development the current Next.js SDK also needs `APP_BASE_URL`; set it
+to your local URL (e.g. `http://localhost:3000`) in `.env.local`, and keep the
+canonical production URL configured for the deployed environment. The SDK can
+infer `APP_BASE_URL` from the request on Vercel previews, but do not derive it
+from an untrusted request header in code.
 
 The native-integration quickstart only configures Auth0 environment variables
 for the Production environment. Do not assume Preview or Development deployments

--- a/plugins/auth0/skills/auth0/references/tooling-vercel/index.md
+++ b/plugins/auth0/skills/auth0/references/tooling-vercel/index.md
@@ -1,0 +1,121 @@
+# Auth0 Vercel native integration
+
+Use this reference when the developer wants to install or manage Auth0 through
+the Vercel Marketplace, connect an Auth0 integration to a Vercel project, or
+sync Auth0 configuration into a Vercel-hosted Next.js application.
+
+The native integration provisions a **new Auth0 tenant environment and
+application** for the Vercel project, then preloads the Auth0 configuration in
+Vercel. It does not connect an existing Auth0 account. For an existing tenant,
+use the standard Auth0 application setup instead of installing this integration.
+
+## Confirm before provisioning
+
+Before installing, state what will happen and get confirmation:
+
+- A new Auth0 account/tenant environment and application will be created.
+- The integration will connect to the selected Vercel project and environments.
+- Auth0 credentials will be populated in Vercel environment variables. Do not
+  print, commit, or copy their values into source control.
+- Removing the integration removes the connected Auth0 account and downgrades
+  the installation to Vercel's Free plan.
+
+Confirm the Vercel team, project, environments, application name, and optional
+environment-variable prefix. If the developer wants an existing Auth0 tenant,
+stop this workflow and use the normal tenant/application configuration path.
+
+## Prerequisites
+
+- A Vercel account and active Vercel project.
+- A Next.js application using the current `@auth0/nextjs-auth0` SDK.
+- Permission to install integrations for the intended Vercel team and create
+  the connected Auth0 account.
+- Iframe embedding enabled after installation, so Universal Login or Classic
+  Login can load in the iframe required by Vercel.
+
+The router co-loads the Next.js reference for the SDK implementation. Do not
+replace its Auth0 routes, middleware/proxy, session handling, or environment
+variable conventions with a marketplace-specific variant.
+
+## Install the native integration
+
+### Vercel Marketplace
+
+1. In Vercel, open **Integrations** → **Browse Marketplace** and find
+   **Auth0** under Native Integrations.
+2. Select **Install**, choose the installation plan, and continue.
+3. Name the Auth0 application and create it. Vercel creates the dedicated
+   Auth0 tenant environment and application; wait for completion.
+4. Select **Connect Project**, choose the Vercel project and target
+   environments, enter a variable prefix only if the project requires one, and
+   connect.
+5. Open the integration's **Getting Started** page and follow its generated
+   quickstart.
+
+The Vercel CLI can start the same provisioning flow from the project directory:
+
+```bash
+vc i auth0
+```
+
+Do not treat `vc i auth0` as read-only. It provisions a resource, so run it
+only after the developer confirms the target team and project.
+
+## Use the generated configuration safely
+
+The integration preloads Auth0 credentials in the Vercel project. Its
+quickstart exposes values such as `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`,
+`AUTH0_DOMAIN`, and `AUTH0_SECRET`; retrieve them through Vercel rather than
+copying secrets from a dashboard or committing a `.env.local` file.
+
+```bash
+# Link the local checkout to the intended Vercel project, then pull local-only values.
+vercel link
+vercel env pull .env.local
+```
+
+Verify `.env.local` is ignored by Git. The current Next.js SDK also needs
+`APP_BASE_URL`; set it to the canonical production URL if it is not populated
+by the integration. Do not derive it from an untrusted request header.
+
+The native-integration quickstart only configures Auth0 environment variables
+for the Production environment. Do not assume Preview or Development deployments
+have the credentials; inspect the Vercel project settings and deliberately add
+or scope variables before testing those environments.
+
+## Deploy and verify
+
+1. Follow the co-loaded Next.js reference to install `@auth0/nextjs-auth0`,
+   configure `Auth0Client`, add the proxy/middleware, and add login/logout UI.
+2. Verify the generated Auth0 application has the production callback and
+   logout URLs. The integration populates localhost and callback URLs initially;
+   update the application settings when the canonical domain or callback path
+   changes.
+3. Deploy to the selected Vercel Production environment and complete login,
+   callback, session, protected-route, and logout checks on the deployed URL.
+4. Enable iframe embedding in the Auth0 tenant after installation. If login
+   fails in Vercel's embedded experience, check this setting before changing
+   callback URLs or SDK code.
+
+## Manage the integration
+
+Use the Vercel project **Integrations** tab → **Auth0** → **Manage** to rotate
+secrets, edit localhost/callback parameters, set allowed environments, change
+the installation plan, or remove the integration. Use the Auth0 Dashboard for
+application settings such as Universal Login customization.
+
+Before rotating secrets or changing callback URLs, identify every deployment
+that consumes the affected variables and plan a redeploy. After rotation,
+confirm the new variables are present in the intended Vercel environment and
+that login works before removing the old secret from dependent systems.
+
+## Troubleshoot
+
+| Symptom | Check | Resolution |
+|---|---|---|
+| Marketplace flow creates a different tenant than expected | Native-integration behavior | Expected: it creates a dedicated new Auth0 tenant environment. Use standard Auth0 setup for an existing tenant. |
+| Local app has missing Auth0 variables | Vercel project link and environment selection | Run `vercel link` for the intended project, then `vercel env pull .env.local`; keep the file out of Git. |
+| Production works but Preview fails | Variable scope | Add or scope the required variables deliberately; the generated quickstart configures Auth0 variables only for Production. |
+| Callback mismatch after deploy | Canonical URL and Auth0 application URLs | Set `APP_BASE_URL` to the canonical URL and update the allowed callback/logout URLs to match the SDK's configured routes exactly. |
+| Login does not render in Vercel's embedded experience | Iframe embedding | Enable iframe embedding in the Auth0 tenant, then retry before changing application code. |
+| Integration removal has unexpected account impact | Removal warning | Stop and confirm the removal: deleting the integration removes the connected Auth0 account and downgrades the Vercel installation. |

--- a/plugins/auth0/skills/auth0/scripts/validate-skill.sh
+++ b/plugins/auth0/skills/auth0/scripts/validate-skill.sh
@@ -101,7 +101,7 @@ if [ "$ORG_LINES" -lt 80 ]; then
   exit 1
 fi
 
-for t in cli mcp terraform; do
+for t in cli mcp terraform vercel; do
   if [ ! -f "$REFS_DIR/tooling-$t/index.md" ]; then
     echo "FAIL: missing references/tooling-$t/index.md"
     exit 1


### PR DESCRIPTION
## Summary
- add a `tooling-vercel` reference for Auth0’s Vercel native Marketplace integration
- route Vercel Marketplace requests to it and add Vercel routing coverage
- document the provisioned tenant/application, environment-variable handling, production-only quickstart limitation, iframe requirement, and safe removal/secret-rotation checks
- add Vercel to the structural tooling-reference gate

## Sources
- https://auth0.com/docs/customize/integrations/integrate-with-vercel
- https://vercel.com/marketplace/auth0
- supplied Vercel integration quickstart PDF

## Validation
- `python3 -m json.tool evals/routing-cases.json`
- `uvx -q "skillsaw==0.16.0" --strict`
- `bash plugins/auth0/skills/auth0/scripts/validate-skill.sh`
- `python3 scripts/check_router_reachability.py plugins/auth0/skills/auth0`
- `python3 scripts/check_routing_evals.py plugins/auth0/skills/auth0`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for setting up and managing Auth0’s native Vercel integration.
  * Added support for recognizing Vercel integration requests and providing the appropriate setup instructions.
  * Added routing evaluation coverage for Next.js with Vercel and standalone Vercel tooling.

* **Documentation**
  * Expanded Vercel setup, deployment verification, environment-variable, troubleshooting, and integration-management guidance.
  * Updated Auth0 skill descriptions to mention Vercel integration.

* **Chores**
  * Increased the context-budget warning threshold while retaining the existing error limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->