### PR TITLE
fix(auth0): correct CLI examples and document agent mode

### DIFF
--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -17,7 +17,7 @@ metadata:
     install:
       - id: brew
         kind: brew
-        formula: auth0/auth0-cli/auth0
+        formula: auth0
         bins: [auth0]
         label: 'Install Auth0 CLI (brew)'
 ---

--- a/plugins/auth0/skills/auth0/references/feature-audit-remediation/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-audit-remediation/index.md
@@ -10,30 +10,30 @@ For each item, build the command. **Use a first-class subcommand when one exists
 
 | Category | First-class command (if available) | Fallback `auth0 api` path |
 |---|---|---|
-| Tenant settings | `auth0 tenant-settings update set` / `unset` (flags only) | `PATCH /api/v2/tenants/settings` |
-| Brute-force protection | `auth0 protection brute-force-protection update` | `PATCH /api/v2/attack-protection/brute-force-protection` |
-| Breached password detection | `auth0 protection breached-password-detection update` | `PATCH /api/v2/attack-protection/breached-password-detection` |
-| Suspicious IP throttling | `auth0 protection suspicious-ip-throttling update` | `PATCH /api/v2/attack-protection/suspicious-ip-throttling` |
-| Branding (universal login, colors, logo) | `auth0 universal-login update` (alias `auth0 ul update`) | `PATCH /api/v2/branding` |
-| Custom domains | `auth0 domains create` / `update` | `POST/PATCH /api/v2/custom-domains` |
-| Connections (DB, social, enterprise) | (none) | `PATCH /api/v2/connections/{id}` (full options blob) |
-| APIs / resource servers | `auth0 apis update` | `PATCH /api/v2/resource-servers/{id}` |
-| Apps / clients (callbacks, origins, grant types, refresh tokens) | `auth0 apps update` | `PATCH /api/v2/clients/{id}` |
-| Roles | `auth0 roles update` | `PATCH /api/v2/roles/{id}` |
-| Actions | `auth0 actions create/update/deploy` | `POST/PATCH /api/v2/actions/actions` |
-| Log streams | `auth0 logs streams create <provider>` / `update <provider>` (provider is required: `eventbridge`, `eventgrid`, `http`, `datadog`, `splunk`, or `sumo`) | `POST/PATCH /api/v2/log-streams` |
-| Email provider/templates | `auth0 email provider update` / `auth0 email templates update` | `PATCH /api/v2/emails/provider` / `/api/v2/email-templates/{name}` |
-| MFA factor toggles | (none) | `PUT /api/v2/guardian/factors/{factor}` |
-| MFA policies | (none) | `PUT /api/v2/mfa/policies` |
-| Prompts customization | `auth0 universal-login prompts update <prompt>` (alias `auth0 ul prompts update`) | `PUT /api/v2/prompts/{prompt}/custom-text/{lang}` |
-| Network ACLs | `auth0 network-acl create` / `update <id>` | `POST/PATCH /api/v2/network-acls` |
-| Auth0 Organizations | `auth0 orgs create/update` | `POST/PATCH /api/v2/organizations` |
+| Tenant settings | `auth0 tenant-settings update set` / `unset` (flags only) | `PATCH tenants/settings` |
+| Brute-force protection | `auth0 protection brute-force-protection update` | `PATCH attack-protection/brute-force-protection` |
+| Breached password detection | `auth0 protection breached-password-detection update` | `PATCH attack-protection/breached-password-detection` |
+| Suspicious IP throttling | `auth0 protection suspicious-ip-throttling update` | `PATCH attack-protection/suspicious-ip-throttling` |
+| Branding (universal login, colors, logo) | `auth0 universal-login update` (alias `auth0 ul update`) | `PATCH branding` |
+| Custom domains | `auth0 domains create` / `update <id>` | `POST custom-domains` / `PATCH custom-domains/<domain-id>` |
+| Connections (DB, social, enterprise) | (none) | `PATCH connections/<connection-id>` (full options blob) |
+| APIs / resource servers | `auth0 apis update <id>` | `PATCH resource-servers/<api-id>` |
+| Apps / clients (callbacks, origins, grant types, refresh tokens) | `auth0 apps update <id>` | `PATCH clients/<app-id>` |
+| Roles | `auth0 roles update <id>` | `PATCH roles/<role-id>` |
+| Actions | `auth0 actions create/update <id>/deploy <id>` | `POST actions/actions` / `PATCH actions/actions/<action-id>` / `POST actions/actions/<action-id>/deploy` |
+| Log streams | `auth0 logs streams create <provider>` / `update <provider> <id>` (provider is required: `eventbridge`, `eventgrid`, `http`, `datadog`, `splunk`, or `sumo`) | `POST log-streams` / `PATCH log-streams/<log-stream-id>` |
+| Email provider/templates | `auth0 email provider update` / `auth0 email templates update` | `PATCH emails/provider` / `PATCH email-templates/<template-name>` |
+| MFA factor toggles | (none) | `PUT guardian/factors/<factor>` |
+| MFA policies | (none) | `PUT guardian/policies` |
+| Prompts customization | `auth0 universal-login prompts update <prompt>` (alias `auth0 ul prompts update`) | `PUT prompts/<prompt>/custom-text/<lang>` |
+| Network ACLs | `auth0 network-acl create` / `update <id>` | `POST network-acls` / `PATCH network-acls/<network-acl-id>` |
+| Auth0 Organizations | `auth0 orgs create` / `update <id>` | `POST organizations` / `PATCH organizations/<org-id>` |
 
-The fallback is `auth0 api <method> <path> --data '<json>'` — pick the method from the
-table's path column: `patch` for most resources, `put` for MFA factor toggles, MFA
-policies, and Prompts customization, and `post` when creating a resource. `patch` is not
-universal. Note that `auth0 api` defaults to `GET` without `--data` and `POST` with
-`--data`, so always state the method explicitly.
+The fallback column lists paths relative to the API root, as `auth0 api` expects.
+Pick the method from the table's path column: `patch` for most resources, `put` for MFA
+factor toggles, MFA policies, and Prompts customization, and `post` when creating a
+resource. `patch` is not universal. Note that `auth0 api` defaults to `GET` without
+`--data` and `POST` with `--data`, so always state the method explicitly.
 
 ## Fix dependencies / prerequisites
 

--- a/plugins/auth0/skills/auth0/references/feature-audit-remediation/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-audit-remediation/index.md
@@ -10,23 +10,23 @@ For each item, build the command. **Use a first-class subcommand when one exists
 
 | Category | First-class command (if available) | Fallback `auth0 api` path |
 |---|---|---|
-| Tenant settings | `auth0 tenants settings update` | `PATCH /api/v2/tenants/settings` |
+| Tenant settings | `auth0 tenant-settings update set` / `unset` (flags only) | `PATCH /api/v2/tenants/settings` |
 | Brute-force protection | `auth0 protection brute-force-protection update` | `PATCH /api/v2/attack-protection/brute-force-protection` |
 | Breached password detection | `auth0 protection breached-password-detection update` | `PATCH /api/v2/attack-protection/breached-password-detection` |
 | Suspicious IP throttling | `auth0 protection suspicious-ip-throttling update` | `PATCH /api/v2/attack-protection/suspicious-ip-throttling` |
-| Branding (universal login, colors, logo) | `auth0 branding update` / `auth0 universal-login update` | `PATCH /api/v2/branding` |
+| Branding (universal login, colors, logo) | `auth0 universal-login update` (alias `auth0 ul update`) | `PATCH /api/v2/branding` |
 | Custom domains | `auth0 domains create` / `update` | `POST/PATCH /api/v2/custom-domains` |
-| Connections (DB, social, enterprise) | `auth0 connections update <id>` | `PATCH /api/v2/connections/{id}` (full options blob) |
+| Connections (DB, social, enterprise) | (none) | `PATCH /api/v2/connections/{id}` (full options blob) |
 | APIs / resource servers | `auth0 apis update` | `PATCH /api/v2/resource-servers/{id}` |
 | Apps / clients (callbacks, origins, grant types, refresh tokens) | `auth0 apps update` | `PATCH /api/v2/clients/{id}` |
 | Roles | `auth0 roles update` | `PATCH /api/v2/roles/{id}` |
 | Actions | `auth0 actions create/update/deploy` | `POST/PATCH /api/v2/actions/actions` |
-| Log streams | `auth0 logs streams create/update` | `POST/PATCH /api/v2/log-streams` |
+| Log streams | `auth0 logs streams create <provider>` / `update <provider>` (provider is required: `eventbridge`, `eventgrid`, `http`, `datadog`, `splunk`, or `sumo`) | `POST/PATCH /api/v2/log-streams` |
 | Email provider/templates | `auth0 email provider update` / `auth0 email templates update` | `PATCH /api/v2/emails/provider` / `/api/v2/email-templates/{name}` |
 | MFA factor toggles | (none) | `PUT /api/v2/guardian/factors/{factor}` |
 | MFA policies | (none) | `PUT /api/v2/mfa/policies` |
-| Prompts customization | (none) | `PUT /api/v2/prompts/{prompt}/custom-text/{lang}` |
-| Network ACLs | (none) | `POST/PATCH /api/v2/network-acls` |
+| Prompts customization | `auth0 universal-login prompts update <prompt>` (alias `auth0 ul prompts update`) | `PUT /api/v2/prompts/{prompt}/custom-text/{lang}` |
+| Network ACLs | `auth0 network-acl create` / `update <id>` | `POST/PATCH /api/v2/network-acls` |
 | Auth0 Organizations | `auth0 orgs create/update` | `POST/PATCH /api/v2/organizations` |
 
 The fallback is `auth0 api <method> <path> --data '<json>'` — pick the method from the
@@ -102,7 +102,7 @@ Even in Express mode, these commands are blocked unless the user explicitly type
 - `auth0 logout`
 - `auth0 tenants delete`
 - `auth0 apps delete` (any app, especially the CheckMate app)
-- `auth0 connections delete`
+- `auth0 api delete "connections/<id>"` (no first-class delete command exists for connections)
 - `auth0 api delete <anything>`
 
 ## Closing the run

--- a/plugins/auth0/skills/auth0/references/feature-audit/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-audit/index.md
@@ -101,7 +101,7 @@ auth0 tenants list --json    # session active? returns tenants array
 ```
 
 If `--version` fails, install per platform:
-- macOS — `brew tap auth0/auth0-cli && brew install auth0`
+- macOS — `brew install auth0`
 - Linux / macOS (curl) — download the binary with `curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b .` (it lands in `./auth0`; move it onto `$PATH` with `sudo mv ./auth0 /usr/local/bin` if you want to run it from any directory)
 - Windows — `scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git && scoop install auth0`, or via PowerShell: fetch the latest release tag from the GitHub releases API, download `auth0-cli_<version>_Windows_x86_64.zip`, expand it, and add it to `$PATH`
 - Any platform with Go ≥ 1.21 — `go install github.com/auth0/auth0-cli/cmd/auth0@latest` (ensure `$GOPATH/bin` is on `$PATH`)

--- a/plugins/auth0/skills/auth0/references/feature-branding/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-branding/index.md
@@ -1017,21 +1017,23 @@ active tenant untouched. Both tenants must already appear in
 `auth0 tenants list`, otherwise the CLI fails with `Failed to find tenant`.
 
 ```bash
+set -euo pipefail
+
 SOURCE_TENANT=source-tenant.auth0.com
 TARGET_TENANT=target-tenant.auth0.com
 
 # Export from source tenant
 BRANDING=$(auth0 api get "branding" --tenant "$SOURCE_TENANT")
-THEME=$(auth0 api get "branding/themes/default" --tenant "$SOURCE_TENANT" 2>/dev/null)
-TEMPLATE=$(auth0 api get "branding/templates/universal-login" --tenant "$SOURCE_TENANT" 2>/dev/null)
-LOGIN_TEXT=$(auth0 api get "prompts/login/custom-text/en" --tenant "$SOURCE_TENANT" 2>/dev/null)
+THEME=$(auth0 api get "branding/themes/default" --tenant "$SOURCE_TENANT" 2>/dev/null || true)
+TEMPLATE=$(auth0 api get "branding/templates/universal-login" --tenant "$SOURCE_TENANT" 2>/dev/null || true)
+LOGIN_TEXT=$(auth0 api get "prompts/login/custom-text/en" --tenant "$SOURCE_TENANT" 2>/dev/null || true)
 
 # Import to target tenant
 printf '%s' "$BRANDING" | auth0 api patch "branding" --tenant "$TARGET_TENANT"
 
 if [ -n "$THEME" ]; then
   THEME_BODY=$(printf '%s' "$THEME" | jq 'del(.themeId)')
-  TARGET_THEME_ID=$(auth0 api get "branding/themes/default" --tenant "$TARGET_TENANT" 2>/dev/null | jq -r '.themeId // empty')
+  TARGET_THEME_ID=$(auth0 api get "branding/themes/default" --tenant "$TARGET_TENANT" 2>/dev/null | jq -r '.themeId // empty' || true)
   if [ -n "$TARGET_THEME_ID" ]; then
     printf '%s' "$THEME_BODY" | auth0 api patch "branding/themes/$TARGET_THEME_ID" --tenant "$TARGET_TENANT"
   else

--- a/plugins/auth0/skills/auth0/references/feature-branding/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-branding/index.md
@@ -1010,30 +1010,41 @@ branding/
 
 ### Copy branding between tenants
 
-```bash
-# Export from source tenant
-AUTH0_TENANT=source-tenant.auth0.com
+`--tenant` is the only way to pick a tenant per call, so pass it on every export
+and import. Without it both halves hit the active tenant and the import
+overwrites the tenant you just exported from. Passing it per call also leaves the
+active tenant untouched. Both tenants must already appear in
+`auth0 tenants list`, otherwise the CLI fails with `Failed to find tenant`.
 
-BRANDING=$(auth0 api get "branding")
-THEME=$(auth0 api get "branding/themes/default" 2>/dev/null)
-TEMPLATE=$(auth0 api get "branding/templates/universal-login" 2>/dev/null)
-LOGIN_TEXT=$(auth0 api get "prompts/login/custom-text/en" 2>/dev/null)
+```bash
+SOURCE_TENANT=source-tenant.auth0.com
+TARGET_TENANT=target-tenant.auth0.com
+
+# Export from source tenant
+BRANDING=$(auth0 api get "branding" --tenant "$SOURCE_TENANT")
+THEME=$(auth0 api get "branding/themes/default" --tenant "$SOURCE_TENANT" 2>/dev/null)
+TEMPLATE=$(auth0 api get "branding/templates/universal-login" --tenant "$SOURCE_TENANT" 2>/dev/null)
+LOGIN_TEXT=$(auth0 api get "prompts/login/custom-text/en" --tenant "$SOURCE_TENANT" 2>/dev/null)
 
 # Import to target tenant
-AUTH0_TENANT=target-tenant.auth0.com
-
-printf '%s' "$BRANDING" | auth0 api patch "branding"
+printf '%s' "$BRANDING" | auth0 api patch "branding" --tenant "$TARGET_TENANT"
 
 if [ -n "$THEME" ]; then
-  printf '%s' "$THEME" | auth0 api post "branding/themes"
+  THEME_BODY=$(printf '%s' "$THEME" | jq 'del(.themeId)')
+  TARGET_THEME_ID=$(auth0 api get "branding/themes/default" --tenant "$TARGET_TENANT" 2>/dev/null | jq -r '.themeId // empty')
+  if [ -n "$TARGET_THEME_ID" ]; then
+    printf '%s' "$THEME_BODY" | auth0 api patch "branding/themes/$TARGET_THEME_ID" --tenant "$TARGET_TENANT"
+  else
+    printf '%s' "$THEME_BODY" | auth0 api post "branding/themes" --tenant "$TARGET_TENANT"
+  fi
 fi
 
 if [ -n "$TEMPLATE" ]; then
-  printf '%s' "$TEMPLATE" | auth0 api put "branding/templates/universal-login"
+  printf '%s' "$TEMPLATE" | auth0 api put "branding/templates/universal-login" --tenant "$TARGET_TENANT"
 fi
 
 if [ -n "$LOGIN_TEXT" ]; then
-  printf '%s' "$LOGIN_TEXT" | auth0 api put "prompts/login/custom-text/en"
+  printf '%s' "$LOGIN_TEXT" | auth0 api put "prompts/login/custom-text/en" --tenant "$TARGET_TENANT"
 fi
 ```
 

--- a/plugins/auth0/skills/auth0/references/feature-branding/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-branding/index.md
@@ -77,7 +77,7 @@ If **no**: end with the summary of what was written.
 Notes:
 - This applies to Capability 1 (Brand my tenant), Capability 2 (Change specific settings), Capability 3 (Match my brand voice), and Capability 4 (Rollback to Auth0 defaults). In the rollback case, the browser page should render Auth0's built-in defaults — that's the verification.
 - Capability 5 (Check my setup) is read-only; skip this step.
-- If the user has a preferred client they test against, they'll mention it; `auth0 test login --client-id <id>` targets a specific app. Otherwise use the default.
+- If the user has a preferred client they test against, they'll mention it; `auth0 test login <id>` targets a specific app. Otherwise use the default.
 
 ## Key Concepts
 
@@ -253,7 +253,7 @@ auth0 ul update --accent "#0059DB" --background "#FFFFFF" \
 auth0 ul templates show
 
 # Update page template from file
-auth0 ul templates update --file login.liquid
+cat login.liquid | auth0 ul templates update
 
 # Update page template (interactive)
 auth0 ul templates update
@@ -288,7 +288,7 @@ auth0 ul switch
 auth0 test login
 
 # Test with specific client
-auth0 test login --client-id "{appClientId}"
+auth0 test login "{appClientId}"
 
 # Test with organization context
 auth0 test login --organization org_abc123
@@ -981,10 +981,10 @@ auth0 ul update \
   --favicon "https://cdn.example.com/favicon.ico" \
   --no-input
 
-auth0 ul templates update --file ./branding/login-template.liquid --no-input
+cat ./branding/login-template.liquid | auth0 ul templates update
 
-auth0 api put "prompts/login/custom-text/en" --data @./branding/text-login-en.json
-auth0 api put "prompts/signup/custom-text/en" --data @./branding/text-signup-en.json
+cat ./branding/text-login-en.json | auth0 ul prompts update login --language en
+cat ./branding/text-signup-en.json | auth0 ul prompts update signup --language en
 ```
 
 ### Multi-environment layout
@@ -1014,26 +1014,26 @@ branding/
 # Export from source tenant
 AUTH0_TENANT=source-tenant.auth0.com
 
-BRANDING=$(auth0 api get "branding" --json)
-THEME=$(auth0 api get "branding/themes/default" --json 2>/dev/null)
-TEMPLATE=$(auth0 api get "branding/templates/universal-login" --json 2>/dev/null)
-LOGIN_TEXT=$(auth0 api get "prompts/login/custom-text/en" --json 2>/dev/null)
+BRANDING=$(auth0 api get "branding")
+THEME=$(auth0 api get "branding/themes/default" 2>/dev/null)
+TEMPLATE=$(auth0 api get "branding/templates/universal-login" 2>/dev/null)
+LOGIN_TEXT=$(auth0 api get "prompts/login/custom-text/en" 2>/dev/null)
 
 # Import to target tenant
 AUTH0_TENANT=target-tenant.auth0.com
 
-echo "$BRANDING" | auth0 api patch "branding" --data @-
+printf '%s' "$BRANDING" | auth0 api patch "branding"
 
 if [ -n "$THEME" ]; then
-  echo "$THEME" | auth0 api post "branding/themes" --data @-
+  printf '%s' "$THEME" | auth0 api post "branding/themes"
 fi
 
 if [ -n "$TEMPLATE" ]; then
-  echo "$TEMPLATE" | auth0 api put "branding/templates/universal-login" --data @-
+  printf '%s' "$TEMPLATE" | auth0 api put "branding/templates/universal-login"
 fi
 
 if [ -n "$LOGIN_TEXT" ]; then
-  echo "$LOGIN_TEXT" | auth0 api put "prompts/login/custom-text/en" --data @-
+  printf '%s' "$LOGIN_TEXT" | auth0 api put "prompts/login/custom-text/en"
 fi
 ```
 
@@ -1044,15 +1044,15 @@ fi
 auth0 test login
 
 # Test with a specific application
-auth0 test login --client-id "{yourAppClientId}"
+auth0 test login "{yourAppClientId}"
 
 # Test with organization context (for B2B branding)
 auth0 test login --organization org_abc123
 
 # Verify via API
-auth0 api get "branding" --json | jq '.colors'
-auth0 api get "branding/themes/default" --json | jq '.colors.primary_button'
-auth0 api get "branding/templates/universal-login" --json | jq '.template' | head -1
+auth0 api get "branding" | jq '.colors'
+auth0 api get "branding/themes/default" | jq '.colors.primary_button'
+auth0 api get "branding/templates/universal-login" | jq '.template' | head -1
 ```
 
 ---

--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -52,13 +52,18 @@ Multi-Factor Authentication (MFA) requires users to provide two or more verifica
 
 ### Via Auth0 CLI
 
-Enforcing MFA takes **two calls, both required, in this order**:
-`PUT guardian/factors/<factor>` makes a factor available, then
-`PUT guardian/policies` makes MFA required. A factor alone never prompts anyone;
-a policy alone leaves users with no usable factor.
+Enforcing MFA takes **two independent calls**: `PUT guardian/factors/<factor>`
+makes a factor available, and `PUT guardian/policies` makes MFA required.
+Configure the factor first — not because the API requires that order, but
+because a policy set before any factor is available leaves users with no way
+to complete MFA. A factor alone never prompts anyone.
 
-Enforcement is the Guardian policy, not a post-login Action calling
-`api.multifactor.enable()`. Actions are for adaptive rules layered on top.
+The Guardian policy provides tenant-wide baseline enforcement. A post-login
+Action calling `api.multifactor.enable()` is a second, independent
+enforcement path — it can require MFA conditionally (based on risk, client,
+scopes, etc.) and can override the global policy for that login. Actions
+aren't limited to adaptive rules layered on top of the policy; they're a
+full alternative way to enforce MFA.
 
 ```bash
 # View current MFA configuration (read factors from the collection path)

--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -52,8 +52,16 @@ Multi-Factor Authentication (MFA) requires users to provide two or more verifica
 
 ### Via Auth0 CLI
 
+Enforcing MFA takes **two calls, both required, in this order**:
+`PUT guardian/factors/<factor>` makes a factor available, then
+`PUT guardian/policies` makes MFA required. A factor alone never prompts anyone;
+a policy alone leaves users with no usable factor.
+
+Enforcement is the Guardian policy, not a post-login Action calling
+`api.multifactor.enable()`. Actions are for adaptive rules layered on top.
+
 ```bash
-# View current MFA configuration
+# View current MFA configuration (read factors from the collection path)
 auth0 api get "guardian/factors"
 
 # Enable TOTP (One-time Password)
@@ -77,9 +85,18 @@ auth0 api put "guardian/factors/email" --data '{"enabled": true}'
 
 ### Configure MFA Policy
 
+Use **`put`** with a bare JSON array. This endpoint replaces the whole policy
+list, so a wrong verb here answers with a 404 that reads like a path or
+permissions problem.
+
 ```bash
 # Set MFA policy: "all-applications" or "confidence-score"
-auth0 api patch "guardian/policies" --data '["all-applications"]'
+auth0 api put "guardian/policies" --data '["all-applications"]'
+auth0 api put "guardian/policies" --data '[]'    # unenforce
+
+# Verify both halves: enabled factor(s) AND a non-empty policy
+auth0 api get "guardian/factors" | jq -c '[.[] | select(.enabled == true)]'
+auth0 api get "guardian/policies"
 ```
 
 ### Same configuration in Terraform
@@ -87,7 +104,7 @@ auth0 api patch "guardian/policies" --data '["all-applications"]'
 The CLI commands above are one way to enable factors and set the policy. If the
 project is infrastructure-as-code, the loaded tooling reference gives the
 equivalent:
-- CLI: `auth0 api put guardian/factors/...` + `auth0 api patch guardian/policies`
+- CLI: `auth0 api put guardian/factors/...` + `auth0 api put guardian/policies`
 - Terraform: `auth0_guardian` resource (`policy` + per-factor blocks)
 - MCP: not available — the Auth0 MCP server exposes no Guardian/MFA tool; use the CLI or Terraform.
 
@@ -311,13 +328,13 @@ The `amr` (Authentication Methods Reference) claim indicates how the user authen
 ### Test Commands
 
 ```bash
-# Check if MFA is enabled
+# Check which factors are available
 auth0 api get "guardian/factors"
 
 # List user's enrollments
 auth0 api get "users/USER_ID/authenticators"
 
-# Check MFA policy
+# Check whether MFA is actually enforced. `[]` means available but not required.
 auth0 api get "guardian/policies"
 ```
 

--- a/plugins/auth0/skills/auth0/references/feature-migration/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-migration/index.md
@@ -1275,7 +1275,7 @@ Auth0 supports these password hashing algorithms:
 **Prerequisites:**
 ```bash
 # Install Auth0 CLI
-brew install auth0/auth0-cli/auth0
+brew install auth0
 
 # Login
 auth0 login
@@ -1284,7 +1284,7 @@ auth0 login
 **Import users:**
 ```bash
 # Get connection ID
-auth0 connections list
+auth0 api get connections
 
 # Import users
 auth0 api post "jobs/users-imports" \
@@ -1507,19 +1507,17 @@ Track migration for each user:
 
 ```bash
 # Get total users in Auth0
-auth0 users list --number 1
+auth0 api get "users?per_page=1&include_totals=true" | jq '.total'
 
-# Or via API
-curl "https://YOUR_DOMAIN.auth0.com/api/v2/users?per_page=1" \
-  -H "Authorization: Bearer YOUR_MGMT_API_TOKEN" \
-  | jq '.total'
+# Spot-check a specific migrated user
+auth0 users search --query "email:user@example.com"
 ```
 
 ### Test Login
 
 ```bash
 # Test user can login
-auth0 test login --client-id YOUR_CLIENT_ID
+auth0 test login YOUR_CLIENT_ID
 ```
 
 ### Verify Password Hashes Work

--- a/plugins/auth0/skills/auth0/references/feature-organizations/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-organizations/index.md
@@ -107,6 +107,31 @@ inferring them from the field they set.
 Reading connections back returns a **bare array**, so use `jq '.[]'`, not
 `jq '.enabled_connections[]'`.
 
+### Finding or creating a login connection
+
+An organization with no enabled connection has no way for its members to log in.
+Reuse an existing database connection when the tenant has one, and only create
+one when it does not:
+
+```bash
+# Reuse: first database connection in the tenant, if any.
+auth0 api get "connections?strategy=auth0" | jq -r '.[0].id // empty'
+
+# Create one only if there is none. `name` must match
+# ^[a-zA-Z0-9](-[a-zA-Z0-9]|[a-zA-Z0-9])*$, max 128 chars.
+auth0 api post connections --data '{"name":"<connection-name>","strategy":"auth0"}'
+
+# Enable it for each app that will use it — status false disables. Max 50 per call.
+auth0 api patch "connections/<con-id>/clients" \
+  --data '[{"client_id":"<client-id>","status":true}]'
+
+# Read back which apps are enabled.
+auth0 api get "connections/<con-id>/clients" | jq -r '.clients[].client_id'
+```
+
+The read is checkpoint-paginated: `take` defaults to 50 (max 1000), and a `next`
+token comes back while more remain, so pass it as `from` until `next` is absent.
+
 ---
 
 ## Invitation flow
@@ -131,6 +156,18 @@ The tenant setting is `default_redirection_uri`, validated as
 `absolute-https-uri-or-empty`: it must be https, and `localhost` is rejected on
 either scheme, so a local-dev URL will not satisfy it.
 
+`default_redirection_uri` is **tenant-wide**, not per app or per organization, so
+setting it changes login behaviour for everything in the tenant. Read the current
+value before you write it, and put it back afterwards if the invitation was the
+only reason you set it:
+
+```bash
+auth0 api get "tenants/settings" | jq -r '.default_redirection_uri // "unset"'
+```
+
+If you keep the new value, say so in your summary. Silently repointing a shared
+tenant setting is the kind of change someone else has to debug.
+
 ```bash
 auth0 orgs invitations create --org-id "<org-id>" \
   --invitee-email "user@company.com" --inviter-name "Admin" \
@@ -152,6 +189,10 @@ auth0 orgs invitations create --org-id "<org-id>" \
 | Mixing up org `id` (org_xxx) and `name` (slug) | `id` for API calls, `name` for display |
 | Granting global roles instead of org-level roles | Use the org member roles endpoint, not the user roles endpoint |
 | Not enabling a connection for the org | `auth0 api post "organizations/<org-id>/enabled_connections"`, or Dashboard → Organization → Connections |
+| A space or underscore in a new connection's `name` | Alphanumerics and hyphens only, starting and ending alphanumeric. Anything else is a 400 |
+| Creating a connection and enabling it for no app | Nothing can use it. `auth0 api patch "connections/<con-id>/clients" --data '[{"client_id":"<client-id>","status":true}]'` |
+| Reading or writing `enabled_clients` on the connection object | "NOT RECOMMENDED" on write, deprecated on read. Use `GET`/`PATCH connections/<con-id>/clients` |
+| Overwriting `default_redirection_uri` without reading it first | It is tenant-wide. Capture the old value, and restore or disclose it |
 | Guessing a `auth0 orgs` subcommand for membership, roles, or connections | Verify with `auth0 commands orgs --detailed`, and use `auth0 api post organizations/...` for whatever has no dedicated subcommand |
 | Prefixing `auth0 api` paths with `/api/v2/` | Paths are relative to the API root. `/api/v2/organizations/...` returns 404 |
 | Inviting before setting `organization_usage` on the app and `default_redirection_uri` on the tenant | Both are hard 400s. Configure them first (see Invitation flow) |

--- a/plugins/auth0/skills/auth0/references/feature-organizations/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-organizations/index.md
@@ -89,35 +89,57 @@ app.get('/api/data', checkJwt, (req, res) => {
 
 See your tooling reference file for the full command syntax. The Auth0 MCP server
 exposes **no** organizations tool, so for an MCP-only session fall back to the CLI
-or Terraform. The operations are:
+or Terraform.
 
-**Create an organization:**
-- CLI: `auth0 orgs create`
-- Terraform: `auth0_organization` resource
+| Operation | CLI | Terraform |
+|---|---|---|
+| Create an organization | `auth0 orgs create --name <slug> --display "<Name>"` | `auth0_organization` |
+| List / show / update / delete | `auth0 orgs list` / `show` / `update` / `delete` | `auth0_organization` |
+| Add a member | `auth0 api post "organizations/<org-id>/members" --data '{"members":["<user-id>"]}'` | `auth0_organization_member` |
+| Enable a connection | `auth0 api post "organizations/<org-id>/enabled_connections" --data '{"connection_id":"<con-id>","assign_membership_on_login":true}'` | `auth0_organization_connections` |
+| Assign an org-scoped role | `auth0 api post "organizations/<org-id>/members/<user-id>/roles" --data '{"roles":["<role-id>"]}'` | `auth0_organization_member_roles` |
+| Create an invitation | `auth0 orgs invitations create` (see below) | not covered |
 
-**Add a member:**
-- CLI: `auth0 orgs members add`
-- Terraform: `auth0_organization_member` resource
+Check `auth0 commands orgs --detailed` for the current subcommand surface before
+falling back to `auth0 api`, and read flag names off `--help` rather than
+inferring them from the field they set.
 
-**Enable a connection for an org:**
-- CLI: `auth0 orgs connections add`
-- Terraform: `auth0_organization_connections` resource
-
-**Assign a role within an org:**
-- CLI: `auth0 orgs roles assign`
-- Management API: `POST /api/v2/organizations/{id}/members/{user_id}/roles`
+Reading connections back returns a **bare array**, so use `jq '.[]'`, not
+`jq '.enabled_connections[]'`.
 
 ---
 
 ## Invitation flow
 
+An invitation lets you add a user who has no Auth0 account yet. The invitee gets
+a link, authenticates, and becomes a member.
+
+**Two prerequisites, each a hard 400.** Do both before the first
+`invitations create` call:
+
 ```bash
-# Create an invitation (user doesn't need an Auth0 account yet)
-auth0 api post /api/v2/organizations/{org_id}/invitations \
-  --data '{"invitee":{"email":"user@company.com"},"inviter":{"name":"Admin"},"client_id":"YOUR_CLIENT_ID"}'
+# 1. Without this: "The specified client_id (...) does not allow organizations."
+auth0 api patch "clients/<client-id>" \
+  --data '{"organization_usage":"allow","organization_require_behavior":"no_prompt"}'
+
+# 2. Without this: "A default login route is required to generate the invitation url."
+auth0 api patch "tenants/settings" \
+  --data '{"default_redirection_uri":"https://app.example.com/callback"}'
 ```
 
-The invitee receives an email. When they click the link, they authenticate and are added as a member.
+The tenant setting is `default_redirection_uri`, validated as
+`absolute-https-uri-or-empty`: it must be https, and `localhost` is rejected on
+either scheme, so a local-dev URL will not satisfy it.
+
+```bash
+auth0 orgs invitations create --org-id "<org-id>" \
+  --invitee-email "user@company.com" --inviter-name "Admin" \
+  --client-id "<client-id>" --roles "<role-id>" --send-email=false
+```
+
+`--send-email` **defaults to `true`**, and it needs the `=` form, since
+`--send-email false` reads `false` as a positional argument. Verify with
+`auth0 orgs invitations list --org-id <org-id>`.
 
 ---
 
@@ -129,7 +151,11 @@ The invitee receives an email. When they click the link, they authenticate and a
 | Using `org_id` from ID token on backend | Validate from the access token, not ID token |
 | Mixing up org `id` (org_xxx) and `name` (slug) | `id` for API calls, `name` for display |
 | Granting global roles instead of org-level roles | Use the org member roles endpoint, not the user roles endpoint |
-| Not enabling a connection for the org | Dashboard → Organization → Connections → enable the connection |
+| Not enabling a connection for the org | `auth0 api post "organizations/<org-id>/enabled_connections"`, or Dashboard → Organization → Connections |
+| Guessing a `auth0 orgs` subcommand for membership, roles, or connections | Verify with `auth0 commands orgs --detailed`, and use `auth0 api post organizations/...` for whatever has no dedicated subcommand |
+| Prefixing `auth0 api` paths with `/api/v2/` | Paths are relative to the API root. `/api/v2/organizations/...` returns 404 |
+| Inviting before setting `organization_usage` on the app and `default_redirection_uri` on the tenant | Both are hard 400s. Configure them first (see Invitation flow) |
+| Letting `auth0 orgs invitations create` send a live email | `--send-email` defaults to `true`. Pass `--send-email=false` |
 
 ---
 

--- a/plugins/auth0/skills/auth0/references/feature-organizations/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-organizations/index.md
@@ -114,12 +114,17 @@ Reuse an existing database connection when the tenant has one, and only create
 one when it does not:
 
 ```bash
-# Reuse: first database connection in the tenant, if any.
-auth0 api get "connections?strategy=auth0" | jq -r '.[0].id // empty'
+# List database connections in the tenant and pick one explicitly by name —
+# the API defines no ordering, so `.[0]` silently grabs an arbitrary connection.
+auth0 api get "connections?strategy=auth0" | jq -r '.[] | select(.name=="<connection-name>") | .id'
 
-# Create one only if there is none. `name` must match
+# Create one only if there is none matching. `name` must match
 # ^[a-zA-Z0-9](-[a-zA-Z0-9]|[a-zA-Z0-9])*$, max 128 chars.
 auth0 api post connections --data '{"name":"<connection-name>","strategy":"auth0"}'
+
+# Enable it for the organization — without this, org members have no way to log in.
+auth0 api post "organizations/<org-id>/enabled_connections" \
+  --data '{"connection_id":"<con-id>","assign_membership_on_login":true}'
 
 # Enable it for each app that will use it — status false disables. Max 50 per call.
 auth0 api patch "connections/<con-id>/clients" \
@@ -131,6 +136,15 @@ auth0 api get "connections/<con-id>/clients" | jq -r '.clients[].client_id'
 
 The read is checkpoint-paginated: `take` defaults to 50 (max 1000), and a `next`
 token comes back while more remain, so pass it as `from` until `next` is absent.
+If listing to find a match automatically rather than by a known name, page
+through all results and fail rather than guess unless exactly one connection
+matches.
+
+`connections/<con-id>/clients` only enables the connection for applications —
+it does not make the connection usable by the organization. An org whose
+connection is enabled for clients but never added to
+`organizations/<org-id>/enabled_connections` still has no way for members to
+log in.
 
 ---
 
@@ -148,6 +162,10 @@ auth0 api patch "clients/<client-id>" \
   --data '{"organization_usage":"allow","organization_require_behavior":"no_prompt"}'
 
 # 2. Without this: "A default login route is required to generate the invitation url."
+#    Read the current value FIRST — the setting is tenant-wide, and you may need
+#    to restore it. An empty response means it's currently unset.
+auth0 api get "tenants/settings" | jq -r '.default_redirection_uri // ""'
+
 auth0 api patch "tenants/settings" \
   --data '{"default_redirection_uri":"https://app.example.com/callback"}'
 ```
@@ -157,13 +175,10 @@ The tenant setting is `default_redirection_uri`, validated as
 either scheme, so a local-dev URL will not satisfy it.
 
 `default_redirection_uri` is **tenant-wide**, not per app or per organization, so
-setting it changes login behaviour for everything in the tenant. Read the current
-value before you write it, and put it back afterwards if the invitation was the
-only reason you set it:
-
-```bash
-auth0 api get "tenants/settings" | jq -r '.default_redirection_uri // "unset"'
-```
+setting it changes login behaviour for everything in the tenant. Put the
+captured value back afterwards if the invitation was the only reason you set
+it — restore it to an empty string (`{"default_redirection_uri":""}`), not the
+literal text `"unset"`, if it was empty before.
 
 If you keep the new value, say so in your summary. Silently repointing a shared
 tenant setting is the kind of change someone else has to debug.

--- a/plugins/auth0/skills/auth0/references/framework-android/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-android/index.md
@@ -1092,7 +1092,7 @@ SCHEME="demo"
 
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
-  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0/auth0-cli/auth0 || \
+  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0 || \
   curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
 fi
 

--- a/plugins/auth0/skills/auth0/references/framework-android/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-android/index.md
@@ -1148,31 +1148,17 @@ for c in data:
         print(c['id'])
         break
 " 2>/dev/null)
-ENABLED_CLIENTS=$(echo "$CONNECTIONS_JSON" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for c in data:
-    if c.get('name') == 'Username-Password-Authentication':
-        print(json.dumps(c.get('enabled_clients', [])))
-        break
-" 2>/dev/null)
-
 if [ -z "$CONNECTION_ID" ]; then
-  auth0 api post connections \
-    --data "{\"strategy\":\"auth0\",\"name\":\"Username-Password-Authentication\",\"enabled_clients\":[\"$CLIENT_ID\"]}" \
-    --no-input > /dev/null
-else
-  UPDATED_CLIENTS=$(echo "$ENABLED_CLIENTS" | python3 -c "
-import sys, json
-clients = json.load(sys.stdin)
-if '$CLIENT_ID' not in clients:
-    clients.append('$CLIENT_ID')
-print(json.dumps(clients))
-")
-  auth0 api patch "connections/$CONNECTION_ID" \
-    --data "{\"enabled_clients\":$UPDATED_CLIENTS}" \
-    --no-input > /dev/null
+  CONNECTION_ID=$(auth0 api post connections \
+    --data "{\"strategy\":\"auth0\",\"name\":\"Username-Password-Authentication\"}" \
+    --no-input | grep -o '"id":"con_[^"]*' | head -1 | cut -d'"' -f4)
 fi
+
+# Enable the connection for this app. Only the client_id sent changes, so re-running
+# this is safe.
+auth0 api patch "connections/$CONNECTION_ID/clients" \
+  --data "[{\"client_id\":\"$CLIENT_ID\",\"status\":true}]" \
+  --no-input > /dev/null
 
 # Write / update strings.xml
 STRINGS_FILE="$PROJECT_PATH/app/src/main/res/values/strings.xml"

--- a/plugins/auth0/skills/auth0/references/framework-android/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-android/index.md
@@ -1151,7 +1151,11 @@ for c in data:
 if [ -z "$CONNECTION_ID" ]; then
   CONNECTION_ID=$(auth0 api post connections \
     --data "{\"strategy\":\"auth0\",\"name\":\"Username-Password-Authentication\"}" \
-    --no-input | grep -o '"id":"con_[^"]*' | head -1 | cut -d'"' -f4)
+    --no-input | python3 -c "import sys, json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
+fi
+if [ -z "$CONNECTION_ID" ]; then
+  echo "Failed to find or create the Username-Password-Authentication connection." >&2
+  exit 1
 fi
 
 # Enable the connection for this app. Only the client_id sent changes, so re-running

--- a/plugins/auth0/skills/auth0/references/framework-angular/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-angular/index.md
@@ -794,7 +794,7 @@ Complete setup instructions for Angular applications.
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
+    brew install auth0
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Download and review the install script before executing
     curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh

--- a/plugins/auth0/skills/auth0/references/framework-aspnetcore-api/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-aspnetcore-api/index.md
@@ -765,7 +765,7 @@ Below uses the Auth0 CLI to create an Auth0 API resource and retrieve your crede
 
 ```bash
 # Install Auth0 CLI (macOS)
-brew install auth0/auth0-cli/auth0
+brew install auth0
 
 # Login
 auth0 login --no-input

--- a/plugins/auth0/skills/auth0/references/framework-aspnetcore-auth/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-aspnetcore-auth/index.md
@@ -1121,7 +1121,7 @@ Then ask the user for explicit confirmation before proceeding — do not continu
 
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
-  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0/auth0-cli/auth0 || \
+  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0 || \
   curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
 fi
 

--- a/plugins/auth0/skills/auth0/references/framework-expo/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-expo/index.md
@@ -1030,13 +1030,13 @@ If using refresh token rotation, configure a token overlap period of at least **
 >    ```bash
 >    auth0 api get "connections" --query "name=Username-Password-Authentication" --no-input
 >    ```
->    Parse the response to extract the connection `id` and its current `enabled_clients` array. Append the new client_id to the existing array and patch:
+>    Parse the response to extract the connection `id`. If it doesn't exist, create it:
 >    ```bash
->    auth0 api patch "connections/CONNECTION_ID" --data '{"enabled_clients":["EXISTING_IDS...", "NEW_CLIENT_ID"]}' --no-input
+>    auth0 api post "connections" --data '{"strategy":"auth0","name":"Username-Password-Authentication"}' --no-input
 >    ```
->    If it doesn't exist, create it:
+>    Then enable it for the client:
 >    ```bash
->    auth0 api post "connections" --data '{"strategy":"auth0","name":"Username-Password-Authentication","enabled_clients":["CLIENT_ID"]}' --no-input
+>    auth0 api patch "connections/CONNECTION_ID/clients" --data '[{"client_id":"NEW_CLIENT_ID","status":true}]' --no-input
 >    ```
 >
 > 5. **Write the plugin config to app.json** using the Edit tool — add `react-native-auth0` to the plugins array with the domain and custom scheme. Do not echo credentials in your response.

--- a/plugins/auth0/skills/auth0/references/framework-expo/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-expo/index.md
@@ -1030,11 +1030,14 @@ If using refresh token rotation, configure a token overlap period of at least **
 >    ```bash
 >    auth0 api get "connections" --query "name=Username-Password-Authentication" --no-input
 >    ```
->    Parse the response to extract the connection `id`. If it doesn't exist, create it:
+>    Parse the response to extract the connection `id` as `CONNECTION_ID`. If it doesn't exist, create it and parse `id` from the create response as `CONNECTION_ID` instead:
+>
 >    ```bash
 >    auth0 api post "connections" --data '{"strategy":"auth0","name":"Username-Password-Authentication"}' --no-input
 >    ```
->    Then enable it for the client:
+>
+>    Then enable it for the client, using the `CONNECTION_ID` found above (existing) or just created:
+>
 >    ```bash
 >    auth0 api patch "connections/CONNECTION_ID/clients" --data '[{"client_id":"NEW_CLIENT_ID","status":true}]' --no-input
 >    ```

--- a/plugins/auth0/skills/auth0/references/framework-express/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-express/index.md
@@ -723,7 +723,7 @@ Then ask the user for explicit confirmation before proceeding — do not continu
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
+    brew install auth0
   else
     # Download and review the install script before executing
     curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh

--- a/plugins/auth0/skills/auth0/references/framework-fastapi-api/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-fastapi-api/index.md
@@ -987,7 +987,7 @@ Below uses the Auth0 CLI to create an Auth0 API resource and retrieve your crede
 
 ```bash
 # Install Auth0 CLI (macOS)
-brew install auth0/auth0-cli/auth0
+brew install auth0
 
 # Login
 auth0 login --no-input

--- a/plugins/auth0/skills/auth0/references/framework-flask/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flask/index.md
@@ -948,7 +948,7 @@ Then ask the user for explicit confirmation before proceeding — do not continu
 
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
-  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0/auth0-cli/auth0 || \
+  [[ "$OSTYPE" == "darwin"* ]] && brew install auth0 || \
   curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
 fi
 

--- a/plugins/auth0/skills/auth0/references/framework-go/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-go/index.md
@@ -1289,7 +1289,7 @@ Setup instructions for Go API applications.
 > **INITIAL SETUP (steps 1–6) — always run during automated setup:**
 >
 > 1. **Check Auth0 CLI**: Run `command -v auth0`. If missing, ask user to install (`brew install auth0`) or switch to manual setup.
-> 2. **Check Auth0 login**: Run `auth0 tenants list --csv --no-input 2>&1`. If it fails or returns empty:
+> 2. **Check Auth0 login**: Run `auth0 tenants list --csv --no-input`. If it fails or returns empty:
 >    - Tell the user: _"Please run `auth0 login` in your terminal and let me know when done."_
 >    - Wait for the user to confirm, then re-run the check to verify.
 > 3. **Confirm active tenant**: Parse the output to identify the active tenant domain. Tell the user: _"Your active Auth0 tenant is: `<domain>`. Is this the correct tenant?"_
@@ -1298,7 +1298,7 @@ Setup instructions for Go API applications.
 > 4. **Create the Auth0 API resource**: Ask for the API name, identifier, and scopes (see SKILL.md checkpoints 4–5 for exact prompts).
 >    **Before creating**, check if an API with the same identifier already exists:
 >    ```bash
->    auth0 apis list --json 2>&1 | grep -c "<INTENDED_IDENTIFIER>"
+>    auth0 apis list | jq -r '.[].identifier' | grep -cx "<INTENDED_IDENTIFIER>"
 >    ```
 >    If it already exists, ask the user: _"An API with identifier `<ID>` already exists. Would you like to reuse it, or should I create a new one with a different identifier?"_
 >    If creating new:

--- a/plugins/auth0/skills/auth0/references/framework-go/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-go/index.md
@@ -1288,7 +1288,7 @@ Setup instructions for Go API applications.
 > ---
 > **INITIAL SETUP (steps 1–6) — always run during automated setup:**
 >
-> 1. **Check Auth0 CLI**: Run `command -v auth0`. If missing, ask user to install (`brew install auth0/auth0-cli/auth0`) or switch to manual setup.
+> 1. **Check Auth0 CLI**: Run `command -v auth0`. If missing, ask user to install (`brew install auth0`) or switch to manual setup.
 > 2. **Check Auth0 login**: Run `auth0 tenants list --csv --no-input 2>&1`. If it fails or returns empty:
 >    - Tell the user: _"Please run `auth0 login` in your terminal and let me know when done."_
 >    - Wait for the user to confirm, then re-run the check to verify.
@@ -1406,7 +1406,7 @@ Below uses the Auth0 CLI to create an Auth0 API resource and retrieve your crede
 
 ```bash
 # Install Auth0 CLI (macOS)
-brew install auth0/auth0-cli/auth0
+brew install auth0
 
 # Login (opens browser for authentication)
 auth0 login

--- a/plugins/auth0/skills/auth0/references/framework-go/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-go/index.md
@@ -1298,7 +1298,9 @@ Setup instructions for Go API applications.
 > 4. **Create the Auth0 API resource**: Ask for the API name, identifier, and scopes (see SKILL.md checkpoints 4–5 for exact prompts).
 >    **Before creating**, check if an API with the same identifier already exists:
 >    ```bash
->    auth0 apis list | jq -r '.[].identifier' | grep -cx "<INTENDED_IDENTIFIER>"
+>    auth0 apis list --json-compact |
+>      jq -r --arg id "<INTENDED_IDENTIFIER>" \
+>        '[.[] | select(.identifier == $id)] | length'
 >    ```
 >    If it already exists, ask the user: _"An API with identifier `<ID>` already exists. Would you like to reuse it, or should I create a new one with a different identifier?"_
 >    If creating new:

--- a/plugins/auth0/skills/auth0/references/framework-ionic-angular/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-angular/index.md
@@ -12,7 +12,7 @@ Add authentication to an Ionic Angular application using the `@auth0/auth0-angul
 - Node.js 20+ and npm 10+
 - Ionic CLI (`npm install -g @ionic/cli`)
 - Capacitor 5+ configured in the project
-- Auth0 CLI (for automatic setup): `brew install auth0/auth0-cli/auth0`
+- Auth0 CLI (for automatic setup): `brew install auth0`
 - An Auth0 account (free tier works)
 
 ## When NOT to Use
@@ -1034,7 +1034,7 @@ auth0 tenants list --csv --no-input
 If the Auth0 CLI is not installed, instruct the user:
 ```bash
 # macOS
-brew install auth0/auth0-cli/auth0
+brew install auth0
 
 # Linux
 curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh

--- a/plugins/auth0/skills/auth0/references/framework-ionic-angular/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-angular/index.md
@@ -1084,18 +1084,16 @@ auth0 api get connections
 
 Parse the JSON array to find the connection with `"name": "Username-Password-Authentication"`.
 
-- **If it exists** but doesn't include the new `client_id` in `enabled_clients`, update it:
-  ```bash
-  auth0 api patch "connections/CONNECTION_ID" --data '{"enabled_clients":["EXISTING_ID_1","EXISTING_ID_2","NEW_CLIENT_ID"]}'
-  ```
-  Keep all existing `enabled_clients` and append the new one.
-
 - **If it doesn't exist**, create it:
   ```bash
-  auth0 api post connections --data '{"strategy":"auth0","name":"Username-Password-Authentication","enabled_clients":["CLIENT_ID"]}'
+  auth0 api post connections --data '{"strategy":"auth0","name":"Username-Password-Authentication"}'
   ```
 
-- **If it already includes the client_id**, skip this step.
+- Then enable it for the new client. Running this when the client is already enabled is
+  a no-op, so it needs no check first:
+  ```bash
+  auth0 api patch "connections/CONNECTION_ID/clients" --data '[{"client_id":"NEW_CLIENT_ID","status":true}]'
+  ```
 
 #### Step A6: Write config file
 

--- a/plugins/auth0/skills/auth0/references/framework-ionic-angular/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-angular/index.md
@@ -1084,13 +1084,16 @@ auth0 api get connections
 
 Parse the JSON array to find the connection with `"name": "Username-Password-Authentication"`.
 
-- **If it doesn't exist**, create it:
+- **If it doesn't exist**, create it and parse `id` from the response as `CONNECTION_ID`:
+
   ```bash
   auth0 api post connections --data '{"strategy":"auth0","name":"Username-Password-Authentication"}'
   ```
 
-- Then enable it for the new client. Running this when the client is already enabled is
-  a no-op, so it needs no check first:
+- Then enable it for the new client, using the `CONNECTION_ID` found above (existing) or
+  just created. Running this when the client is already enabled is a no-op, so it needs
+  no check first:
+
   ```bash
   auth0 api patch "connections/CONNECTION_ID/clients" --data '[{"client_id":"NEW_CLIENT_ID","status":true}]'
   ```

--- a/plugins/auth0/skills/auth0/references/framework-ionic-react/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-react/index.md
@@ -11,7 +11,7 @@ Add Auth0 authentication to Ionic React applications using Capacitor. This skill
 - Auth0 account and tenant
 - For iOS: Xcode 14+ and CocoaPods
 - For Android: Android Studio with API level 21+
-- Auth0 CLI — `brew install auth0/auth0-cli/auth0`
+- Auth0 CLI — `brew install auth0`
 
 ## When NOT to Use
 
@@ -862,7 +862,7 @@ npx cap open android  # Build and run on device from Android Studio
 
 > **Agent instruction:** Run these pre-flight checks before creating the Auth0 application. Do NOT run `auth0 login` from the agent — it is interactive and will hang.
 >
-> 1. **Check Auth0 CLI**: `command -v auth0`. If missing, install it: `brew install auth0/auth0-cli/auth0`.
+> 1. **Check Auth0 CLI**: `command -v auth0`. If missing, install it: `brew install auth0`.
 > 2. **Check Auth0 login**: `auth0 tenants list --csv --no-input 2>&1`. If it fails or returns empty:
 >    - Tell the user: _"Please run `auth0 login` in your terminal and let me know when done."_
 >    - Wait for confirmation, then re-run the check. Retry up to 3 times before treating as a persistent failure.

--- a/plugins/auth0/skills/auth0/references/framework-ionic-react/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-react/index.md
@@ -863,7 +863,7 @@ npx cap open android  # Build and run on device from Android Studio
 > **Agent instruction:** Run these pre-flight checks before creating the Auth0 application. Do NOT run `auth0 login` from the agent — it is interactive and will hang.
 >
 > 1. **Check Auth0 CLI**: `command -v auth0`. If missing, install it: `brew install auth0`.
-> 2. **Check Auth0 login**: `auth0 tenants list --csv --no-input 2>&1`. If it fails or returns empty:
+> 2. **Check Auth0 login**: `auth0 tenants list --csv --no-input`. If it fails or returns empty:
 >    - Tell the user: _"Please run `auth0 login` in your terminal and let me know when done."_
 >    - Wait for confirmation, then re-run the check. Retry up to 3 times before treating as a persistent failure.
 > 3. **Confirm active tenant**: Parse the `→` line from the CSV output. Tell the user: _"Your active Auth0 tenant is: `<domain>`. Is this correct?"_

--- a/plugins/auth0/skills/auth0/references/framework-ionic-vue/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-vue/index.md
@@ -1002,7 +1002,7 @@ npx cap open android  # Build and run on device from Android Studio
 > #### Step B — Verify Auth0 CLI login session
 >
 > ```bash
-> auth0 tenants list --csv --no-input 2>&1
+> auth0 tenants list --csv --no-input
 > ```
 >
 > - **If the command succeeds** and returns CSV output with tenant rows: proceed to Step C.

--- a/plugins/auth0/skills/auth0/references/framework-ionic-vue/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-vue/index.md
@@ -15,7 +15,7 @@ Add Auth0 authentication to Ionic Vue applications using Capacitor. This skill c
 - Auth0 account and tenant
 - For iOS: Xcode 14+ and CocoaPods
 - For Android: Android Studio with API level 21+
-- Auth0 CLI — `brew install auth0/auth0-cli/auth0`
+- Auth0 CLI — `brew install auth0`
 
 ## When NOT to Use
 
@@ -993,7 +993,7 @@ npx cap open android  # Build and run on device from Android Studio
 >
 > If missing, install it:
 > ```bash
-> brew install auth0/auth0-cli/auth0
+> brew install auth0
 > ```
 > On Linux: `curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh`
 >

--- a/plugins/auth0/skills/auth0/references/framework-java-mvc/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-java-mvc/index.md
@@ -1105,7 +1105,7 @@ Or manually in Auth0 Dashboard:
 
 ```bash
 # List existing connections
-auth0 connections list --json
+auth0 api get connections
 
 # Enable your app on the default database connection
 # (done automatically if using Option A: Automatic Setup)

--- a/plugins/auth0/skills/auth0/references/framework-nextjs/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-nextjs/index.md
@@ -710,7 +710,7 @@ Then ask the user for explicit confirmation before proceeding — do not continu
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
+    brew install auth0
   else
     # Download and review the install script before executing
     curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh

--- a/plugins/auth0/skills/auth0/references/framework-php-api/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-php-api/index.md
@@ -1304,7 +1304,7 @@ Then determine the target file using this precedence: `.env.local` (if present),
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
+    brew install auth0
   else
     curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
     echo "Review the install script at /tmp/auth0-install.sh before running"

--- a/plugins/auth0/skills/auth0/references/framework-php/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-php/index.md
@@ -1379,7 +1379,7 @@ Then determine the target file using this precedence: `.env.local` (if present),
 # Install Auth0 CLI
 if ! command -v auth0 &> /dev/null; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
+    brew install auth0
   else
     curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
     echo "Review the install script at /tmp/auth0-install.sh before running"

--- a/plugins/auth0/skills/auth0/references/framework-react/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-react/index.md
@@ -1679,7 +1679,7 @@ iwr -useb get.scoop.sh | iex
 
 **Browser doesn't open:**
 ```bash
-auth0 login --domain "$AUTH0_DOMAIN" --client-id "$AUTH0_CLIENT_ID" --client-secret "$AUTH0_CLIENT_SECRET"
+auth0 login --no-input   # prints the URL and code instead of opening a browser
 ```
 
 **"Not logged in" error:**

--- a/plugins/auth0/skills/auth0/references/framework-react/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-react/index.md
@@ -1399,7 +1399,7 @@ if ! command -v auth0 &> /dev/null; then
       echo "   https://github.com/auth0/auth0-cli#installation"
       exit 1
     fi
-    brew install auth0/auth0-cli/auth0
+    brew install auth0
   elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
     echo "Please install Auth0 CLI: https://github.com/auth0/auth0-cli#installation"
     exit 1
@@ -1595,13 +1595,13 @@ npm install @auth0/auth0-react
 
 **macOS:**
 ```bash
-brew install auth0/auth0-cli/auth0
+brew install auth0
 ```
 
 **Linux (via Homebrew):**
 ```bash
 # Requires Homebrew on Linux: https://brew.sh
-brew install auth0/auth0-cli/auth0
+brew install auth0
 ```
 
 **Windows:**
@@ -1679,14 +1679,13 @@ iwr -useb get.scoop.sh | iex
 
 **Browser doesn't open:**
 ```bash
-# Use device code flow
-auth0 login --no-browser
+auth0 login --domain "$AUTH0_DOMAIN" --client-id "$AUTH0_CLIENT_ID" --client-secret "$AUTH0_CLIENT_SECRET"
 ```
 
 **"Not logged in" error:**
 ```bash
-# Force new login
-auth0 login --force
+auth0 logout
+auth0 login
 ```
 
 ### Environment Variable Issues

--- a/plugins/auth0/skills/auth0/references/framework-spa-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-spa-js/index.md
@@ -1160,7 +1160,7 @@ Still, follow these practices:
 
 **Browser doesn't open for login:**
 ```bash
-auth0 login --domain "$AUTH0_DOMAIN" --client-id "$AUTH0_CLIENT_ID" --client-secret "$AUTH0_CLIENT_SECRET"
+auth0 login --no-input   # prints the URL and code instead of opening a browser
 ```
 
 **"Not logged in" error:**

--- a/plugins/auth0/skills/auth0/references/framework-spa-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-spa-js/index.md
@@ -903,7 +903,7 @@ Then ask the user for explicit confirmation before proceeding — do not continu
 if ! command -v auth0 &> /dev/null; then
   echo "Installing Auth0 CLI..."
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
+    brew install auth0
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b /usr/local/bin
   else
@@ -1060,7 +1060,7 @@ npm install @auth0/auth0-spa-js
 
 **macOS:**
 ```bash
-brew install auth0/auth0-cli/auth0
+brew install auth0
 ```
 
 **Linux:**
@@ -1160,12 +1160,13 @@ Still, follow these practices:
 
 **Browser doesn't open for login:**
 ```bash
-auth0 login --no-browser
+auth0 login --domain "$AUTH0_DOMAIN" --client-id "$AUTH0_CLIENT_ID" --client-secret "$AUTH0_CLIENT_SECRET"
 ```
 
 **"Not logged in" error:**
 ```bash
-auth0 login --force
+auth0 logout
+auth0 login
 ```
 
 ---

--- a/plugins/auth0/skills/auth0/references/framework-springboot-api/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-springboot-api/index.md
@@ -1005,7 +1005,7 @@ Uses the Auth0 CLI to create an Auth0 API resource and configure your project.
 
 ```bash
 # Install Auth0 CLI (macOS)
-brew install auth0/auth0-cli/auth0
+brew install auth0
 
 # Login
 auth0 login --no-input

--- a/plugins/auth0/skills/auth0/references/framework-swift/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift/index.md
@@ -980,10 +980,10 @@ func fetchData() async throws -> [Item] {
 > **Pre-flight checks:**
 >
 > 1. **Check Auth0 CLI**: `command -v auth0`. If missing, install it: `brew install auth0`.
-> 2. **Check Auth0 login**: `auth0 tenants list --csv --no-input > /tmp/auth0-tenants.txt`. Read the file to check the result. If it fails or returns empty:
+> 2. **Check Auth0 login**: redirect to a private temp file the same way (`OUT=$(mktemp -t auth0-tenants); auth0 tenants list --csv --no-input > "$OUT"`). Read `$OUT` to check the result, then `rm -f "$OUT"`. If it fails or returns empty:
 >    - Tell the user: _"Please run `auth0 login` in your terminal and let me know when done."_
 >    - Wait for confirmation, then re-run the check. Retry up to 3 times before treating as a persistent failure.
-> 3. **Confirm active tenant**: Redirect tenant list output to a file and read it. Parse the `→` line to extract the domain. Tell the user using a masked format: _"Your active Auth0 tenant is: `your-te****.us.auth0.com`. Is this correct? (Recommend using a development/test tenant rather than production.)"_ — mask all but the first 7 characters of the subdomain.
+> 3. **Confirm active tenant**: Parse the `→` line from step 2's output to extract the domain. Tell the user using a masked format: _"Your active Auth0 tenant is: `your-te****.us.auth0.com`. Is this correct? (Recommend using a development/test tenant rather than production.)"_ — mask all but the first 7 characters of the subdomain.
 >    - If no, ask the user to run `auth0 tenants use <tenant-domain>`, then re-run step 2.
 >
 > **Detect project settings:**
@@ -993,8 +993,10 @@ func fetchData() async throws -> [Item] {
 >
 > **Create the Auth0 application:**
 >
-> 6. **Create a Native application** with both HTTPS and custom scheme callback URLs:
+> 6. **Create a Native application** with both HTTPS and custom scheme callback URLs (use a fresh `mktemp` for `$OUT`, the same way as step 2):
+>
 >    ```bash
+>    OUT=$(mktemp -t auth0-app-created)
 >    auth0 apps create \
 >      --name "BUNDLE_ID-ios" \
 >      --type native \
@@ -1002,22 +1004,32 @@ func fetchData() async throws -> [Item] {
 >      --callbacks "https://DOMAIN/ios/BUNDLE_ID/callback,BUNDLE_ID://DOMAIN/ios/BUNDLE_ID/callback" \
 >      --logout-urls "https://DOMAIN/ios/BUNDLE_ID/callback,BUNDLE_ID://DOMAIN/ios/BUNDLE_ID/callback" \
 >      --json \
->      --no-input > /tmp/auth0-app-created.json
+>      --no-input > "$OUT"
 >    ```
->    Read `/tmp/auth0-app-created.json` to extract `client_id`. Do not display the file contents in the terminal.
 >
-> 7. **Set up database connection**: Check whether `Username-Password-Authentication` already exists:
+>    Read `$OUT` to extract `client_id`, then `rm -f "$OUT"`. Do not display the file contents in the terminal.
+>
+> 7. **Set up database connection**: check whether `Username-Password-Authentication` already exists (reuse the same `$OUT` pattern):
+>
 >    ```bash
->    auth0 api get connections --no-input > /tmp/auth0-connections.json
+>    OUT=$(mktemp -t auth0-connections)
+>    auth0 api get connections --no-input > "$OUT"
 >    ```
->    Read `/tmp/auth0-connections.json` to check existing connections.
->    - If the connection does not exist, create it:
+>
+>    Read `$OUT` to check existing connections, then `rm -f "$OUT"`.
+>    - If the connection exists, set `CONNECTION_ID` to its `id` from that file.
+>    - If it does not exist, create it and set `CONNECTION_ID` to the `id` in the response — it is never assigned otherwise:
+>
 >      ```bash
+>      OUT=$(mktemp -t auth0-connection-created)
 >      auth0 api post connections \
 >        --data '{"strategy":"auth0","name":"Username-Password-Authentication"}' \
->        --no-input > /dev/null 2>&1
+>        --no-input > "$OUT"
 >      ```
+>
+>      Read `$OUT` to extract `id` as `CONNECTION_ID`, then `rm -f "$OUT"`.
 >    - Then enable it for the client, whether or not the connection already existed:
+>
 >      ```bash
 >      auth0 api patch connections/CONNECTION_ID/clients \
 >        --data '[{"client_id":"CLIENT_ID","status":true}]' \

--- a/plugins/auth0/skills/auth0/references/framework-swift/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift/index.md
@@ -1006,7 +1006,7 @@ func fetchData() async throws -> [Item] {
 >    ```
 >    Read `/tmp/auth0-app-created.json` to extract `client_id`. Do not display the file contents in the terminal.
 >
-> 7. **Set up database connection**: Check if `Username-Password-Authentication` already exists and has the new client enabled:
+> 7. **Set up database connection**: Check whether `Username-Password-Authentication` already exists:
 >    ```bash
 >    auth0 api get connections --no-input > /tmp/auth0-connections.json 2>&1
 >    ```
@@ -1014,16 +1014,15 @@ func fetchData() async throws -> [Item] {
 >    - If the connection does not exist, create it:
 >      ```bash
 >      auth0 api post connections \
->        --data '{"strategy":"auth0","name":"Username-Password-Authentication","enabled_clients":["CLIENT_ID"]}' \
+>        --data '{"strategy":"auth0","name":"Username-Password-Authentication"}' \
 >        --no-input > /dev/null 2>&1
 >      ```
->    - If it exists but the client is not in `enabled_clients`, update it:
+>    - Then enable it for the client, whether or not the connection already existed:
 >      ```bash
->      auth0 api patch connections/CONNECTION_ID \
->        --data '{"enabled_clients":["EXISTING_CLIENT_1","EXISTING_CLIENT_2","CLIENT_ID"]}' \
+>      auth0 api patch connections/CONNECTION_ID/clients \
+>        --data '[{"client_id":"CLIENT_ID","status":true}]' \
 >        --no-input > /dev/null 2>&1
 >      ```
->    - If it exists and already includes the client, skip this step.
 >
 > 8. **Configure Device Settings** (for Universal Links — Auth0 hosts `apple-app-site-association`):
 >    If Team ID was detected in step 5:

--- a/plugins/auth0/skills/auth0/references/framework-swift/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift/index.md
@@ -21,7 +21,7 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 - **Xcode** 16.x
 - **Swift** 6.0+
 - Auth0 account — [Sign up free](https://auth0.com/signup)
-- Auth0 CLI — `brew install auth0/auth0-cli/auth0` (for automated setup)
+- Auth0 CLI — `brew install auth0` (for automated setup)
 
 ## Quick Start Workflow
 
@@ -971,7 +971,7 @@ func fetchData() async throws -> [Item] {
 > ```bash
 > umask 077
 > OUT=$(mktemp -t auth0-output)
-> auth0 <command> --json --no-input > "$OUT" 2>&1
+> auth0 <command> --no-input > "$OUT" 2>&1
 > echo "$OUT"   # note the path; do NOT print the file contents
 > ```
 >
@@ -979,7 +979,7 @@ func fetchData() async throws -> [Item] {
 >
 > **Pre-flight checks:**
 >
-> 1. **Check Auth0 CLI**: `command -v auth0`. If missing, install it: `brew install auth0/auth0-cli/auth0`.
+> 1. **Check Auth0 CLI**: `command -v auth0`. If missing, install it: `brew install auth0`.
 > 2. **Check Auth0 login**: `auth0 tenants list --csv --no-input > /tmp/auth0-tenants.txt 2>&1`. Read the file to check the result. If it fails or returns empty:
 >    - Tell the user: _"Please run `auth0 login` in your terminal and let me know when done."_
 >    - Wait for confirmation, then re-run the check. Retry up to 3 times before treating as a persistent failure.

--- a/plugins/auth0/skills/auth0/references/framework-swift/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift/index.md
@@ -29,7 +29,7 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 >
 > **IMPORTANT — Credential privacy:** Never echo Auth0 credentials (domain, client ID, client secret) in your response text or terminal output. Write them directly into config files using the Write or Edit tool. When running Auth0 CLI commands that produce output containing these values, redirect output to a file and read it programmatically. For example:
 > ```bash
-> auth0 apps create ... --json --no-input > /tmp/auth0-output.json 2>&1
+> auth0 apps create ... --json --no-input > /tmp/auth0-output.json
 > ```
 > Then use the Read tool on `/tmp/auth0-output.json` to extract needed values and write them directly into `Auth0.plist` or other config files — never echo them in response text or terminal. When confirming the active tenant with the user, use a masked format (e.g., `your-te****.us.auth0.com`).
 
@@ -89,7 +89,7 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 >
 > First, retrieve existing callback and logout URLs to avoid overwriting them:
 > ```bash
-> auth0 apps show CLIENT_ID --json --no-input > /tmp/auth0-app-info.json 2>&1
+> auth0 apps show CLIENT_ID --json --no-input > /tmp/auth0-app-info.json
 > ```
 > Read `/tmp/auth0-app-info.json` to extract existing `callbacks` and `allowed_logout_urls` arrays.
 >
@@ -113,7 +113,7 @@ Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, wat
 >
 > First, retrieve existing callback and logout URLs to avoid overwriting them:
 > ```bash
-> auth0 apps show CLIENT_ID --json --no-input > /tmp/auth0-app-info.json 2>&1
+> auth0 apps show CLIENT_ID --json --no-input > /tmp/auth0-app-info.json
 > ```
 > Read `/tmp/auth0-app-info.json` to extract existing `callbacks` and `allowed_logout_urls` arrays.
 >
@@ -971,7 +971,7 @@ func fetchData() async throws -> [Item] {
 > ```bash
 > umask 077
 > OUT=$(mktemp -t auth0-output)
-> auth0 <command> --no-input > "$OUT" 2>&1
+> auth0 <command> --no-input > "$OUT"
 > echo "$OUT"   # note the path; do NOT print the file contents
 > ```
 >
@@ -980,7 +980,7 @@ func fetchData() async throws -> [Item] {
 > **Pre-flight checks:**
 >
 > 1. **Check Auth0 CLI**: `command -v auth0`. If missing, install it: `brew install auth0`.
-> 2. **Check Auth0 login**: `auth0 tenants list --csv --no-input > /tmp/auth0-tenants.txt 2>&1`. Read the file to check the result. If it fails or returns empty:
+> 2. **Check Auth0 login**: `auth0 tenants list --csv --no-input > /tmp/auth0-tenants.txt`. Read the file to check the result. If it fails or returns empty:
 >    - Tell the user: _"Please run `auth0 login` in your terminal and let me know when done."_
 >    - Wait for confirmation, then re-run the check. Retry up to 3 times before treating as a persistent failure.
 > 3. **Confirm active tenant**: Redirect tenant list output to a file and read it. Parse the `→` line to extract the domain. Tell the user using a masked format: _"Your active Auth0 tenant is: `your-te****.us.auth0.com`. Is this correct? (Recommend using a development/test tenant rather than production.)"_ — mask all but the first 7 characters of the subdomain.
@@ -1002,13 +1002,13 @@ func fetchData() async throws -> [Item] {
 >      --callbacks "https://DOMAIN/ios/BUNDLE_ID/callback,BUNDLE_ID://DOMAIN/ios/BUNDLE_ID/callback" \
 >      --logout-urls "https://DOMAIN/ios/BUNDLE_ID/callback,BUNDLE_ID://DOMAIN/ios/BUNDLE_ID/callback" \
 >      --json \
->      --no-input > /tmp/auth0-app-created.json 2>&1
+>      --no-input > /tmp/auth0-app-created.json
 >    ```
 >    Read `/tmp/auth0-app-created.json` to extract `client_id`. Do not display the file contents in the terminal.
 >
 > 7. **Set up database connection**: Check whether `Username-Password-Authentication` already exists:
 >    ```bash
->    auth0 api get connections --no-input > /tmp/auth0-connections.json 2>&1
+>    auth0 api get connections --no-input > /tmp/auth0-connections.json
 >    ```
 >    Read `/tmp/auth0-connections.json` to check existing connections.
 >    - If the connection does not exist, create it:

--- a/plugins/auth0/skills/auth0/references/framework-vue/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-vue/index.md
@@ -1053,7 +1053,7 @@ VITE_AUTH0_CLIENT_ID=<your-client-id>
 
 **Browser doesn't open:**
 ```bash
-auth0 login --domain "$AUTH0_DOMAIN" --client-id "$AUTH0_CLIENT_ID" --client-secret "$AUTH0_CLIENT_SECRET"
+auth0 login --no-input   # prints the URL and code instead of opening a browser
 ```
 
 **"Not logged in" error:**

--- a/plugins/auth0/skills/auth0/references/framework-vue/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-vue/index.md
@@ -837,7 +837,7 @@ Run this script to automatically set up everything:
 if ! command -v auth0 &> /dev/null; then
   echo "Installing Auth0 CLI..."
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install auth0/auth0-cli/auth0
+    brew install auth0
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Download and review the install script before executing
     curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh -o /tmp/auth0-install.sh
@@ -983,7 +983,7 @@ npm install @auth0/auth0-vue
 
 **macOS:**
 ```bash
-brew install auth0/auth0-cli/auth0
+brew install auth0
 ```
 
 **Linux (review script before executing):**
@@ -1053,12 +1053,13 @@ VITE_AUTH0_CLIENT_ID=<your-client-id>
 
 **Browser doesn't open:**
 ```bash
-auth0 login --no-browser
+auth0 login --domain "$AUTH0_DOMAIN" --client-id "$AUTH0_CLIENT_ID" --client-secret "$AUTH0_CLIENT_SECRET"
 ```
 
 **"Not logged in" error:**
 ```bash
-auth0 login --force
+auth0 logout
+auth0 login
 ```
 
 ### CORS Errors

--- a/plugins/auth0/skills/auth0/references/pattern-multi-tenant/index.md
+++ b/plugins/auth0/skills/auth0/references/pattern-multi-tenant/index.md
@@ -67,7 +67,8 @@ function requireOrg(orgId) {
 Each Organization can have dedicated enterprise connections (Okta SAML, Azure AD, Google Workspace):
 
 ```bash
-auth0 orgs connections add --org-id org_xxx --connection-id con_xxx
+auth0 api post "organizations/org_xxx/enabled_connections" \
+  --data '{"connection_id":"con_xxx","assign_membership_on_login":true}'
 ```
 
 Users in that org authenticate through their company's IdP automatically.

--- a/plugins/auth0/skills/auth0/references/pattern-rate-limiting/index.md
+++ b/plugins/auth0/skills/auth0/references/pattern-rate-limiting/index.md
@@ -46,7 +46,8 @@ The `retry-after` header tells you exactly how many seconds to wait.
 Use the bulk import API instead of individual user creation calls:
 
 ```bash
-auth0 api post /api/v2/jobs/users-imports \
+# Paths are relative to the Management API root — no /api/v2/ prefix.
+auth0 api post "jobs/users-imports" \
   --data '{"users": [...], "connection_id": "con_xxx", "upsert": true}'
 ```
 

--- a/plugins/auth0/skills/auth0/references/tooling-cli/index.md
+++ b/plugins/auth0/skills/auth0/references/tooling-cli/index.md
@@ -11,6 +11,7 @@ Install with: `brew install auth0`
 
 ```bash
 auth0 login                          # interactive device-code login
+auth0 login --no-input               # headless: prints the URL and code, no browser
 auth0 login --scopes "read:stats"  # request extra scopes if 403
 auth0 login --domain <tenant>.auth0.com --client-id <id> --client-secret "$AUTH0_CLIENT_SECRET"  # CI/CD
 ```
@@ -67,7 +68,7 @@ optional resource that may not exist.
 Agent mode disables prompts, so instead of silently deleting, destructive
 commands **refuse to run** without `--force`:
 
-```
+```text
 This is a destructive command; re-run with --force to proceed without a confirmation prompt.
 ```
 
@@ -166,7 +167,7 @@ auth0 apps update --help | jq -r '.[0].flags[].name'
 |-------------------|---------------|
 | Discovering which command to run | `auth0 commands --flat` |
 | Checking a command's flags | `auth0 <command> --help` |
-| Setting up a new project | `auth0 apps create --type spa\|regular\|m2m\|native` |
+| Setting up a new project | `auth0 apps create --type spa` (see App types below) |
 | Need a client ID or secret | `auth0 apps show <id> -r` |
 | Registering a backend API | `auth0 apis create --identifier "https://..."` |
 | Authorizing an M2M app for an API | `auth0 client-grants create` |
@@ -188,7 +189,7 @@ auth0 apps update --help | jq -r '.[0].flags[].name'
 | Token exchange / custom auth profiles | `auth0 token-exchange create` |
 | Anything with no dedicated command | `auth0 api get <path>` |
 | Security hardening | `auth0 protection brute-force-protection update --enabled true` |
-| Routing logs externally | `auth0 logs streams create datadog\|http\|splunk` |
+| Routing logs externally | `auth0 logs streams create datadog` (one subcommand per provider) |
 | Bulk importing users | `auth0 users import --connection-name ...` |
 
 ---
@@ -472,7 +473,8 @@ Method defaults to `GET` without data and `POST` with data. If a call returns
 
 ## Piping to `jq`
 
-Agent mode already emits JSON on stdout, so redirect stderr and pipe:
+Agent mode already emits JSON on stdout and keeps its banners on stderr, so
+leave stderr alone and pipe stdout:
 
 ```bash
 auth0 apps list | jq '.[] | {client_id, name}'

--- a/plugins/auth0/skills/auth0/references/tooling-cli/index.md
+++ b/plugins/auth0/skills/auth0/references/tooling-cli/index.md
@@ -100,8 +100,8 @@ case check the flag exists first (see the next section).
 | Running as an agent | Nothing. Agent mode already emits JSON. |
 | `auth0 api ...` | Never pass `--json`. It returns JSON only and **rejects the flag** with `Unknown flag: --json`. |
 | Scripting outside an agent session | Add `--json`, but confirm the command defines it. |
-| Piping large output to `jq` | `--json-compact` (defined on 125 commands). |
-| Spreadsheet / tabular export | `--csv` (defined on 32 `list`/`search` commands). |
+| Piping large output to `jq` | `--json-compact` (defined on most `list`/`show` commands). |
+| Spreadsheet / tabular export | `--csv` (defined on many `list`/`search` commands). |
 | Any non-interactive run | `--no-input` so the CLI errors instead of prompting. |
 
 Roughly a third of runnable commands define **no** JSON flag at all. These are

--- a/plugins/auth0/skills/auth0/references/tooling-cli/index.md
+++ b/plugins/auth0/skills/auth0/references/tooling-cli/index.md
@@ -121,6 +121,24 @@ auth0 apps create --help --json           # same JSON when agent mode is off
 
 ---
 
+## Value Syntax Rules
+
+**List values are comma-joined in one argument.** Space-separating them makes the
+extras look like positional args (`Accepts at most 1 arg(s), received 3`):
+
+```bash
+auth0 roles permissions add <role-id> --api-id <api-id> --permissions "read:data,write:data"
+auth0 apis create --name "My API" --identifier "https://api.example.com" --scopes "read:data,write:data"
+```
+
+**Boolean flags need the `=` form.** `--send-email false` reads `false` as a
+positional arg, so a default-`true` flag silently stays on. Use `--send-email=false`.
+
+**Don't guess flag names.** `auth0 orgs create` takes `--display`, not
+`--display-name`. On `Unknown flag:`, read the real name off `--help`.
+
+---
+
 ## Command Discovery — `auth0 commands`
 
 `auth0 commands` prints the entire CLI surface in one place, so the right
@@ -310,10 +328,31 @@ Manage organizations for B2B SaaS scenarios. Alias: `auth0 orgs`.
 ```bash
 auth0 orgs create --name "acme-corp" --display "Acme Corporation" \
   --logo "https://acme.com/logo.png" --accent "#FF6600"
+auth0 orgs list
 auth0 orgs members list <org-id>
+auth0 orgs roles list <org-id>
 auth0 orgs invitations create --org-id <org-id> --invitee-email "new@acme.com" \
-  --inviter-name "Admin" --client-id <id>
+  --inviter-name "Admin" --client-id <id> --roles <role-id> --send-email=false
+auth0 orgs invitations list --org-id <org-id>
 ```
+
+Adding members, assigning org-scoped roles, and enabling a connection on an org
+go through `auth0 api`:
+
+```bash
+auth0 api post "organizations/<org-id>/members" --data '{"members":["<user-id>"]}'
+auth0 api post "organizations/<org-id>/members/<user-id>/roles" --data '{"roles":["<role-id>"]}'
+auth0 api post "organizations/<org-id>/enabled_connections" \
+  --data '{"connection_id":"<con-id>","assign_membership_on_login":true}'
+```
+
+Confirm the current surface with `auth0 commands orgs --detailed` before reaching
+for `auth0 api`, since a dedicated subcommand may exist by now. Note that
+`--help` on an unrecognized subcommand falls back to the parent command's help
+rather than erroring, so `auth0 commands` is the more reliable probe.
+
+Invitations need two prerequisites that each 400; see the organizations feature
+reference.
 
 ### Actions — Serverless Auth Pipeline
 
@@ -469,6 +508,22 @@ cat data.json | auth0 api post clients      # data can be piped instead of using
 Method defaults to `GET` without data and `POST` with data. If a call returns
 403, re-run `auth0 login --scopes "<needed:scope>"`.
 
+**Paths are relative to the API root.** Write `connections`, not
+`/api/v2/connections`. The prefixed form returns a flat `404: Not Found` that
+reads like a missing resource.
+
+**A 404 on a path you believe exists usually means the wrong verb.** Verbs are
+forwarded unvalidated, so an endpoint that doesn't accept the one you sent answers
+404 rather than 405. Check the verb and whether the resource is addressable
+individually or only as a collection, before assuming a permissions problem. The
+[Management API OpenAPI spec](https://auth0.com/docs/oas/management/v2/management-api-oas.json)
+is the authoritative answer for which methods a path accepts and what body it
+expects.
+
+**Response shapes vary.** Some endpoints return a bare array where the docs show
+a wrapper, such as `organizations/<id>/enabled_connections`. On
+`jq: Cannot index array with string`, print the raw body before editing the filter.
+
 ---
 
 ## Piping to `jq`
@@ -482,6 +537,12 @@ auth0 users show <user-id> | jq '{id: .user_id, email: .email}'
 auth0 roles list | jq '.[].name'
 ```
 
+**Never `2>&1` into `jq`.** It folds the agent-mode notice and the
+`=== <tenant> applications (3)` header into the JSON stream, and every filter
+dies with `parse error: Invalid numeric literal at line 1, column 5`. The error
+is about the banner, not the data, so rewriting the filter won't fix it. If a
+whole verification block starts returning parse errors, look for `2>&1` first.
+
 Outside an agent session, add the flag explicitly on commands that define it:
 
 ```bash
@@ -494,4 +555,8 @@ auth0 apps list --json-compact | jq '.[] | {client_id, name}'
 
 - [Auth0 CLI Documentation](https://auth0.github.io/auth0-cli/)
 - [Auth0 Management API v2](https://auth0.com/docs/api/management/v2)
+- [Management API OpenAPI spec](https://auth0.com/docs/oas/management/v2/management-api-oas.json) —
+  machine-readable source of truth for `auth0 api` paths, accepted methods, and
+  request/response shapes. Use it to confirm a verb or payload instead of
+  inferring one from a 404.
 - [Auth0 Documentation](https://auth0.com/docs)

--- a/plugins/auth0/skills/auth0/references/tooling-cli/index.md
+++ b/plugins/auth0/skills/auth0/references/tooling-cli/index.md
@@ -58,6 +58,10 @@ never enters a pipe:
 auth0 apps list | jq -r '.[0].client_id'
 ```
 
+Pipe stdout as it is. A failing command explains itself on stderr, so `2>&1`
+feeds that explanation to `jq` and you get `parse error: Invalid numeric
+literal` in place of the reason the command failed.
+
 Don't reflexively add `2>/dev/null`. It buys nothing here and throws away the
 error message when a command fails, leaving you with empty output and no reason
 why. Add it only to silence an error you actively expect, such as probing an

--- a/plugins/auth0/skills/auth0/references/tooling-cli/index.md
+++ b/plugins/auth0/skills/auth0/references/tooling-cli/index.md
@@ -1,13 +1,9 @@
-# Auth0 CLI — Tenant Configuration
+# Auth0 CLI — Tenant Configuration and Command Reference
 
-Use the Auth0 CLI when the project has no Terraform infrastructure and no active MCP session.
-This is the default tooling. Install with: `brew install auth0/auth0-cli/auth0`
+Use the Auth0 CLI when the project has no Terraform infrastructure and no active
+MCP session. This is the default tooling.
 
-Authenticate: `auth0 login`
-
-# Auth0 CLI — Command Reference
-
-The Auth0 CLI (`auth0`) lets you manage your tenant from the terminal. Install it via Homebrew (`brew install auth0/auth0-cli/auth0`). For complete flag definitions and examples, see the Full CLI Reference section below.
+Install with: `brew install auth0`
 
 ---
 
@@ -15,11 +11,152 @@ The Auth0 CLI (`auth0`) lets you manage your tenant from the terminal. Install i
 
 ```bash
 auth0 login                          # interactive device-code login
-auth0 login --scopes "read:client_grants"  # request extra scopes if 403
+auth0 login --scopes "read:stats"  # request extra scopes if 403
 auth0 login --domain <tenant>.auth0.com --client-id <id> --client-secret "$AUTH0_CLIENT_SECRET"  # CI/CD
 ```
 
-See the Authentication Details section below for machine login with JWT, tenant management, and logout.
+Machine login (client credentials) is the recommended method for non-interactive
+environments and for Private Cloud tenants. `auth0 login` and `auth0 logout` do
+not accept output flags. Switch tenants with `auth0 tenants use <domain>`, or
+target one command at a time with the global `--tenant` flag.
+
+---
+
+## Agent Mode — Read This Before Adding Output Flags
+
+The CLI has an agent mode that is **auto-enabled when it detects it is being run
+by an AI agent**. When it is on, the CLI already:
+
+- prints **JSON** on stdout,
+- disables interactive prompts,
+- disables colors.
+
+```bash
+auth0 --agent-mode ...           # force it on
+auth0 --agent-mode=false ...     # force it off for one command
+AUTH0_AGENT_MODE=false auth0 ... # force it off via environment
+```
+
+Resolution order: an explicit `--agent-mode` flag wins, then the
+`AUTH0_AGENT_MODE` environment variable (any Go-parseable bool — `1`, `true`,
+`false`), then auto-detection. Detection identifies Claude Code, Cursor, Codex,
+Gemini CLI, Antigravity, GitHub Copilot, and the Auth0 MCP server, via an
+`AUTH0_CLI_CLIENT` handshake, then a known-env-var allow-list, then a
+parent-process walk.
+
+Because agent mode is on by default in an agent session, **do not reflexively
+append `--json` to every command.** The output is already JSON, and on the
+commands that don't define the flag the extra `--json` makes the command fail
+outright.
+
+Agent mode writes its notice banner and section headers to **stderr**, so stdout
+stays clean and pipes straight into `jq` — no redirect needed, since stderr
+never enters a pipe:
+
+```bash
+auth0 apps list | jq -r '.[0].client_id'
+```
+
+Don't reflexively add `2>/dev/null`. It buys nothing here and throws away the
+error message when a command fails, leaving you with empty output and no reason
+why. Add it only to silence an error you actively expect, such as probing an
+optional resource that may not exist.
+
+### Destructive commands require `--force` in agent mode
+
+Agent mode disables prompts, so instead of silently deleting, destructive
+commands **refuse to run** without `--force`:
+
+```
+This is a destructive command; re-run with --force to proceed without a confirmation prompt.
+```
+
+This applies to `delete` and `revoke` across every resource, and to
+`auth0 api delete`. Treat the error as a confirmation checkpoint — confirm the
+intent, then re-run with `--force`:
+
+```bash
+auth0 apps delete <client-id> --force
+auth0 api delete "actions/actions/<action-id>" --force
+```
+
+### When you still need `--json` explicitly
+
+Add it only when the command runs **outside** an agent session and you need
+machine-readable output anyway — a shell script, a CI job, a Makefile. In that
+case check the flag exists first (see the next section).
+
+---
+
+## Output Flag Rules
+
+| Situation | What to do |
+|-----------|-----------|
+| Running as an agent | Nothing. Agent mode already emits JSON. |
+| `auth0 api ...` | Never pass `--json`. It returns JSON only and **rejects the flag** with `Unknown flag: --json`. |
+| Scripting outside an agent session | Add `--json`, but confirm the command defines it. |
+| Piping large output to `jq` | `--json-compact` (defined on 125 commands). |
+| Spreadsheet / tabular export | `--csv` (defined on 32 `list`/`search` commands). |
+| Any non-interactive run | `--no-input` so the CLI errors instead of prompting. |
+
+Roughly a third of runnable commands define **no** JSON flag at all. These are
+the action-style and interactive commands — `delete`, `open`, `revoke`,
+`unblock`, `login`, `logout`, plus notable ones agents reach for often:
+
+- `auth0 api` — JSON-only by design
+- `auth0 logs tail` — only takes `--filter` and `--number`
+- `auth0 users import` — only takes `--connection-name`, `--users`, `--upsert`, `--template`, `--email-results`
+- `auth0 roles permissions add` / `remove`
+- `auth0 terraform generate`
+- `auth0 universal-login customize` / `templates update` / `prompts update`
+- `auth0 acul init` / `acul dev` / `acul config set`
+
+When unsure, don't guess — ask the CLI:
+
+```bash
+auth0 apps create --help                  # JSON in agent mode: flags, types, defaults, examples
+auth0 apps create --help --json           # same JSON when agent mode is off
+```
+
+---
+
+## Command Discovery — `auth0 commands`
+
+`auth0 commands` prints the entire CLI surface in one place, so the right
+command can be found without opening `--help` page by page. Prefer this over
+guessing a command name.
+
+```bash
+auth0 commands                          # full tree
+auth0 commands --flat                   # one runnable command per line — best for intent matching
+auth0 commands apps                     # expand only the apps branch
+auth0 commands apps create --detailed   # usage, flags, arguments, auth requirement
+auth0 commands --depth 1                # top-level resources only
+auth0 commands apps --json --detailed   # machine-readable
+```
+
+`--detailed` is what lets you construct a valid invocation in one shot: it
+includes each command's flags, arguments, and whether it requires
+authentication.
+
+```bash
+# find every command that mentions organizations
+auth0 commands --flat | grep -i organization
+```
+
+### Structured `--help`
+
+In agent mode, `--help` returns a JSON object per command rather than prose:
+`path`, `name`, `short`, `description`, `usage`, `example`, `runnable`,
+`requiresAuth`, and a `flags` array carrying each flag's `name`, `shorthand`,
+`usage`, `type`, and `default`. Outside agent mode, combine `--help --json` for
+the same output.
+
+Use it to verify a flag before running a command that changes tenant state:
+
+```bash
+auth0 apps update --help | jq -r '.[0].flags[].name'
+```
 
 ---
 
@@ -27,23 +164,32 @@ See the Authentication Details section below for machine login with JWT, tenant 
 
 | What you're doing | Command to use |
 |-------------------|---------------|
-| Setting up a new project | `auth0 apps create --type spa\|regular\|m2m\|native --json` |
-| Need a client ID or secret | `auth0 apps show <id> -r --json` |
-| Registering a backend API | `auth0 apis create --identifier "https://..." --json` |
-| Finding a user's ID | `auth0 users search --query "email:..." --json` |
+| Discovering which command to run | `auth0 commands --flat` |
+| Checking a command's flags | `auth0 <command> --help` |
+| Setting up a new project | `auth0 apps create --type spa\|regular\|m2m\|native` |
+| Need a client ID or secret | `auth0 apps show <id> -r` |
+| Registering a backend API | `auth0 apis create --identifier "https://..."` |
+| Authorizing an M2M app for an API | `auth0 client-grants create` |
+| Finding a user's ID | `auth0 users search --query "email:..."` |
+| Counting or paging all users | `auth0 api get "users?include_totals=true"` |
 | Creating/managing roles (RBAC) | `auth0 roles create` / `auth0 users roles assign` |
+| Revoking a user's access right now | `auth0 users sessions delete` / `auth0 users refresh-tokens delete` |
 | B2B multi-tenancy | `auth0 orgs create` |
-| Custom login logic | `auth0 actions create --trigger post-login --json` |
+| Custom login logic | `auth0 actions create --trigger post-login` |
 | Branding the login page | `auth0 ul update --logo ... --accent ...` |
-| Custom domain for login | `auth0 domains create --domain "auth.myapp.com" --json` |
-| Debugging a failed login | `auth0 logs tail --filter "type:f" --json-compact` |
+| Custom domain for login | `auth0 domains create --domain "auth.myapp.com"` |
+| Debugging a failed login | `auth0 logs tail --filter "type:f"` |
 | Testing a login flow | `auth0 test login <client-id>` |
+| Getting an access token to test an API | `auth0 test token --audience "https://..."` |
 | Exporting config as Terraform | `auth0 terraform generate --output-dir ./terraform` |
-| Managing connections, grants, hooks | `auth0 api get <path>` |
-| Scripting / parsing output | Add `--json` or `--json-compact` to any command |
+| Restricting tenant traffic by IP | `auth0 network-acl create` |
+| Streaming tenant events to your system | `auth0 event-streams create` |
+| Reading or changing tenant-wide settings | `auth0 tenant-settings show` / `update set` |
+| Token exchange / custom auth profiles | `auth0 token-exchange create` |
+| Anything with no dedicated command | `auth0 api get <path>` |
 | Security hardening | `auth0 protection brute-force-protection update --enabled true` |
 | Routing logs externally | `auth0 logs streams create datadog\|http\|splunk` |
-| Bulk importing users | `auth0 users import --connection-name ... --users '...' --json` |
+| Bulk importing users | `auth0 users import --connection-name ...` |
 
 ---
 
@@ -51,64 +197,109 @@ See the Authentication Details section below for machine login with JWT, tenant 
 
 ### Apps — Manage Applications
 
-Create or inspect Auth0 applications (client ID, secret, callback URLs, app type). Alias: `auth0 clients`.
+Create or inspect Auth0 applications (client ID, secret, callback URLs, app
+type). Alias: `auth0 clients`.
 
 ```bash
 auth0 apps create --name "My SPA" --type spa \
   --auth-method None \
   --callbacks "http://localhost:3000" \
   --logout-urls "http://localhost:3000" \
-  --origins "http://localhost:3000" --json
+  --origins "http://localhost:3000"
 
-auth0 apps list --json-compact
-auth0 apps show <client-id> --json
-auth0 apps update <client-id> --callbacks "http://localhost:3000,https://myapp.com" --json
+auth0 apps list
+auth0 apps show <client-id> -r          # -r reveals the client secret
+auth0 apps update <client-id> --callbacks "http://localhost:3000,https://myapp.com"
 auth0 apps delete <client-id> --force
+auth0 apps session-transfer show <client-id>
 ```
 
 App types: `spa`, `regular`, `m2m`, `native`, `resource_server`
 
 ### APIs — Manage API Resources
 
-Register backend APIs (Resource Servers) to protect with Auth0 tokens. Alias: `auth0 resource-servers`.
+Register backend APIs (Resource Servers) to protect with Auth0 tokens. Alias:
+`auth0 resource-servers`.
 
 ```bash
 auth0 apis create --name "My API" --identifier "https://api.myapp.com" \
-  --scopes "read:data,write:data" --token-lifetime 3600 --json
+  --scopes "read:data,write:data" --token-lifetime 3600
 
-auth0 apis list --json-compact
-auth0 apis scopes list <api-id> --json
+auth0 apis list
+auth0 apis scopes list <api-id>
 ```
 
-**Key distinction:** `apps` = the client requesting tokens. `apis` = the resource accepting tokens.
+**Key distinction:** `apps` = the client requesting tokens. `apis` = the
+resource accepting tokens.
+
+### Client Grants — Authorize M2M Access
+
+Grant an application permission to call an API with specific scopes. This is the
+step that makes a `client_credentials` flow work.
+
+```bash
+auth0 client-grants create
+auth0 client-grants list
+auth0 client-grants show <grant-id>
+auth0 client-grants update <grant-id>
+auth0 client-grants organizations list <grant-id>
+```
 
 ### Users — Manage Users
 
 Create, search, inspect, import, and manage users in your tenant.
 
 ```bash
-auth0 users search --query "email:user@example.com" --json
-auth0 users search-by-email user@example.com --json-compact
+auth0 users search --query "email:user@example.com"
+auth0 users search-by-email user@example.com
 auth0 users create --connection-name "Username-Password-Authentication" \
-  --email "test@example.com" --password "$USER_PASSWORD" --json
-auth0 users show <user-id> --json
-auth0 users blocks list <email> --json
+  --email "test@example.com" --password "$USER_PASSWORD"
+auth0 users show <user-id>
+auth0 users blocks list <email>
 auth0 users blocks unblock <email>
 auth0 users import --connection-name "Username-Password-Authentication" \
-  --users '[...]' --upsert --json
+  --users '[...]' --upsert
 ```
 
-**Note:** `--json` output for user commands returns full profiles (email, metadata) and import payloads carry password hashes — avoid piping to shared logs/CI output.
+**There is no `auth0 users list`.** `auth0 users search` is the listing command,
+and it also accepts no `--query` at all if you just want the first page. It
+returns a bare array with no total count, so for a count or for paging use the
+raw API:
+
+```bash
+auth0 api get "users?per_page=1&include_totals=true" | jq '.total'
+auth0 api get "users?per_page=100&page=0&include_totals=true"
+```
+
+**Note:** user output carries full profiles (email, metadata) and import
+payloads carry password hashes — avoid piping to shared logs/CI output.
+
+### Sessions and Refresh Tokens — Revoke Access
+
+Inspect and revoke a user's live sessions and refresh tokens. Use these when a
+user must lose access immediately rather than at token expiry.
+
+```bash
+auth0 users sessions list <user-id>
+auth0 users sessions delete <user-id>
+auth0 users refresh-tokens list <user-id>
+auth0 users refresh-tokens delete <user-id>
+
+auth0 sessions show <session-id>
+auth0 sessions revoke <session-id>
+auth0 refresh-tokens show <token-id>
+auth0 refresh-tokens revoke <token-id>
+```
 
 ### Roles — Manage RBAC Roles
 
 Create roles, assign permissions, and assign roles to users.
 
 ```bash
-auth0 roles create --name "editor" --description "Can edit content" --json
-auth0 roles permissions add <role-id> --api-id <api-id> --permissions "read:data,write:data" --json
+auth0 roles create --name "editor" --description "Can edit content"
+auth0 roles permissions add <role-id> --api-id <api-id> --permissions "read:data,write:data"
 auth0 users roles assign <user-id> --roles <role-id>
-auth0 users roles show <user-id> --json-compact
+auth0 users roles show <user-id>
 ```
 
 ### Organizations — B2B Multi-Tenancy
@@ -117,10 +308,10 @@ Manage organizations for B2B SaaS scenarios. Alias: `auth0 orgs`.
 
 ```bash
 auth0 orgs create --name "acme-corp" --display "Acme Corporation" \
-  --logo "https://acme.com/logo.png" --accent "#FF6600" --json
-auth0 orgs members list <org-id> --json
+  --logo "https://acme.com/logo.png" --accent "#FF6600"
+auth0 orgs members list <org-id>
 auth0 orgs invitations create --org-id <org-id> --invitee-email "new@acme.com" \
-  --inviter-name "Admin" --client-id <id> --json
+  --inviter-name "Admin" --client-id <id>
 ```
 
 ### Actions — Serverless Auth Pipeline
@@ -129,36 +320,102 @@ Create and deploy serverless functions at auth pipeline trigger points.
 
 ```bash
 auth0 actions create --name "Add Claims" --trigger "post-login" \
-  --code 'exports.onExecutePostLogin = async (event, api) => { ... }' --json
+  --code 'exports.onExecutePostLogin = async (event, api) => { ... }'
 auth0 actions deploy <action-id>
+auth0 actions diff <action-id>
+auth0 actions modules list          # shared code modules reusable across actions
 ```
 
-Triggers: `post-login`, `credentials-exchange`, `pre-user-registration`, `post-user-registration`, `post-change-password`, `send-phone-message`
+Triggers: `post-login`, `credentials-exchange`, `pre-user-registration`,
+`post-user-registration`, `post-change-password`, `send-phone-message`
 
-**Important:** You must `deploy` after creating or updating for changes to take effect.
+**Important:** You must `deploy` after creating or updating for changes to take
+effect.
 
 ### Logs — Debugging & Monitoring
 
 ```bash
-auth0 logs tail --filter "type:f" --json-compact    # real-time failed logins
-auth0 logs list --filter "type:f" --number 20 --json-compact  # historical
+auth0 logs tail --filter "type:f"                 # real-time failed logins
+auth0 logs list --filter "type:f" --number 20     # historical
 ```
 
-Common codes: `s` (success), `f` (failed login), `slo` (logout), `fs` (silent auth failure)
+Common codes: `s` (success), `f` (failed login), `slo` (logout), `fs` (silent
+auth failure)
+
+**Note:** `auth0 logs tail` streams and takes only `--filter` and `--number` —
+it has no output flags. Use `auth0 logs list` when you need structured output.
+
+### Event Streams — Push Tenant Events Out
+
+Subscribe an external system to tenant events, then inspect and replay
+deliveries.
+
+```bash
+auth0 event-streams create
+auth0 event-streams list
+auth0 event-streams deliveries list <stream-id>
+auth0 event-streams stats <stream-id>
+auth0 event-streams redeliver <stream-id>
+auth0 event-streams subscribe <stream-id>
+```
+
+### Network ACLs — Restrict Tenant Traffic
+
+```bash
+auth0 network-acl create
+auth0 network-acl list
+auth0 network-acl show <acl-id>
+auth0 network-acl update <acl-id>
+```
+
+### Tenant Settings
+
+```bash
+auth0 tenant-settings show
+auth0 tenant-settings update set <flag>
+auth0 tenant-settings update unset <flag>
+```
+
+### Token Exchange — Custom Auth Profiles
+
+Configure token exchange profiles for custom authentication and on-behalf-of
+flows. Alias: `auth0 te`.
+
+```bash
+auth0 token-exchange create
+auth0 token-exchange list
+auth0 token-exchange show <profile-id>
+```
+
+The matching app-side flag is
+`auth0 apps create --allow-any-profile-of-type custom_authentication,on_behalf_of_token_exchange`.
+
+### Email and Phone Providers
+
+```bash
+auth0 email provider create
+auth0 email provider show
+auth0 email templates update <template>
+auth0 phone provider create
+auth0 phone provider list
+```
 
 ### Domains — Custom Domains
 
 ```bash
-auth0 domains create --domain "auth.myapp.com" --type "auth0_managed_certs" --json
-auth0 domains verify <domain-id> --json
+auth0 domains create --domain "auth.myapp.com" --type "auth0_managed_certs"
+auth0 domains verify <domain-id>
 ```
 
 ### Universal Login — Branding
 
 ```bash
 auth0 ul update --accent "#FF6600" --background "#FFFFFF" \
-  --logo "https://myapp.com/logo.png" --json
+  --logo "https://myapp.com/logo.png"
 ```
+
+`auth0 ul customize`, `templates update`, and `prompts update` are interactive
+editors and define no output flags.
 
 ### Terraform — Export as IaC
 
@@ -166,11 +423,12 @@ auth0 ul update --accent "#FF6600" --background "#FFFFFF" \
 auth0 terraform generate --output-dir ./terraform --resources "auth0_client,auth0_connection"
 ```
 
-### Test — Verify Login Flows
+### Test — Verify Login Flows and Tokens
 
 ```bash
 auth0 test login <client-id>
 auth0 test login <client-id> --audience "https://api.myapp.com" --scopes "openid profile email"
+auth0 test token --audience "https://api.myapp.com" --scopes "read:data"
 ```
 
 ### Attack Protection — Security Hardening
@@ -178,45 +436,54 @@ auth0 test login <client-id> --audience "https://api.myapp.com" --scopes "openid
 ```bash
 auth0 protection brute-force-protection update --enabled true
 auth0 protection breached-password-detection update --enabled true
-auth0 protection bot-detection update --enabled true
+auth0 protection bot-detection update --bot-detection-level medium
+auth0 protection suspicious-ip-throttling ips check <ip>
+auth0 protection suspicious-ip-throttling ips unblock <ip>
 ```
 
 ### Log Streams — External Routing
 
 ```bash
-auth0 logs streams create datadog    # interactive setup
-auth0 logs streams create http       # custom webhook
-auth0 logs streams list --json
+auth0 logs streams create datadog     # subcommand per provider
+auth0 logs streams create http        # custom webhook
+auth0 logs streams list
 ```
 
-Supported: eventbridge, eventgrid, http, datadog, splunk, sumo
+Supported: `eventbridge`, `eventgrid`, `http`, `datadog`, `splunk`, `sumo`
 
 ### Raw API Mode — Direct Management API Access
 
-When a dedicated command doesn't exist, `auth0 api` calls Management API v2 endpoints directly.
+When a dedicated command doesn't exist, `auth0 api` calls Management API v2
+endpoints directly. It **returns JSON already** and accepts **no** output flags
+— passing `--json` fails with `Unknown flag: --json`.
 
 ```bash
 auth0 api get connections
 auth0 api post client-grants --data '{"client_id":"...","audience":"...","scope":["read:data"]}'
 auth0 api get stats/daily -q "from=20240101" -q "to=20240131"
+auth0 api delete "actions/actions/<action-id>" --force
+cat data.json | auth0 api post clients      # data can be piped instead of using --data
 ```
+
+Method defaults to `GET` without data and `POST` with data. If a call returns
+403, re-run `auth0 login --scopes "<needed:scope>"`.
 
 ---
 
-## Output Formatting
+## Piping to `jq`
 
-Always use `--json` or `--json-compact` for machine-readable output.
+Agent mode already emits JSON on stdout, so redirect stderr and pipe:
 
-| Flag | When to use |
-|------|-------------|
-| `--json` | Human inspection, debugging — pretty-printed with indentation |
-| `--json-compact` | Piping to `jq`, scripting, pipelines — compact single-line |
-| `--csv` | Spreadsheets and tabular export |
+```bash
+auth0 apps list | jq '.[] | {client_id, name}'
+auth0 users show <user-id> | jq '{id: .user_id, email: .email}'
+auth0 roles list | jq '.[].name'
+```
+
+Outside an agent session, add the flag explicitly on commands that define it:
 
 ```bash
 auth0 apps list --json-compact | jq '.[] | {client_id, name}'
-auth0 users show <user-id> --json-compact | jq '{id: .user_id, email: .email}'
-auth0 roles list --json-compact | jq '.[].name'
 ```
 
 ---


### PR DESCRIPTION
## Summary
- replace the blanket "add `--json`" advice in `tooling-cli` with an output-flag
  table: `auth0 api` rejects the flag, roughly a third of runnable commands
  never define one, `--json-compact` exists on most `list`/`show` commands,
  and `--csv` on many `list`/`search` commands
- document agent mode: auto-detection waterfall, `--agent-mode` /
  `AUTH0_AGENT_MODE` precedence, stderr-only banners so stdout pipes into `jq`,
  and destructive commands refusing to run without `--force`
- document `auth0 commands` for CLI surface discovery and the structured JSON
  `--help` payload
- add reference sections for client-grants, sessions and refresh-tokens,
  event-streams, network-acl, tenant-settings, token-exchange, and
  session-transfer
- fix 11 invalid flags: `auth0 login --no-browser` and `--force`,
  `auth0 test login --client-id`, `auth0 ul templates update --file`,
  `auth0 protection bot-detection update --enabled`
- fix 3 commands that do not exist: `auth0 connections list`,
  `auth0 users list`, `auth0 orgs connections add`
- fix `auth0 api --data @-` and `--data @./file.json`, which the CLI rejects with
  `invalid character '@'`; pipe the body on stdin instead
- switch `echo "$VAR" |` to `printf '%s' "$VAR" |` in the branding copy script,
  since zsh's `echo` expands backslash escapes and corrupts Liquid templates
- prefer native commands over raw API where one exists, so template and prompt
  imports use `auth0 ul templates update` and `auth0 ul prompts update`
- drop the Homebrew tap from 33 install lines now that the CLI is in
  homebrew-core: `brew install auth0`

## Validation
- `uvx skillsaw --strict` — 0 errors, Grade A
- `bash plugins/auth0/skills/auth0/scripts/validate-skill.sh`
- `python3 scripts/check_router_reachability.py`
- `python3 scripts/check_routing_evals.py` — 35 cases
- resolved all 401 `auth0 ...` examples across every reference against
  `auth0 commands --flat --detailed --json` and diffed their flags against the
  real flag sets: 0 invalid flags remaining
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Auth0 CLI installation instructions to use the current Homebrew package command.
  - Modernized CLI examples for authentication, deployments, migrations, connections, organizations, tenant configuration, and framework integrations.
  - Improved troubleshooting guidance for browser and non-interactive authentication.
  - Expanded CLI reference coverage, including agent mode, output handling, command discovery, safety guidance, direct API access, and structured output piping.
  - Clarified MFA enforcement, organization invitations, bulk imports, tenant-copy workflows, and database connection setup.
  - Updated branding, page-template, deployment, tenant migration, audit remediation, and framework integration examples for current CLI commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
