### PR TITLE
chore(auth0): ignore first-party Auth0 URL W012 findings

### DIFF
--- a/.snyk-agent-scan-ignore.json
+++ b/.snyk-agent-scan-ignore.json
@@ -1,6 +1,24 @@
 [
   {
     "code": "W012",
+    "skills": ["auth0"],
+    "url": "https://auth0.com/pricing.md",
+    "reason": "First-party Auth0 pricing page; the skill retrieves current published prices instead of hardcoding pricing data"
+  },
+  {
+    "code": "W012",
+    "skills": ["auth0"],
+    "url": "https://github.com/auth0/auth0-oidc-client-net",
+    "reason": "First-party Auth0 OIDC client repository; the WinForms guidance resolves its current release version"
+  },
+  {
+    "code": "W012",
+    "skills": ["auth0"],
+    "url": "https://github.com/auth0/auth0-java-mvc-common",
+    "reason": "First-party Auth0 Java MVC repository; the Java guidance resolves its current release version"
+  },
+  {
+    "code": "W012",
     "url": "https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh",
     "reason": "First-party Auth0 CLI install script from Auth0-owned repository"
   },


### PR DESCRIPTION
This came up when I was reviewing PR https://github.com/auth0/agent-skills/pull/166

Adds three snyk-agent-scan ignore entries for first-party Auth0 URLs the skill legitimately references at runtime (auth0.com/pricing.md, auth0/auth0-oidc-client-net, auth0/auth0-java-mvc-common), so the W012 external-URL gate stops blocking PRs on them. Split out of #172 (Vercel), drop these same entries from #172.