### PR TITLE
chore(auth0): bump version to 2.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "path": "plugins/auth0"
       },
       "description": "Add Auth0 authentication to any app — login, MFA, SSO, Organizations, RBAC, ACUL, custom domains, and branding. Debug auth errors, validate JWTs, manage token lifecycles, and migrate from Clerk, Firebase, or Cognito. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, Spring Boot, Go, Swift, Android, Flutter, Laravel, PHP, ASP.NET Core, React Native, Expo, Ionic, .NET MAUI, and more.",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "repository": "https://github.com/auth0/agent-skills.git",
       "license": "Apache-2.0",
       "author": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Auth0 agent skills for authentication, SDK integration, migration, branding, custom domains, and MFA.",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "pluginRoot": "plugins"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "auth0",
       "source": "auth0",
       "description": "Add Auth0 authentication to any app — login, MFA, SSO, Organizations, RBAC, ACUL, custom domains, and branding. Debug auth errors, validate JWTs, manage token lifecycles, and migrate from Clerk, Firebase, or Cognito. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, Spring Boot, Go, Swift, Android, Flutter, Laravel, PHP, ASP.NET Core, React Native, Expo, Ionic, .NET MAUI, and more.",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "repository": "https://github.com/auth0/agent-skills.git",
       "license": "Apache-2.0",
       "author": {

--- a/plugins/auth0/.claude-plugin/plugin.json
+++ b/plugins/auth0/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A single unified Auth0 skill that detects your framework, feature, and tooling, then loads the right reference guides for adding authentication — login, MFA, Organizations, ACUL, custom domains, branding, JWT validation, migration, and debugging — to any app.",
   "author": {
     "name": "Auth0",

--- a/plugins/auth0/.codex-plugin/plugin.json
+++ b/plugins/auth0/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Add Auth0 authentication to any app — login, MFA, SSO, Organizations, RBAC, ACUL, custom domains, and branding. Debug auth errors, validate JWTs, manage token lifecycles, and migrate from Clerk, Firebase, or Cognito. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, Spring Boot, Go, Swift, Android, Flutter, Laravel, PHP, ASP.NET Core, React Native, Expo, Ionic, .NET MAUI, and more.",
   "skills": "./skills/",
   "author": {

--- a/plugins/auth0/.cursor-plugin/plugin.json
+++ b/plugins/auth0/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auth0",
   "displayName": "Auth0",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A single unified Auth0 skill that detects your framework, feature, and tooling, then loads the right reference guides for adding authentication — login, MFA, Organizations, ACUL, custom domains, branding, JWT validation, migration, and debugging — to any app.",
   "author": {
     "name": "Auth0",

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -4,7 +4,7 @@ description: Use when adding, fixing, or improving how an app authenticates user
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
-  version: '2.0.1'
+  version: '2.1.0'
   openclaw:
     emoji: "\U0001F510"
     homepage: https://github.com/auth0/agent-skills


### PR DESCRIPTION
## What

Bumps the plugin version `2.0.1 → 2.1.0` across all marketplace and plugin manifests so the release picks up the new **Vercel native integration reference** (merged in #172).

## Why

Minor bump: #172 added a new tooling capability (`tooling-vercel`) — new functionality, backward compatible.

## Changed

Version string updated in all 7 places (hand-maintained, no generator):

- `.claude-plugin/marketplace.json` — Claude marketplace
- `plugins/auth0/.claude-plugin/plugin.json` — Claude plugin
- `.cursor-plugin/marketplace.json` (×2: repo + plugin) — Cursor
- `plugins/auth0/.cursor-plugin/plugin.json` — Cursor plugin
- `plugins/auth0/.codex-plugin/plugin.json` — OpenAI/Codex
- `plugins/auth0/skills/auth0/SKILL.md` frontmatter

## Notes

- No content/behavior change — version strings only.
- Claude marketplace tracks the `main` snapshot and auto-discovers skills, so no external submission is needed for Claude. OpenAI/Codex public listing still requires separate portal submission (per `PLUGIN.md`).
- Per `PLUGIN.md` → Publishing, a `v2.1.0` tag should be cut after this merges.