### PR TITLE
feat: Adds specific guidance on handling invitation and organization params

### DIFF
--- a/plugins/auth0/skills/auth0/references/feature-organizations/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-organizations/index.md
@@ -193,6 +193,21 @@ auth0 orgs invitations create --org-id "<org-id>" \
 `--send-email false` reads `false` as a positional argument. Verify with
 `auth0 orgs invitations list --org-id <org-id>`.
 
+### Accepting an invitation (app side)
+
+The invite link lands on your app carrying **both** an `invitation` and an `organization` parameter:
+
+```
+https://your-app.com/login?invitation={ticket_id}&organization={org_id}
+```
+
+Your app must read **both** params from the URL and forward **both** to the `/authorize` request (the SDK's login call). This is protocol-level behavior — it holds for SPA, mobile, and Regular Web App SDKs alike; only *where* you wire it differs:
+
+- **SPA / mobile** (public client): read from the browser URL, pass in `authorizationParams` on the login call.
+- **Regular Web App** (confidential client): read from the server request, pass through the OIDC middleware / challenge params.
+
+**Forward the invitation's own `organization` — do not substitute your app's configured default org.** The invite is scoped to the org it was issued for, which may differ from your default.
+
 ---
 
 ## Common mistakes
@@ -200,6 +215,8 @@ auth0 orgs invitations create --org-id "<org-id>" \
 | Mistake | Fix |
 |---|---|
 | Forgetting `organization` in `authorizationParams` | Always pass the org identifier at login time |
+| Not forwarding the `invitation` param when accepting an invite | Read `invitation` + `organization` from the callback URL and forward both to `/authorize` |
+| Using your default org for an invitation link | Forward the invite's own `organization` param — it may differ from your configured default |
 | Using `org_id` from ID token on backend | Validate from the access token, not ID token |
 | Mixing up org `id` (org_xxx) and `name` (slug) | `id` for API calls, `name` for display |
 | Granting global roles instead of org-level roles | Use the org member roles endpoint, not the user roles endpoint |


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Documents how an app should accept an Auth0 organization invitation. The `feature-organizations` reference previously covered creating invitations, but not what the app needs to do when a user clicks the invite link.

The new guidance explains that:

- The invite link arrives with **both** an `invitation` and an `organization` parameter, and the app must forward both to the login request.
- This is protocol-level behavior — it applies to SPA, mobile, and Regular Web App SDKs alike; only where you wire it up differs.
- The app should forward the invitation's own `organization`, not its configured default org.

Two entries were also added to the "Common mistakes" table to reinforce these points.


### References


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for accepting organization invitations.
  * Documented forwarding the invitation and organization parameters during authorization.
  * Added recommendations for SPA, mobile, and Regular Web Apps.
  * Expanded common-mistake guidance to address missing invitation details and incorrect organization defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->