### PR TITLE
chore: Adds examples entry for auth0-server-python in feature/mfa

### DIFF
--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -151,7 +151,7 @@ Returned by the token/authorization endpoints during an MFA flow (KEEP INLINE):
 **Before writing MFA code:** find the one row below matching the detected SDK and read
 ONLY the named section from its URL (from that heading down to the next `## `) - these are
 large multi-topic files, so with `WebFetch` ask it to return just that section verbatim.
-No matching row (e.g. a backend SDK like `auth0-server-python`), or the fetch fails? Fall
+No matching row (a backend SDK not listed below), or the fetch fails? Fall
 back to the language-neutral mechanic above. Never substitute a web search for "how to do
 MFA".
 files or docs searches.
@@ -165,6 +165,7 @@ files or docs searches.
 | `@auth0/nextjs-auth0` | https://raw.githubusercontent.com/auth0/nextjs-auth0/main/EXAMPLES.md | `## Multi-Factor Authentication (MFA)` |
 | `@auth0/auth0-auth-js` | https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-auth-js/EXAMPLES.md | `## Using Multi-Factor Authentication (MFA)` |
 | `@auth0/auth0-server-js` | https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-server-js/MFA.md | whole file |
+| `auth0-server-python` | https://raw.githubusercontent.com/auth0/auth0-server-python/main/examples/StepUpAuthentication.md | whole file |
 
 ## Tenant configuration
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
- Adds an entry for auth0-server-python example in the `feature/mfa` reference


### References

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MFA reference documentation to include the Auth0 Python server SDK among the supported example-code options.
  * Removed outdated fallback wording related to this SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->