### PR TITLE
feat(auth0): add Agent Plugins manifest

### DIFF
--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -1,6 +1,6 @@
 # Agent Plugin Architecture
 
-This repository provides one canonical Auth0 skill distributed through Claude Code, Cursor, and OpenAI/Codex plugin packaging. The OpenAI package is also usable by ChatGPT desktop through the universal plugin directory.
+This repository provides one canonical Auth0 skill distributed through Claude Code, Cursor, OpenAI/Codex, and the portable Agent Plugins package format. The OpenAI package is also usable by ChatGPT desktop through the universal plugin directory.
 
 ## Architecture Overview
 
@@ -67,6 +67,7 @@ auth0/agent-skills/
 │   └── marketplace.json          # Cursor marketplace metadata
 ├── plugins/
 │   └── auth0/                    # Single unified plugin
+│       ├── plugin.json            # Agent Plugins v1 portable manifest
 │       ├── .claude-plugin/
 │       │   └── plugin.json       # Claude plugin config
 │       ├── .cursor-plugin/
@@ -117,9 +118,16 @@ the OpenAI plugin submission portal.
 - Plugin configuration with source path
 - Skills are auto-discovered from the `skills/` directory within the plugin
 
+### plugins/auth0/plugin.json
+
+**Purpose**: Portable [Agent Plugins](https://agent-plugins.org/) v1 manifest.
+
+Agent Plugins clients discover `auth0` from `skills/auth0/SKILL.md`. This
+package does not include `mcp.json` because it does not bundle an MCP server.
+
 ### plugins/auth0/.claude-plugin/plugin.json
 
-**Purpose**: Plugin-specific configuration
+**Purpose**: Claude-specific plugin configuration.
 
 **Contains**:
 - Plugin name, display name, and version
@@ -162,6 +170,12 @@ UI to install Auth0 from the published `main` snapshot. Public distribution
 requires submission through https://platform.openai.com/plugins and OpenAI
 approval. See [`docs/openai-plugin.md`](docs/openai-plugin.md).
 
+### Agent Plugins-compatible clients
+
+Load `plugins/auth0` as a plugin directory using the client's install flow.
+Agent Plugins defines the portable package format, not a universal install
+command.
+
 ---
 
 ## Use Cases
@@ -179,6 +193,7 @@ no per-framework skill to pick.
 
 Edit the relevant marketplace and plugin manifests. For OpenAI/Codex, update
 `.agents/plugins/marketplace.json` and `plugins/auth0/.codex-plugin/plugin.json`.
+For Agent Plugins, update `plugins/auth0/plugin.json`.
 
 ### Create Release
 

--- a/plugins/auth0/README.md
+++ b/plugins/auth0/README.md
@@ -31,6 +31,12 @@ Then install the plugin:
 npx skills add auth0/agent-skills/plugins/auth0
 ```
 
+**Via an Agent Plugins-compatible client:**
+
+Load the `plugins/auth0` directory using the client's plugin install flow.
+[Agent Plugins](https://agent-plugins.org/) defines the portable package format,
+not a universal install command.
+
 ## Skills
 
 | Skill | Description | Documentation |

--- a/plugins/auth0/plugin.json
+++ b/plugins/auth0/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "auth0",
+  "version": "2.1.0",
+  "description": "A unified Auth0 skill that routes developers to the right guidance for adding, securing, debugging, or migrating authentication in any app.",
+  "author": {
+    "name": "Auth0",
+    "email": "support@auth0.com",
+    "url": "https://auth0.com"
+  },
+  "homepage": "https://auth0.com/docs/quickstart/agent-skills",
+  "repository": "https://github.com/auth0/agent-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "auth0",
+    "authentication",
+    "authorization",
+    "oauth",
+    "oidc",
+    "mfa",
+    "sdk"
+  ]
+}


### PR DESCRIPTION
## Summary
- add an Agent Plugins v1 manifest at `plugins/auth0/plugin.json`
- document loading the existing portable `skills/auth0` package in Agent Plugins-compatible clients
- clarify that Auth0 does not bundle an MCP server, so no `mcp.json` is included

## Validation
- validated `plugins/auth0/plugin.json` against the Agent Plugins v1 schema with AJV
- `uvx -q "skillsaw==0.16.0" --strict`
- `bash plugins/auth0/skills/auth0/scripts/validate-skill.sh`
- `uv run --with pytest python -m pytest scripts/test_check_router_reachability.py scripts/test_check_routing_evals.py -q`
- `uv run python scripts/check_router_reachability.py plugins/auth0/skills/auth0`
- `uv run python scripts/check_routing_evals.py plugins/auth0/skills/auth0`
- `npx skills add plugins/auth0 --list`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for distributing the Auth0 plugin in the portable Agent Plugins format.
  - Added installation guidance for Agent Plugins-compatible clients.
  - Added plugin metadata, including version, description, links, licensing, and authentication keywords.

- **Documentation**
  - Updated plugin documentation with directory structure, installation, manifest, and version-publishing guidance.
  - Clarified platform-specific plugin terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->