### PR TITLE
feat: Adds guidance on where to get org_id from

### DIFF
--- a/plugins/auth0/skills/auth0/references/feature-organizations/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-organizations/index.md
@@ -61,13 +61,18 @@ app.get('/login/:orgId', (req, res) => {
 });
 ```
 
-### Read org from access token
+### Reading the organization back
 
-After login, the access token includes `org_id` and `org_name` claims:
+`org_id` (and `org_name`, when your tenant uses organization names) is present in
+**both** the ID token and the access token after an organization login. Which one
+you read depends on *why* you need it:
 
-```javascript
-const { org_id, org_name } = tokenPayload;
-```
+- **To display which org the user is in (client / web app):** read `org_id` /
+  `org_name` from the **ID token**. Auth0's guidance is that web applications
+  validate `org_id` from the ID token. Use the SDK's own claim accessor rather
+  than hand-decoding a token.
+- **To authorize an API request (server side):** validate `org_id` from the
+  **access token** the API receives (see below).
 
 ### Validate org on the backend
 
@@ -218,6 +223,8 @@ Your app must read **both** params from the URL and forward **both** to the `/au
 | Not forwarding the `invitation` param when accepting an invite | Read `invitation` + `organization` from the callback URL and forward both to `/authorize` |
 | Using your default org for an invitation link | Forward the invite's own `organization` param — it may differ from your configured default |
 | Using `org_id` from ID token on backend | Validate from the access token, not ID token |
+| Reading the display `org_id` from the access token in a client app | Web apps read `org_id` from the ID token; reserve the access token's `org_id` for API validation |
+| Hand-decoding a token to read `org_id` | Use the SDK's claim accessor (`getUser()` / `getIdTokenClaims()` / session user) — the claim is already exposed |
 | Mixing up org `id` (org_xxx) and `name` (slug) | `id` for API calls, `name` for display |
 | Granting global roles instead of org-level roles | Use the org member roles endpoint, not the user roles endpoint |
 | Not enabling a connection for the org | `auth0 api post "organizations/<org-id>/enabled_connections"`, or Dashboard → Organization → Connections |


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Fills two gaps in the `feature-organizations` reference around Auth0 Organizations.

**Reading the organization back.** The reference previously said only that the access token carries `org_id`/`org_name`. It now explains that both the ID token and the access token carry these claims after an organization login, and which one to read depends on intent:

- To display which org the user is in (client / web app), read `org_id` / `org_name` from the **ID token**, using the SDK's claim accessor rather than hand-decoding a token.
- To authorize an API request (server side), validate `org_id` from the **access token**.

**Accepting an invitation (app side).** The reference covered creating invitations but not what the app does when a user clicks the invite link. The new guidance explains that:

- The invite link arrives with **both** an `invitation` and an `organization` parameter, and the app must forward both to the login request. 
- This is protocol-level behavior. It applies to SPA, mobile, and Regular Web App SDKs alike; only where you wire it up differs.
- The app should forward the invitation's own `organization`, not its configured default org.

Four entries were also added to the "Common mistakes" table to reinforce these points.

### References

### Testing

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which token claims to use for organization displays and backend API authorization.
  * Recommended SDK-provided claim accessors instead of manual token decoding.
  * Added guidance addressing common organization-claim handling mistakes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->