### PR TITLE
feat: Add Auth0 Flutter Windows desktop reference + evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ per-framework skill.
 | **iOS/macOS** | [`Auth0.swift`](https://github.com/auth0/Auth0.swift) | Swift (iOS, macOS, tvOS, watchOS, visionOS) |
 | **Flutter** | [`auth0_flutter`](https://github.com/auth0/auth0-flutter) | Flutter mobile (iOS/Android, Dart) |
 | **Flutter Web** | [`auth0_flutter`](https://github.com/auth0/auth0-flutter) | Flutter Web (Dart) |
+| **Flutter Windows** | [`auth0_flutter`](https://github.com/auth0/auth0-flutter) | Flutter Windows desktop (Dart) |
 | **.NET MAUI** | [`Auth0.OidcClient.MAUI`](https://github.com/auth0/auth0-oidc-client-net) | .NET MAUI (iOS, Android, macOS, Windows) |
 | **.NET Android** | [`Auth0.OidcClient.AndroidX`](https://github.com/auth0/auth0-oidc-client-net) | .NET Android (Xamarin) |
 | **.NET iOS** | [`Auth0.OidcClient.iOS`](https://github.com/auth0/auth0-oidc-client-net) | .NET iOS (Xamarin) |

--- a/evals/activation/cases.json
+++ b/evals/activation/cases.json
@@ -97,6 +97,14 @@
       "spot_check": true
     },
     {
+      "id": "fw-flutter-windows",
+      "prompt": "Add Auth0 login to my Flutter Windows desktop app.",
+      "should_activate": true,
+      "why": "Framework-only signal naming a specific platform variant (Flutter Windows desktop), not just 'Flutter' generically.",
+      "tags": ["framework-loss"],
+      "spot_check": true
+    },
+    {
       "id": "fw-fastapi",
       "prompt": "I need to protect these FastAPI endpoints so only authenticated callers can reach them.",
       "should_activate": true,

--- a/evals/activation/cases.json
+++ b/evals/activation/cases.json
@@ -98,7 +98,7 @@
     },
     {
       "id": "fw-flutter-windows",
-      "prompt": "Add Auth0 login to my Flutter Windows desktop app.",
+      "prompt": "Add login and logout to my Flutter Windows desktop app.",
       "should_activate": true,
       "why": "Framework-only signal naming a specific platform variant (Flutter Windows desktop), not just 'Flutter' generically.",
       "tags": ["framework-loss"],

--- a/evals/behavioral/cases/flutter-windows-intermediary.json
+++ b/evals/behavioral/cases/flutter-windows-intermediary.json
@@ -1,12 +1,12 @@
 {
-  "slug": "flutter-windows",
+  "slug": "flutter-windows-intermediary",
   "origin_skill": "auth0-flutter-windows",
   "skill_name": "auth0-flutter-windows",
   "evals": [
     {
       "id": 1,
-      "prompt": "Add Auth0 authentication to a Flutter Windows desktop application using the auth0_flutter SDK.\n\n**Auth0 Credentials:**\n- Domain: `dev-example.auth0.com`\n- Client ID: `abc123def456ghi789jkl012`",
-      "expected_output": "Working Flutter Windows app with Auth0 Web Auth login/logout via windowsWebAuthentication(), appCustomURL passed for the custom URL scheme, and manually managed (not CredentialsManager-backed) credential storage",
+      "prompt": "Add Auth0 authentication to a Flutter Windows desktop application using the auth0_flutter SDK. Use an intermediary HTTPS callback page so the browser can return to the app cleanly instead of leaving a blank tab.\n\n**Auth0 Credentials:**\n- Domain: `dev-example.auth0.com`\n- Client ID: `abc123def456ghi789jkl012`",
+      "expected_output": "Working Flutter Windows app with Auth0 Web Auth login/logout via windowsWebAuthentication(), appCustomURL plus redirectUrl/returnTo for the intermediary HTTPS callback flow, and manually managed (not CredentialsManager-backed) credential storage",
       "expectations": [
         "auth0_flutter SDK added to pubspec.yaml dependencies",
         "Has import for the auth0_flutter package (import package:auth0_flutter/auth0_flutter.dart)",
@@ -15,6 +15,8 @@
         "Implements login via windowsWebAuthentication().login()",
         "Implements logout via windowsWebAuthentication().logout()",
         "Passes appCustomURL to login() and logout()",
+        "Passes redirectUrl to login() for the intermediary HTTPS callback flow",
+        "Passes returnTo to logout() for the intermediary HTTPS callback flow",
         "Does not use credentialsManager / CredentialsManager (not supported on Windows)",
         "Manually stores the Credentials object returned from login()",
         "Auth0 domain dev-example.auth0.com passed to the Auth0 constructor",
@@ -22,7 +24,7 @@
         "Does not use web-specific APIs (Auth0Web, auth0_flutter_web.dart, auth0-spa-js)",
         "Does not use mobile-only manifest config (manifestPlaceholders, AndroidManifest, Info.plist, CFBundleURLTypes)",
         "No client_secret in native code (PKCE does not require one)",
-        "Solution correctly integrates Auth0 into a Flutter Windows app with login, logout, and manual credential handling"
+        "Solution correctly integrates Auth0 into a Flutter Windows app with intermediary HTTPS callback handling and manual credential storage"
       ]
     }
   ],
@@ -59,13 +61,18 @@
     },
     {
       "type": "matches",
-      "pattern": "\\.login\\([\\s\\S]{0,150}?appCustomURL\\s*:",
-      "description": "Passes appCustomURL to login()"
+      "pattern": "appCustomURL\\s*:",
+      "description": "Passes appCustomURL to login() and logout()"
     },
     {
       "type": "matches",
-      "pattern": "\\.logout\\([\\s\\S]{0,150}?appCustomURL\\s*:",
-      "description": "Passes appCustomURL to logout()"
+      "pattern": "redirectUrl\\s*:",
+      "description": "Passes redirectUrl to login() for the intermediary HTTPS callback flow"
+    },
+    {
+      "type": "matches",
+      "pattern": "returnTo\\s*:",
+      "description": "Passes returnTo to logout() for the intermediary HTTPS callback flow"
     },
     {
       "type": "not_contains_any",
@@ -111,9 +118,9 @@
     },
     {
       "type": "judge",
-      "description": "Solution correctly integrates Auth0 into a Flutter Windows app with login, logout, and manual credential handling",
-      "question": "Does the solution correctly integrate Auth0 into a Flutter Windows desktop app with: (1) working login via auth0.windowsWebAuthentication().login(appCustomURL: ...), (2) logout via windowsWebAuthentication().logout(appCustomURL: ...), (3) the returned Credentials object stored/managed manually by the app (not via a CredentialsManager, which doesn't exist on Windows), and (4) correct Auth0(domain, clientId) initialization?",
-      "examples": "PASS: Uses Auth0(domain, clientId), windowsWebAuthentication().login(appCustomURL: 'myapp://callback') for login, windowsWebAuthentication().logout(appCustomURL: ...) for logout, and stores the returned Credentials in app state or local storage itself.\nFAIL: Uses webAuthentication() or Auth0Web instead of windowsWebAuthentication().\nFAIL: Calls credentialsManager.credentials() as if Windows had automatic credential storage.\nFAIL: Missing appCustomURL on login or logout.",
+      "description": "Solution correctly integrates Auth0 into a Flutter Windows app with intermediary HTTPS callback handling and manual credential storage",
+      "question": "Does the solution correctly integrate Auth0 into a Flutter Windows desktop app with: (1) working login via auth0.windowsWebAuthentication().login(appCustomURL: ..., redirectUrl: ...), (2) logout via windowsWebAuthentication().logout(appCustomURL: ..., returnTo: ...), (3) the returned Credentials object stored/managed manually by the app (not via a CredentialsManager, which doesn't exist on Windows), and (4) correct Auth0(domain, clientId) initialization?",
+      "examples": "PASS: Uses Auth0(domain, clientId), windowsWebAuthentication().login(appCustomURL: 'myapp://callback', redirectUrl: 'https://your-app.example.com/callback') for login, windowsWebAuthentication().logout(appCustomURL: 'myapp://callback', returnTo: 'https://your-app.example.com/logout') for logout, and stores the returned Credentials in app state or local storage itself.\nFAIL: Uses webAuthentication() or Auth0Web instead of windowsWebAuthentication().\nFAIL: Omits redirectUrl or returnTo even though the prompt requests the intermediary HTTPS callback flow.\nFAIL: Calls credentialsManager.credentials() as if Windows had automatic credential storage.",
       "framework": "dart"
     }
   ]

--- a/evals/behavioral/cases/flutter-windows-intermediary.json
+++ b/evals/behavioral/cases/flutter-windows-intermediary.json
@@ -51,27 +51,32 @@
     },
     {
       "type": "matches",
-      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,40}\\.login\\(",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\.login\\(",
       "description": "Implements login via windowsWebAuthentication().login()"
     },
     {
       "type": "matches",
-      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,40}\\.logout\\(",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\.logout\\(",
       "description": "Implements logout via windowsWebAuthentication().logout()"
     },
     {
       "type": "matches",
-      "pattern": "appCustomURL\\s*:",
-      "description": "Passes appCustomURL to login() and logout()"
+      "pattern": "\\.login\\([\\s\\S]{0,150}?appCustomURL\\s*:",
+      "description": "Passes appCustomURL to login()"
     },
     {
       "type": "matches",
-      "pattern": "redirectUrl\\s*:",
+      "pattern": "\\.logout\\([\\s\\S]{0,150}?appCustomURL\\s*:",
+      "description": "Passes appCustomURL to logout()"
+    },
+    {
+      "type": "matches",
+      "pattern": "\\.login\\([\\s\\S]{0,150}?redirectUrl\\s*:",
       "description": "Passes redirectUrl to login() for the intermediary HTTPS callback flow"
     },
     {
       "type": "matches",
-      "pattern": "returnTo\\s*:",
+      "pattern": "\\.logout\\([\\s\\S]{0,150}?returnTo\\s*:",
       "description": "Passes returnTo to logout() for the intermediary HTTPS callback flow"
     },
     {

--- a/evals/behavioral/cases/flutter-windows-intermediary.json
+++ b/evals/behavioral/cases/flutter-windows-intermediary.json
@@ -51,12 +51,12 @@
     },
     {
       "type": "matches",
-      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\.login\\(",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|(\\w+)\\s*=[^;\\n]*windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\1\\.login\\(",
       "description": "Implements login via windowsWebAuthentication().login()"
     },
     {
       "type": "matches",
-      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\.logout\\(",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|(\\w+)\\s*=[^;\\n]*windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\1\\.logout\\(",
       "description": "Implements logout via windowsWebAuthentication().logout()"
     },
     {

--- a/evals/behavioral/cases/flutter-windows.json
+++ b/evals/behavioral/cases/flutter-windows.json
@@ -1,0 +1,114 @@
+{
+  "slug": "flutter-windows",
+  "origin_skill": "auth0-flutter-windows",
+  "skill_name": "auth0-flutter-windows",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add Auth0 authentication to a Flutter Windows desktop application using the auth0_flutter SDK.\n\n**Auth0 Credentials:**\n- Domain: `dev-example.auth0.com`\n- Client ID: `abc123def456ghi789jkl012`",
+      "expected_output": "Working Flutter Windows app with Auth0 Web Auth login/logout via windowsWebAuthentication(), appCustomURL passed for the custom URL scheme, and manually managed (not CredentialsManager-backed) credential storage",
+      "expectations": [
+        "auth0_flutter SDK added to pubspec.yaml dependencies",
+        "Has import for the auth0_flutter package (import package:auth0_flutter/auth0_flutter.dart)",
+        "Uses the Auth0 mobile/desktop class (not Auth0Web)",
+        "Uses windowsWebAuthentication() instead of webAuthentication() for login/logout",
+        "Implements login via windowsWebAuthentication().login()",
+        "Implements logout via windowsWebAuthentication().logout()",
+        "Passes appCustomURL to login() and logout()",
+        "Does not use credentialsManager / CredentialsManager (not supported on Windows)",
+        "Manually stores the Credentials object returned from login()",
+        "Auth0 domain dev-example.auth0.com passed to the Auth0 constructor",
+        "Client ID abc123def456ghi789jkl012 passed to the Auth0 constructor",
+        "Does not use web-specific APIs (Auth0Web, auth0_flutter_web.dart, auth0-spa-js)",
+        "Does not use mobile-only manifest config (manifestPlaceholders, AndroidManifest, Info.plist, CFBundleURLTypes)",
+        "No client_secret in native code (PKCE does not require one)",
+        "Solution correctly integrates Auth0 into a Flutter Windows app with login, logout, and manual credential handling"
+      ]
+    }
+  ],
+  "graders": [
+    {
+      "type": "matches",
+      "pattern": "auth0_flutter:\\s*\\^|auth0_flutter:",
+      "description": "auth0_flutter SDK added to pubspec.yaml dependencies"
+    },
+    {
+      "type": "contains",
+      "value": "package:auth0_flutter/auth0_flutter.dart",
+      "description": "Has import for the auth0_flutter package (import package:auth0_flutter/auth0_flutter.dart)"
+    },
+    {
+      "type": "matches",
+      "pattern": "Auth0\\(['\"]|Auth0\\(\\s",
+      "description": "Uses the Auth0 mobile/desktop class (not Auth0Web)"
+    },
+    {
+      "type": "matches",
+      "pattern": "windowsWebAuthentication\\(",
+      "description": "Uses windowsWebAuthentication() instead of webAuthentication() for login/logout"
+    },
+    {
+      "type": "matches",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,40}\\.login\\(",
+      "description": "Implements login via windowsWebAuthentication().login()"
+    },
+    {
+      "type": "matches",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,40}\\.logout\\(",
+      "description": "Implements logout via windowsWebAuthentication().logout()"
+    },
+    {
+      "type": "matches",
+      "pattern": "appCustomURL\\s*:",
+      "description": "Passes appCustomURL to login() and logout()"
+    },
+    {
+      "type": "not_contains_any",
+      "values": [
+        "credentialsManager",
+        "CredentialsManager"
+      ],
+      "description": "Does not use credentialsManager / CredentialsManager (not supported on Windows)"
+    },
+    {
+      "type": "contains",
+      "value": "dev-example.auth0.com",
+      "description": "Auth0 domain dev-example.auth0.com passed to the Auth0 constructor"
+    },
+    {
+      "type": "contains",
+      "value": "abc123def456ghi789jkl012",
+      "description": "Client ID abc123def456ghi789jkl012 passed to the Auth0 constructor"
+    },
+    {
+      "type": "not_contains_any",
+      "values": [
+        "Auth0Web(",
+        "auth0_flutter_web.dart",
+        "auth0-spa-js"
+      ],
+      "description": "Does not use web-specific APIs (Auth0Web, auth0_flutter_web.dart, auth0-spa-js)"
+    },
+    {
+      "type": "not_contains_any",
+      "values": [
+        "manifestPlaceholders",
+        "AndroidManifest",
+        "CFBundleURLTypes"
+      ],
+      "description": "Does not use mobile-only manifest config (manifestPlaceholders, AndroidManifest, Info.plist, CFBundleURLTypes)"
+    },
+    {
+      "type": "not_contains",
+      "value": "client_secret",
+      "description": "No client_secret in native code (PKCE does not require one)"
+    },
+    {
+      "type": "judge",
+      "description": "Solution correctly integrates Auth0 into a Flutter Windows app with login, logout, and manual credential handling",
+      "question": "Does the solution correctly integrate Auth0 into a Flutter Windows desktop app with: (1) working login via auth0.windowsWebAuthentication().login(appCustomURL: ...), (2) logout via windowsWebAuthentication().logout(appCustomURL: ...), (3) the returned Credentials object stored/managed manually by the app (not via a CredentialsManager, which doesn't exist on Windows), and (4) correct Auth0(domain, clientId) initialization?",
+      "examples": "PASS: Uses Auth0(domain, clientId), windowsWebAuthentication().login(appCustomURL: 'myapp://callback') for login, windowsWebAuthentication().logout(appCustomURL: ...) for logout, and stores the returned Credentials in app state or local storage itself.\nFAIL: Uses webAuthentication() or Auth0Web instead of windowsWebAuthentication().\nFAIL: Calls credentialsManager.credentials() as if Windows had automatic credential storage.\nFAIL: Missing appCustomURL on login or logout.",
+      "framework": "dart"
+    }
+  ]
+}

--- a/evals/behavioral/cases/flutter-windows.json
+++ b/evals/behavioral/cases/flutter-windows.json
@@ -59,8 +59,13 @@
     },
     {
       "type": "matches",
-      "pattern": "appCustomURL\\s*:",
-      "description": "Passes appCustomURL to login() and logout()"
+      "pattern": "\\.login\\([\\s\\S]{0,150}?appCustomURL\\s*:",
+      "description": "Passes appCustomURL to login()"
+    },
+    {
+      "type": "matches",
+      "pattern": "\\.logout\\([\\s\\S]{0,150}?appCustomURL\\s*:",
+      "description": "Passes appCustomURL to logout()"
     },
     {
       "type": "not_contains_any",
@@ -94,7 +99,8 @@
       "values": [
         "manifestPlaceholders",
         "AndroidManifest",
-        "CFBundleURLTypes"
+        "CFBundleURLTypes",
+        "Info.plist"
       ],
       "description": "Does not use mobile-only manifest config (manifestPlaceholders, AndroidManifest, Info.plist, CFBundleURLTypes)"
     },

--- a/evals/behavioral/cases/flutter-windows.json
+++ b/evals/behavioral/cases/flutter-windows.json
@@ -49,12 +49,12 @@
     },
     {
       "type": "matches",
-      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\.login\\(",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|(\\w+)\\s*=[^;\\n]*windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\1\\.login\\(",
       "description": "Implements login via windowsWebAuthentication().login()"
     },
     {
       "type": "matches",
-      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\.logout\\(",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|(\\w+)\\s*=[^;\\n]*windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\1\\.logout\\(",
       "description": "Implements logout via windowsWebAuthentication().logout()"
     },
     {

--- a/evals/behavioral/cases/flutter-windows.json
+++ b/evals/behavioral/cases/flutter-windows.json
@@ -49,12 +49,12 @@
     },
     {
       "type": "matches",
-      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,40}\\.login\\(",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.login\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\.login\\(",
       "description": "Implements login via windowsWebAuthentication().login()"
     },
     {
       "type": "matches",
-      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,40}\\.logout\\(",
+      "pattern": "windowsWebAuthentication\\(\\)\\s*\\.logout\\(|windowsWebAuthentication\\(\\)[\\s\\S]{0,300}?\\.logout\\(",
       "description": "Implements logout via windowsWebAuthentication().logout()"
     },
     {

--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -262,6 +262,13 @@
       "framework": null,
       "tooling": "cli",
       "expect_refs": ["feature-healthcheck/index.md", "feature-audit/index.md", "feature-audit-pricing/index.md", "feature-audit-remediation/index.md", "tooling-cli/index.md"]
+    },
+    {
+      "id": "integrate-flutter-windows",
+      "intent": "integrate",
+      "framework": "flutter-windows",
+      "tooling": "cli",
+      "expect_refs": ["framework-flutter-windows/index.md", "tooling-cli/index.md"]
     }
   ]
 }

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -145,24 +145,14 @@ SDK, so check the `@capacitor/browser` rows before it.
 
 ### Mobile (native)
 
-Check the `flutter-windows` row first — a Flutter project can carry a
-`windows/` platform directory alongside `android/`/`ios/`/`web/`; a `windows/`
-directory is the more specific signal.
-
 | Signal | Framework |
 |---|---|
 | `build.gradle(.kts)` + `com.auth0.kmp:auth0` (Kotlin Multiplatform module) | `kmp` |
 | `Package.swift` or `.xcodeproj` + Auth0.swift | `swift` |
 | `build.gradle` + `com.auth0.android:auth0` | `android` |
-| `pubspec.yaml` + `auth0_flutter` + `windows/` platform directory present | `flutter-windows` |
+| `pubspec.yaml` + `auth0_flutter` + `windows/` | `flutter-windows` |
 | `pubspec.yaml` + `auth0_flutter` + `flutter.web: false` | `flutter-native` |
 | `pubspec.yaml` + `auth0_flutter` + web enabled | `flutter-web` |
-
-> **Flutter platform note:** a Flutter project often has multiple platform
-> folders (`android/`, `ios/`, `web/`, `windows/`) at once. If more than one
-> is present and the request doesn't say which platform it's about, ask
-> before loading — don't guess between `flutter-native`, `flutter-web`, and
-> `flutter-windows`.
 
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
@@ -193,7 +183,7 @@ variant is resolved in "Variant disambiguation" below. As in Tier 1, check the
 | `go.mod` present + HTTP server/router | `go` |
 | `org.jetbrains.kotlin.multiplatform` plugin + `commonMain` source set (shared Android+iOS module) | `kmp` |
 | `Package.swift` or `.xcodeproj` | `swift` |
-| `pubspec.yaml` (Flutter) + `windows/` platform directory present | `flutter-windows` |
+| `pubspec.yaml` (Flutter) + `windows/` | `flutter-windows` |
 | `pubspec.yaml` (Flutter, web disabled) | `flutter-native` |
 | `pubspec.yaml` (Flutter, web enabled) | `flutter-web` |
 | `*.csproj` referencing MAUI | `maui` |
@@ -234,7 +224,7 @@ request. **Stop at the first match.**
 | Kotlin Multiplatform / KMP / shared Android+iOS auth code / `com.auth0.kmp` | `kmp` |
 | Swift / iOS | `swift` |
 | Android / Kotlin | `android` |
-| Flutter (native / web / Windows desktop) | `flutter-native` / `flutter-web` / `flutter-windows` |
+| Flutter (native / web / Windows) | `flutter-native` / `flutter-web` / `flutter-windows` |
 | React Native / Expo | `react-native` / `expo` |
 | Ionic (Angular/React/Vue) | `ionic-angular` / `ionic-react` / `ionic-vue` |
 

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -145,13 +145,24 @@ SDK, so check the `@capacitor/browser` rows before it.
 
 ### Mobile (native)
 
+Check the `flutter-windows` row first — a Flutter project can carry a
+`windows/` platform directory alongside `android/`/`ios/`/`web/`; a `windows/`
+directory is the more specific signal.
+
 | Signal | Framework |
 |---|---|
 | `build.gradle(.kts)` + `com.auth0.kmp:auth0` (Kotlin Multiplatform module) | `kmp` |
 | `Package.swift` or `.xcodeproj` + Auth0.swift | `swift` |
 | `build.gradle` + `com.auth0.android:auth0` | `android` |
+| `pubspec.yaml` + `auth0_flutter` + `windows/` platform directory present | `flutter-windows` |
 | `pubspec.yaml` + `auth0_flutter` + `flutter.web: false` | `flutter-native` |
 | `pubspec.yaml` + `auth0_flutter` + web enabled | `flutter-web` |
+
+> **Flutter platform note:** a Flutter project often has multiple platform
+> folders (`android/`, `ios/`, `web/`, `windows/`) at once. If more than one
+> is present and the request doesn't say which platform it's about, ask
+> before loading — don't guess between `flutter-native`, `flutter-web`, and
+> `flutter-windows`.
 
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
@@ -182,6 +193,7 @@ variant is resolved in "Variant disambiguation" below. As in Tier 1, check the
 | `go.mod` present + HTTP server/router | `go` |
 | `org.jetbrains.kotlin.multiplatform` plugin + `commonMain` source set (shared Android+iOS module) | `kmp` |
 | `Package.swift` or `.xcodeproj` | `swift` |
+| `pubspec.yaml` (Flutter) + `windows/` platform directory present | `flutter-windows` |
 | `pubspec.yaml` (Flutter, web disabled) | `flutter-native` |
 | `pubspec.yaml` (Flutter, web enabled) | `flutter-web` |
 | `*.csproj` referencing MAUI | `maui` |
@@ -222,7 +234,7 @@ request. **Stop at the first match.**
 | Kotlin Multiplatform / KMP / shared Android+iOS auth code / `com.auth0.kmp` | `kmp` |
 | Swift / iOS | `swift` |
 | Android / Kotlin | `android` |
-| Flutter (native / web) | `flutter-native` / `flutter-web` |
+| Flutter (native / web / Windows desktop) | `flutter-native` / `flutter-web` / `flutter-windows` |
 | React Native / Expo | `react-native` / `expo` |
 | Ionic (Angular/React/Vue) | `ionic-angular` / `ionic-react` / `ionic-vue` |
 

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -150,9 +150,15 @@ SDK, so check the `@capacitor/browser` rows before it.
 | `build.gradle(.kts)` + `com.auth0.kmp:auth0` (Kotlin Multiplatform module) | `kmp` |
 | `Package.swift` or `.xcodeproj` + Auth0.swift | `swift` |
 | `build.gradle` + `com.auth0.android:auth0` | `android` |
-| `pubspec.yaml` + `auth0_flutter` + `windows/` | `flutter-windows` |
+| `pubspec.yaml` + `auth0_flutter` + developer names/targets Windows desktop | `flutter-windows` |
 | `pubspec.yaml` + `auth0_flutter` + `flutter.web: false` | `flutter-native` |
 | `pubspec.yaml` + `auth0_flutter` + web enabled | `flutter-web` |
+
+> `flutter create` scaffolds `windows/`, `android/`, `ios/`, and `web/`
+> together by default, so the presence of `windows/` alone doesn't mean
+> Windows is the target. Only pick `flutter-windows` when the developer's
+> request names Windows/desktop, or `windows/` is the *only* platform
+> directory present. Otherwise ask which platform(s) they're building for.
 
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
@@ -183,7 +189,7 @@ their base framework.
 | `go.mod` present + HTTP server/router | `go` |
 | `org.jetbrains.kotlin.multiplatform` plugin + `commonMain` source set (shared Android+iOS module) | `kmp` |
 | `Package.swift` or `.xcodeproj` | `swift` |
-| `pubspec.yaml` (Flutter) + `windows/` | `flutter-windows` |
+| `pubspec.yaml` (Flutter) + developer names/targets Windows desktop | `flutter-windows` |
 | `pubspec.yaml` (Flutter, web disabled) | `flutter-native` |
 | `pubspec.yaml` (Flutter, web enabled) | `flutter-web` |
 | `*.csproj` referencing MAUI | `maui` |

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -31,10 +31,10 @@ Detect intent → detect framework → detect tooling → load 2–3 reference f
 ## Step 1: Detect intent
 
 Match the request against the **What the developer wants** column — it describes
-the goal in plain language, not just the Auth0 term (someone who says *"make
-users confirm with a code from their phone"* lands on `feature:mfa`). The
-**Intent** you pick is a lookup key: in **Step 4** it appears verbatim as a
-section heading (`### feature:mfa`) listing which reference files to load.
+the goal in plain language, not just the Auth0 term (e.g. *"make users confirm
+with a code from their phone"* → `feature:mfa`). The **Intent** you pick is a
+lookup key: in **Step 4** it appears verbatim as a section heading
+(`### feature:mfa`) listing which reference files to load.
 
 | What the developer wants (plain language + Auth0 term) | Intent |
 |---|---|
@@ -58,15 +58,15 @@ section heading (`### feature:mfa`) listing which reference files to load.
 
 ### If nothing clearly matches
 
-Pick the closest goal. If the goal is genuinely unclear, ask the developer what they're trying to accomplish - don't guess an intent.
+Pick the closest goal, or ask what they're trying to accomplish if genuinely unclear — don't guess.
 
 ---
 
 ## Step 2: Detect framework
 
-> **Skip this step for the `tooling` intent** — a CLI-first request has no
-> framework. Go to Step 3, load the tooling reference; only ask about a
-> framework if the developer later pivots to integrating auth into an app.
+> **Skip this step for the `tooling` intent** — go to Step 3 and load the
+> tooling reference; only revisit framework if the developer pivots to
+> integrating auth into an app.
 
 Work top-down. **Stop at the first tier that yields a framework.**
 
@@ -157,9 +157,9 @@ SDK, so check the `@capacitor/browser` rows before it.
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
 If no Auth0 SDK matched, detect the framework from ordinary (non-Auth0)
-dependencies. **Stop at the first match.** This picks the base; any web-vs-API
-variant is resolved in "Variant disambiguation" below. As in Tier 1, check the
-`@ionic/*` rows before their base framework.
+dependencies. **Stop at the first match.** Web-vs-API variants are resolved in
+"Variant disambiguation" below. As in Tier 1, check `@ionic/*` rows before
+their base framework.
 
 | Signal | Base framework |
 |---|---|
@@ -241,8 +241,7 @@ pin the variant, choose **intent-first**:
 | laravel | `laravel` | `laravel-api` | API-only (token guard), no Blade UI |
 | aspnetcore | `aspnetcore-auth` | `aspnetcore-api` | Web API / JWT bearer, no cookie login UI |
 
-If intent is still ambiguous (both a UI and protected endpoints, or unclear),
-**state what you detected and ask the developer** web app vs API before loading.
+If still ambiguous, **state what you detected and ask** web app vs API before loading.
 
 ### If nothing matched
 
@@ -250,10 +249,9 @@ Ask the developer what framework/language they are using. Do not guess.
 
 ### Conflicts
 
-If Tier 2 (workspace) and Tier 3 (prompt) disagree materially (e.g. the prompt
-says "Next.js" but `package.json` has no `next`), **state the conflict and ask**
-rather than silently picking. Workspace signals outrank the prompt when both are
-present and consistent.
+If Tier 2 (workspace) and Tier 3 (prompt) disagree materially (e.g. prompt says
+"Next.js" but `package.json` has no `next`), **state the conflict and ask**
+rather than silently picking. Workspace outranks prompt when both are consistent.
 
 ---
 

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -31,10 +31,10 @@ Detect intent → detect framework → detect tooling → load 2–3 reference f
 ## Step 1: Detect intent
 
 Match the request against the **What the developer wants** column — it describes
-the goal in plain language, not just the Auth0 term (e.g. *"make users confirm
-with a code from their phone"* → `feature:mfa`). The **Intent** you pick is a
-lookup key: in **Step 4** it appears verbatim as a section heading
-(`### feature:mfa`) listing which reference files to load.
+the goal in plain language, not just the Auth0 term (someone who says *"make
+users confirm with a code from their phone"* lands on `feature:mfa`). The
+**Intent** you pick is a lookup key: in **Step 4** it appears verbatim as a
+section heading (`### feature:mfa`) listing which reference files to load.
 
 | What the developer wants (plain language + Auth0 term) | Intent |
 |---|---|
@@ -58,15 +58,15 @@ lookup key: in **Step 4** it appears verbatim as a section heading
 
 ### If nothing clearly matches
 
-Pick the closest goal, or ask what they're trying to accomplish if genuinely unclear — don't guess.
+Pick the closest goal. If the goal is genuinely unclear, ask the developer what they're trying to accomplish - don't guess an intent.
 
 ---
 
 ## Step 2: Detect framework
 
-> **Skip this step for the `tooling` intent** — go to Step 3 and load the
-> tooling reference; only revisit framework if the developer pivots to
-> integrating auth into an app.
+> **Skip this step for the `tooling` intent** — a CLI-first request has no
+> framework. Go to Step 3, load the tooling reference; only ask about a
+> framework if the developer later pivots to integrating auth into an app.
 
 Work top-down. **Stop at the first tier that yields a framework.**
 
@@ -163,9 +163,9 @@ SDK, so check the `@capacitor/browser` rows before it.
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
 If no Auth0 SDK matched, detect the framework from ordinary (non-Auth0)
-dependencies. **Stop at the first match.** Web-vs-API variants are resolved in
-"Variant disambiguation" below. As in Tier 1, check `@ionic/*` rows before
-their base framework.
+dependencies. **Stop at the first match.** This picks the base; any web-vs-API
+variant is resolved in "Variant disambiguation" below. As in Tier 1, check the
+`@ionic/*` rows before their base framework.
 
 | Signal | Base framework |
 |---|---|
@@ -247,7 +247,8 @@ pin the variant, choose **intent-first**:
 | laravel | `laravel` | `laravel-api` | API-only (token guard), no Blade UI |
 | aspnetcore | `aspnetcore-auth` | `aspnetcore-api` | Web API / JWT bearer, no cookie login UI |
 
-If still ambiguous, **state what you detected and ask** web app vs API before loading.
+If intent is still ambiguous (both a UI and protected endpoints, or unclear),
+**state what you detected and ask the developer** web app vs API before loading.
 
 ### If nothing matched
 
@@ -255,9 +256,10 @@ Ask the developer what framework/language they are using. Do not guess.
 
 ### Conflicts
 
-If Tier 2 (workspace) and Tier 3 (prompt) disagree materially (e.g. prompt says
-"Next.js" but `package.json` has no `next`), **state the conflict and ask**
-rather than silently picking. Workspace outranks prompt when both are consistent.
+If Tier 2 (workspace) and Tier 3 (prompt) disagree materially (e.g. the prompt
+says "Next.js" but `package.json` has no `next`), **state the conflict and ask**
+rather than silently picking. Workspace signals outrank the prompt when both are
+present and consistent.
 
 ---
 

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -154,12 +154,6 @@ SDK, so check the `@capacitor/browser` rows before it.
 | `pubspec.yaml` + `auth0_flutter` + `flutter.web: false` | `flutter-native` |
 | `pubspec.yaml` + `auth0_flutter` + web enabled | `flutter-web` |
 
-> `flutter create` scaffolds `windows/`, `android/`, `ios/`, and `web/`
-> together by default, so the presence of `windows/` alone doesn't mean
-> Windows is the target. Only pick `flutter-windows` when the developer's
-> request names Windows/desktop, or `windows/` is the *only* platform
-> directory present. Otherwise ask which platform(s) they're building for.
-
 ### Tier 2 — Framework from non-Auth0 workspace dependencies
 
 If no Auth0 SDK matched, detect the framework from ordinary (non-Auth0)

--- a/plugins/auth0/skills/auth0/references/framework-flutter-native/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flutter-native/index.md
@@ -25,6 +25,7 @@
 ## When NOT to Use
 
 - **Flutter web**: Use the Auth0 Flutter web integration — web uses a different platform interface (`Auth0Web`) wrapping Auth0 SPA JS
+- **Flutter Windows desktop**: Use the Auth0 Flutter Windows integration — Windows uses `windowsWebAuthentication()`, a custom URL scheme + Registry protocol handler, and has no `CredentialsManager`
 - **Native iOS (Swift, no Flutter)**: Use the Auth0 Swift integration
 - **Native Android (Kotlin/Java, no Flutter)**: Use the Auth0 Android integration
 - **React Native**: Use the Auth0 React Native integration
@@ -409,6 +410,7 @@ For complete patterns with Riverpod, Bloc, biometrics, and advanced scenarios, s
 
 - Initial Auth0 setup and account creation — if Auth0 isn't set up yet, set it up first with the Auth0 CLI (`auth0 login`, then `auth0 apps create`)
 - Same SDK on the web platform — ask for the Auth0 Flutter web integration
+- Same SDK on Windows desktop — ask for the Auth0 Flutter Windows integration
 - Native iOS (Swift) — ask for the Auth0 Swift integration
 - Native Android (Kotlin/Java) — ask for the Auth0 Android integration
 

--- a/plugins/auth0/skills/auth0/references/framework-flutter-web/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flutter-web/index.md
@@ -14,6 +14,7 @@
 ## When NOT to Use
 
 - **Flutter mobile (iOS/Android)**: use the Auth0 integration workflow for Flutter native — mobile uses a different platform interface with Web Auth via system browser
+- **Flutter Windows desktop**: use the Auth0 integration workflow for Flutter Windows — Windows uses `windowsWebAuthentication()` and a custom URL scheme protocol handler, not the browser-embedded `Auth0Web` API
 - **Native iOS (Swift)**: use the Auth0 integration workflow for Swift
 - **Native Android (Kotlin/Java)**: use the Auth0 integration workflow for Android
 - **React SPA**: use the Auth0 integration workflow for React

--- a/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
@@ -235,11 +235,24 @@ import 'package:shared_preferences/shared_preferences.dart';
 class AuthService {
   late final Auth0 _auth0;
   Credentials? _credentials;
-
-  static const _appCustomURL = 'myapp://callback';
+  final String _appCustomURL;
+  final String? _redirectUrl;
+  final String? _returnTo;
   static const _credentialsKey = 'auth0_credentials';
 
-  AuthService({required String domain, required String clientId}) {
+  AuthService({
+    required String domain,
+    required String clientId,
+    required String appCustomURL,
+    String? redirectUrl,
+    String? returnTo,
+  })  : _appCustomURL = appCustomURL,
+        _redirectUrl = redirectUrl,
+        _returnTo = returnTo {
+    assert(
+      (redirectUrl == null) == (returnTo == null),
+      'Set both redirectUrl and returnTo when using the intermediary HTTPS callback.',
+    );
     _auth0 = Auth0(domain, clientId);
   }
 
@@ -258,17 +271,34 @@ class AuthService {
   /// Launch Web Auth via the system browser and persist the result.
   /// No credentials are stored automatically on Windows.
   Future<void> login() async {
-    _credentials = await _auth0.windowsWebAuthentication().login(
-      appCustomURL: _appCustomURL,
-      scopes: {'openid', 'profile', 'email', 'offline_access'},
-    );
+    final webAuth = _auth0.windowsWebAuthentication();
+    if (_redirectUrl == null) {
+      _credentials = await webAuth.login(
+        appCustomURL: _appCustomURL,
+        scopes: {'openid', 'profile', 'email', 'offline_access'},
+      );
+    } else {
+      _credentials = await webAuth.login(
+        appCustomURL: _appCustomURL,
+        redirectUrl: _redirectUrl!,
+        scopes: {'openid', 'profile', 'email', 'offline_access'},
+      );
+    }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_credentialsKey, jsonEncode(_credentials!.toMap()));
   }
 
   /// Clear the browser session and drop persisted + in-memory credentials.
   Future<void> logout() async {
-    await _auth0.windowsWebAuthentication().logout(appCustomURL: _appCustomURL);
+    final webAuth = _auth0.windowsWebAuthentication();
+    if (_returnTo == null) {
+      await webAuth.logout(appCustomURL: _appCustomURL);
+    } else {
+      await webAuth.logout(
+        appCustomURL: _appCustomURL,
+        returnTo: _returnTo!,
+      );
+    }
     _credentials = null;
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_credentialsKey);
@@ -302,6 +332,10 @@ class _MyAppState extends State<MyApp> {
   final _authService = AuthService(
     domain: 'YOUR_AUTH0_DOMAIN',
     clientId: 'YOUR_AUTH0_CLIENT_ID',
+    appCustomURL: 'com.example.app://callback',
+    // For Option B, also set:
+    // redirectUrl: 'https://your-app.example.com/callback',
+    // returnTo: 'https://your-app.example.com/logout',
   );
 
   @override

--- a/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
@@ -222,17 +222,17 @@ waiting plugin.
 
 ### Step 7 — Implement Authentication
 
-> **Agent instruction:** search the project for the main app entry point (`lib/main.dart`). Create an `AuthService` class that stores `Credentials` manually — there is no `CredentialsManager` on Windows, so the app owns persistence (e.g. via `shared_preferences` or secure storage).
+> **Agent instruction:** search the project for the main app entry point (`lib/main.dart`). Create an `AuthService` class that stores `Credentials` manually — there is no `CredentialsManager` on Windows, so the app owns persistence via secure storage (e.g. `flutter_secure_storage`), since the credentials can include a refresh token.
 
 ```bash
-flutter pub add shared_preferences
+flutter pub add flutter_secure_storage
 ```
 
 ```dart
 // lib/auth_service.dart
 import 'dart:convert';
 import 'package:auth0_flutter/auth0_flutter.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class AuthService {
   late final Auth0 _auth0;
@@ -240,6 +240,7 @@ class AuthService {
   final String _appCustomURL;
   final String? _redirectUrl;
   final String? _returnTo;
+  static const _storage = FlutterSecureStorage();
   static const _credentialsKey = 'auth0_credentials';
 
   AuthService({
@@ -263,17 +264,21 @@ class AuthService {
   UserProfile? get user => _credentials?.user;
 
   /// Restore credentials saved from a previous session, if still valid.
-  /// There's no refresh-token renewal here — an expired record is dropped,
-  /// leaving the user to log in again.
+  /// There's no refresh-token renewal here — an expired or unreadable
+  /// record is dropped, leaving the user to log in again.
   Future<void> restoreSession() async {
-    final prefs = await SharedPreferences.getInstance();
-    final stored = prefs.getString(_credentialsKey);
+    final stored = await _storage.read(key: _credentialsKey);
     if (stored == null) return;
-    final credentials = Credentials.fromMap(jsonDecode(stored));
-    if (credentials.expiresAt.isAfter(DateTime.now())) {
-      _credentials = credentials;
-    } else {
-      await prefs.remove(_credentialsKey);
+    try {
+      final credentials = Credentials.fromMap(jsonDecode(stored));
+      if (credentials.expiresAt.isAfter(DateTime.now())) {
+        _credentials = credentials;
+      } else {
+        await _storage.delete(key: _credentialsKey);
+      }
+    } catch (_) {
+      // Malformed or outdated schema from a previous app version.
+      await _storage.delete(key: _credentialsKey);
     }
   }
 
@@ -293,8 +298,10 @@ class AuthService {
         scopes: {'openid', 'profile', 'email', 'offline_access'},
       );
     }
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_credentialsKey, jsonEncode(_credentials!.toMap()));
+    await _storage.write(
+      key: _credentialsKey,
+      value: jsonEncode(_credentials!.toMap()),
+    );
   }
 
   /// Clear the browser session and drop persisted + in-memory credentials.
@@ -314,17 +321,16 @@ class AuthService {
       }
     } finally {
       _credentials = null;
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_credentialsKey);
+      await _storage.delete(key: _credentialsKey);
     }
   }
 }
 ```
 
-> **Note:** `shared_preferences` stores plaintext on disk — fine for this
-> example, but for production apps handling refresh tokens prefer OS-backed
-> secure storage (e.g. `flutter_secure_storage`, which uses DPAPI on
-> Windows).
+> **Note:** `login()` requests the `offline_access` scope, so the persisted
+> `Credentials` can contain a refresh token — store it with
+> `flutter_secure_storage` (DPAPI-backed on Windows), never with
+> `shared_preferences`, which is plaintext on disk.
 
 ```dart
 // lib/main.dart

--- a/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
@@ -1,0 +1,441 @@
+# Auth0 Flutter Windows
+
+# Auth0 Flutter Windows Desktop Integration
+
+`auth0_flutter` is the official Auth0 SDK for Flutter applications. **Windows
+desktop** support reached General Availability in SDK v2.1.0. It uses a
+different API surface than mobile/web: `windowsWebAuthentication()` instead
+of `webAuthentication()`, a custom URL scheme registered as a Windows
+protocol handler instead of Info.plist/AndroidManifest registration, a native
+C++ runner integration to receive the callback, and **no built-in credential
+storage** — the app must persist the returned `Credentials` itself.
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running one of:
+> ```bash
+> gh api repos/auth0/auth0-flutter/releases/latest --jq '.tag_name'
+> ```
+> ```bash
+> flutter pub info auth0_flutter 2>/dev/null | head -5
+> ```
+> Or check pub.dev:
+> ```bash
+> curl -s https://pub.dev/api/packages/auth0_flutter | python3 -c "import sys,json;print(json.load(sys.stdin)['latest']['version'])"
+> ```
+> Use the returned version in all dependency lines instead of any hardcoded version below. Windows support requires v2.1.0 or later.
+
+## When NOT to Use
+
+- **Flutter mobile (iOS/Android)**: use the Auth0 integration workflow for Flutter native — mobile uses `webAuthentication()` and the built-in `CredentialsManager`, neither of which apply here
+- **Flutter web**: use the Auth0 integration workflow for Flutter web — browser platform, different API (`Auth0Web`)
+- **Flutter macOS**: macOS goes through the same mobile-style `webAuthentication()` flow documented in the Flutter native reference, not the Windows-specific API in this file
+- **Flutter Linux**: `auth0_flutter` has no official Linux support (only an unofficial third-party plugin exists) — flag this to the user rather than guessing at an implementation
+- **.NET MAUI, WinForms, or WPF desktop apps**: those use the `Auth0.OidcClient.*` NuGet packages, a completely different SDK family — use the Auth0 integration workflow for MAUI/WinForms/WPF
+- **Native iOS (Swift, no Flutter)** or **native Android (Kotlin/Java, no Flutter)**: use the Auth0 Swift or Android integration
+
+## Prerequisites
+
+| Flutter | Windows | Native tooling |
+|---|---|---|
+| SDK 3.24.0+ | Windows 10+ | C++17, Visual Studio 2022 |
+| Dart 3.5.0+ | | [vcpkg](https://vcpkg.io/) (for native dependencies) |
+
+- Auth0 account — [Sign up free](https://auth0.com/signup)
+- Auth0 CLI — [install instructions](https://github.com/auth0/auth0-cli) (used to create and configure the Auth0 application)
+
+## Quick Start Workflow
+
+> **Agent instruction:** Follow these steps in order. If you encounter an error at any step, attempt to fix it up to 5 times before calling `AskUserQuestion` to ask the user for guidance. Always search existing code first — if there are existing login/logout handlers, hook into them rather than creating new ones.
+
+### Step 1 — Install SDK
+
+> **Agent instruction:** Check the project directory for `pubspec.yaml` and a `windows/` platform directory. If neither is present, this is not a Flutter Windows project — ask the user.
+
+```bash
+flutter pub add auth0_flutter
+```
+
+### Step 2 — Choose a callback pattern and configure Auth0
+
+Windows has no OS-level equivalent of an iOS Universal Link or Android App
+Link — the app registers a **custom URL scheme** (e.g. `myapp://callback`)
+as a Windows protocol handler, and Auth0 redirects to it after login. There
+are two supported patterns:
+
+- **Option A — Direct custom-scheme redirect (recommended for most apps).**
+  Register the custom scheme directly as the callback/logout URL. Simpler,
+  but the browser may leave a blank tab open after redirecting (a browser
+  behavior, not an error).
+- **Option B — Intermediary HTTPS server.** Register an HTTPS URL you
+  control as the callback/logout URL; that server 302s onward to the custom
+  scheme, letting it show a "Returning you to the app…" page and close
+  cleanly. Requires you to run and validate a small server endpoint.
+
+> **Agent instruction:**
+> - **If Auth0 credentials (domain AND client ID) are already in the user's prompt:** use those values directly.
+> - **If no credentials are provided:** ask the user whether to create the Auth0 application automatically (Auth0 CLI) or manually (Dashboard), and which callback pattern (A or B) they want. Default to Option A unless the user specifically wants to avoid a lingering browser tab.
+> - Choose a scheme name unique to the app (e.g. `myapp`, `com.company.myapp`) and use it consistently across the Auth0 Dashboard, the Windows Registry, and the Dart `appCustomURL` value.
+
+Create a **Native** application, then register the callback and logout URLs:
+
+```bash
+# Option A — direct custom scheme
+auth0 apps update CLIENT_ID \
+  --callbacks "myapp://callback" \
+  --logout-urls "myapp://callback" \
+  --no-input
+
+# Option B — intermediary HTTPS server
+auth0 apps update CLIENT_ID \
+  --callbacks "https://your-app.example.com/callback" \
+  --logout-urls "https://your-app.example.com/logout" \
+  --no-input
+```
+
+### Step 3 — Install native dependencies via vcpkg
+
+The Windows plugin is implemented in native C++ and depends on `cpp-httplib`,
+`nlohmann-json`, and `openssl`, managed via vcpkg. The plugin's own
+`vcpkg.json` manifest lives inside the plugin package, not the app's
+`windows/` root, so vcpkg's manifest mode won't auto-install these — install
+them explicitly into the vcpkg instance:
+
+```powershell
+git clone https://github.com/microsoft/vcpkg
+.\vcpkg\bootstrap-vcpkg.bat
+setx VCPKG_ROOT "%CD%\vcpkg"
+```
+
+```powershell
+vcpkg install --recurse "cpp-httplib[core,openssl]:x64-windows" nlohmann-json:x64-windows openssl:x64-windows
+```
+
+### Step 4 — Configure `windows/CMakeLists.txt`
+
+The app's top-level `windows/CMakeLists.txt` must enable vcpkg toolchain
+integration so the plugin's native dependencies resolve. Add this **before**
+the first `project()` call:
+
+```cmake
+# windows/CMakeLists.txt
+
+cmake_minimum_required(VERSION 3.14)
+
+# --- vcpkg integration (required for auth0_flutter) ---
+if(DEFINED ENV{VCPKG_ROOT} AND EXISTS "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        CACHE STRING "Vcpkg toolchain file")
+endif()
+
+project(your_app LANGUAGES CXX)
+
+# ... rest of your CMakeLists.txt ...
+```
+
+> **Agent instruction:** the `CMAKE_TOOLCHAIN_FILE` assignment must come before `project()`. If it's added after, CMake will already have configured the compiler and the build fails with errors like `Could not find a package configuration file provided by "httplib"`. Insert it into the existing file rather than overwriting other content.
+
+### Step 5 — Register the custom URL scheme
+
+Windows routes `myapp://callback` back to the app via a Registry protocol
+handler entry. Pick the registration method based on where the app is in its
+lifecycle:
+
+**Development — manual `.reg` file:**
+
+```reg
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\myapp]
+@="URL:myapp Protocol"
+"URL Protocol"=""
+
+[HKEY_CURRENT_USER\Software\Classes\myapp\shell]
+
+[HKEY_CURRENT_USER\Software\Classes\myapp\shell\open]
+
+[HKEY_CURRENT_USER\Software\Classes\myapp\shell\open\command]
+@="\"C:\\Path\\To\\Your\\App\\your_app.exe\" \"%1\""
+```
+
+Replace `myapp` with the chosen scheme and the path with the built
+executable (e.g. `build\windows\x64\runner\Debug\your_app.exe` during
+development, the installed path in production).
+
+**Production — installer or first-run registration:** if the app ships via
+MSIX, declare the protocol in `Package.appxmanifest`:
+
+```xml
+<Extensions>
+  <uap:Extension Category="windows.protocol">
+    <uap:Protocol Name="myapp">
+      <uap:DisplayName>My App Callback</uap:DisplayName>
+    </uap:Protocol>
+  </uap:Extension>
+</Extensions>
+```
+
+For other installers (Inno Setup, WiX) or a first-run self-registration
+approach, write the same Registry keys shown above from the installer script
+or from `main.cpp` on first launch.
+
+### Step 6 — Update the Windows runner (`windows/runner/main.cpp`)
+
+The plugin does not automatically receive OS protocol-scheme activations —
+the app's runner must capture the callback URI and hand it to the plugin via
+the `PLUGIN_STARTUP_URL` environment variable. Without this, `login()` always
+times out with `USER_CANCELLED` because the callback never reaches the
+waiting plugin.
+
+> **Agent instruction:** this involves security-sensitive Win32 code (a
+> named pipe with a restricted DACL, single-instance mutex handling, prefix
+> validation of the forwarded URI). Do not hand-write this logic from
+> memory — fetch the canonical reference implementation and adapt only the
+> callback-prefix constant to the chosen scheme:
+> ```bash
+> curl -sL https://raw.githubusercontent.com/auth0/auth0-flutter/main/auth0_flutter/example/windows/runner/main.cpp
+> ```
+> The three required pieces, copied from that file into the app's
+> `wWinMain`:
+> 1. **Single-instance mutex** — a second launch triggered by the OS
+>    protocol handler forwards its URI to the already-running instance
+>    instead of opening a new window.
+> 2. **Named-pipe server** (`\\.\pipe\auth0flutter_pipe`) — the running
+>    instance listens for the forwarded URI, validates it starts with the
+>    app's callback prefix (e.g. `myapp://callback`), and writes it to
+>    `PLUGIN_STARTUP_URL`. The pipe's security descriptor must restrict
+>    access to the current user only — do not use a `NULL` security
+>    descriptor, which would let any process on the machine inject an
+>    arbitrary startup URL.
+> 3. **Startup URI capture** — on first launch, `argv[1]` (the
+>    protocol-scheme URI, if present) is written to `PLUGIN_STARTUP_URL`
+>    before Flutter starts, after the same prefix check.
+>
+> Update `kCallbackPrefix` in the copied file to match the chosen scheme
+> (e.g. `L"myapp://callback"`).
+
+### Step 7 — Implement Authentication
+
+> **Agent instruction:** search the project for the main app entry point (`lib/main.dart`). Create an `AuthService` class that stores `Credentials` manually — there is no `CredentialsManager` on Windows, so the app owns persistence (e.g. via `shared_preferences` or secure storage).
+
+```dart
+// lib/auth_service.dart
+import 'package:auth0_flutter/auth0_flutter.dart';
+
+class AuthService {
+  late final Auth0 _auth0;
+  Credentials? _credentials;
+
+  static const _appCustomURL = 'myapp://callback';
+
+  AuthService({required String domain, required String clientId}) {
+    _auth0 = Auth0(domain, clientId);
+  }
+
+  bool get isAuthenticated => _credentials != null;
+  UserProfile? get user => _credentials?.user;
+
+  /// Launch Web Auth via the system browser. No credentials are stored
+  /// automatically on Windows — persist the result yourself.
+  Future<void> login() async {
+    _credentials = await _auth0.windowsWebAuthentication().login(
+      appCustomURL: _appCustomURL,
+      scopes: {'openid', 'profile', 'email', 'offline_access'},
+    );
+    // TODO: persist _credentials (e.g. shared_preferences / secure storage)
+  }
+
+  /// Clear the browser session and drop the in-memory credentials.
+  Future<void> logout() async {
+    await _auth0.windowsWebAuthentication().logout(appCustomURL: _appCustomURL);
+    _credentials = null;
+    // TODO: also clear any persisted credentials
+  }
+}
+```
+
+```dart
+// lib/main.dart
+import 'package:flutter/material.dart';
+import 'package:auth0_flutter/auth0_flutter.dart'; // for WebAuthenticationException
+import 'auth_service.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final _authService = AuthService(
+    domain: 'YOUR_AUTH0_DOMAIN',
+    clientId: 'YOUR_AUTH0_CLIENT_ID',
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: _authService.isAuthenticated
+          ? HomeScreen(authService: _authService, onChanged: _refresh)
+          : LoginScreen(authService: _authService, onChanged: _refresh),
+    );
+  }
+
+  void _refresh() => setState(() {});
+}
+
+class LoginScreen extends StatelessWidget {
+  final AuthService authService;
+  final VoidCallback onChanged;
+  const LoginScreen({super.key, required this.authService, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () async {
+            final messenger = ScaffoldMessenger.of(context);
+            try {
+              await authService.login();
+              onChanged();
+            } on WebAuthenticationException catch (e) {
+              messenger.showSnackBar(
+                SnackBar(content: Text('Login failed: ${e.message}')),
+              );
+            }
+          },
+          child: const Text('Log In'),
+        ),
+      ),
+    );
+  }
+}
+
+class HomeScreen extends StatelessWidget {
+  final AuthService authService;
+  final VoidCallback onChanged;
+  const HomeScreen({super.key, required this.authService, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = authService.user;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home'),
+        actions: [
+          IconButton(
+            onPressed: () async {
+              await authService.logout();
+              onChanged();
+            },
+            icon: const Icon(Icons.logout),
+          ),
+        ],
+      ),
+      body: Center(child: Text('Welcome, ${user?.name ?? 'User'}!')),
+    );
+  }
+}
+```
+
+### Step 8 — Verify Build
+
+```bash
+flutter build windows --debug
+flutter run -d windows
+```
+
+If the build fails, review error messages and fix up to 5 times before
+asking the user. Common failures at this step are usually a missing vcpkg
+toolchain line (Step 4) or missing vcpkg packages (Step 3).
+
+## Callback URL Configuration
+
+| Pattern | `appCustomURL` | `redirectUrl` (login) / `returnTo` (logout) | Allowed Callback/Logout URL registered in Dashboard |
+|---|---|---|---|
+| Option A — direct | required, e.g. `myapp://callback` | omit | `myapp://callback` |
+| Option B — intermediary server | required | required, e.g. `https://your-app.example.com/callback` | the HTTPS URL |
+
+`appCustomURL` is always required — it's the scheme the app listens on and,
+in Option A, doubles as the `redirect_uri`/`returnTo` value automatically.
+
+Minimal intermediary-server implementation (Node.js/Express) for Option B —
+validate `state` server-side before forwarding, since this endpoint is an
+open-redirect target otherwise:
+
+```javascript
+app.get('/callback', (req, res) => {
+  const { code, state, error, error_description } = req.query;
+  if (error) {
+    res.redirect(`myapp://callback?error=${error}&error_description=${encodeURIComponent(error_description)}`);
+  } else {
+    res.redirect(`myapp://callback?code=${code}&state=${state}`);
+  }
+});
+```
+
+## Security Considerations
+
+- Custom URL schemes are vulnerable to app-impersonation: another app could
+  register the same scheme on the same device. PKCE is enabled automatically
+  by the SDK and is the primary mitigation — no extra configuration needed.
+- In Option B, validate `state` on the intermediary server before
+  redirecting onward; the SDK also validates `state` client-side as part of
+  PKCE, but server-side validation is defense-in-depth against open-redirect
+  abuse of that endpoint.
+- The named pipe used for single-instance URI forwarding (Step 6) must
+  restrict its DACL to the current user — an unrestricted pipe lets any
+  local process inject an arbitrary startup URL.
+
+## Done When
+
+- [ ] `auth0_flutter` added to `pubspec.yaml` (version pinned, Windows GA v2.1.0+)
+- [ ] vcpkg installed with `cpp-httplib`, `nlohmann-json`, `openssl` for `x64-windows`
+- [ ] `windows/CMakeLists.txt` sets `CMAKE_TOOLCHAIN_FILE` before `project()`
+- [ ] Custom URL scheme registered in the Windows Registry (or installer/MSIX manifest)
+- [ ] `windows/runner/main.cpp` updated with the mutex + named-pipe + startup-URI logic, adapted from the SDK's example runner
+- [ ] Callback/logout URLs registered in the Auth0 Dashboard matching the chosen pattern (A or B)
+- [ ] `AuthService` calls `windowsWebAuthentication().login()` / `.logout()` with `appCustomURL`
+- [ ] Returned `Credentials` are persisted manually (no `CredentialsManager` on Windows)
+- [ ] `flutter build windows` succeeds
+- [ ] Login → redirect → callback → app foregrounded → credentials received tested end-to-end
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| `login()` always times out with `USER_CANCELLED` | The runner isn't forwarding the callback URI — verify `windows/runner/main.cpp` has the mutex/pipe/`PLUGIN_STARTUP_URL` integration from Step 6 |
+| Build fails with `Could not find a package configuration file provided by "httplib"` | `CMAKE_TOOLCHAIN_FILE` was set after `project()` in `windows/CMakeLists.txt`, or vcpkg packages weren't installed — redo Steps 3–4 |
+| Assuming `credentialsManager` exists on Windows | It doesn't — Windows has no `CredentialsManager`; store and restore `Credentials` manually |
+| Using `webAuthentication()` instead of `windowsWebAuthentication()` | Windows requires the Windows-specific API, which also requires `appCustomURL` |
+| Scheme registered in the Registry doesn't match `appCustomURL` in Dart, or the Dashboard callback URL | All three (Registry scheme, `appCustomURL`, Dashboard Allowed Callback/Logout URLs) must use the exact same scheme string |
+| Using Option B without validating `state` server-side | The intermediary endpoint becomes an open redirect — validate `state` before forwarding to the custom scheme |
+| Hand-writing the pipe/mutex C++ logic instead of copying the example | The DACL and prefix-validation details are security-sensitive; adapt the SDK's example runner rather than reimplementing from memory |
+
+## Related capabilities
+
+- Same SDK on iOS/Android — ask for the Auth0 Flutter native integration
+- Same SDK on the web platform — ask for the Auth0 Flutter web integration
+- .NET desktop apps (not Flutter) — ask for the Auth0 WPF, WinForms, or MAUI integration
+- Initial Auth0 setup and account creation — if Auth0 isn't set up yet, set it up first with the Auth0 CLI (`auth0 login`, then `auth0 apps create`)
+
+## Quick Reference
+
+| API | Purpose |
+|-----|---------|
+| `Auth0(domain, clientId)` | Create the SDK client |
+| `auth0.windowsWebAuthentication().login(appCustomURL: ..., redirectUrl: ...)` | Launch Universal Login in the system browser (Windows) |
+| `auth0.windowsWebAuthentication().logout(appCustomURL: ..., returnTo: ...)` | Clear the browser session (Windows) |
+| `PLUGIN_STARTUP_URL` | Environment variable the runner uses to hand the callback URI to the plugin |
+
+## References
+
+- [auth0_flutter on pub.dev](https://pub.dev/packages/auth0_flutter)
+- [auth0_flutter GitHub](https://github.com/auth0/auth0-flutter)
+- [Example Windows runner (main.cpp)](https://github.com/auth0/auth0-flutter/blob/main/auth0_flutter/example/windows/runner/main.cpp)
+- [Flutter Windows Quickstart](https://auth0.com/docs/quickstart/native/flutter-windows)
+- [Auth0 Dashboard](https://manage.auth0.com)

--- a/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
@@ -1,5 +1,3 @@
-# Auth0 Flutter Windows
-
 # Auth0 Flutter Windows Desktop Integration
 
 `auth0_flutter` is the official Auth0 SDK for Flutter applications. **Windows
@@ -249,10 +247,11 @@ class AuthService {
   })  : _appCustomURL = appCustomURL,
         _redirectUrl = redirectUrl,
         _returnTo = returnTo {
-    assert(
-      (redirectUrl == null) == (returnTo == null),
-      'Set both redirectUrl and returnTo when using the intermediary HTTPS callback.',
-    );
+    if ((redirectUrl == null) != (returnTo == null)) {
+      throw ArgumentError(
+        'Set both redirectUrl and returnTo when using the intermediary HTTPS callback.',
+      );
+    }
     _auth0 = Auth0(domain, clientId);
   }
 

--- a/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
@@ -10,18 +10,16 @@ protocol handler instead of Info.plist/AndroidManifest registration, a native
 C++ runner integration to receive the callback, and **no built-in credential
 storage** — the app must persist the returned `Credentials` itself.
 
-> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running one of:
-> ```bash
-> gh api repos/auth0/auth0-flutter/releases/latest --jq '.tag_name'
-> ```
-> ```bash
-> flutter pub info auth0_flutter 2>/dev/null | head -5
-> ```
-> Or check pub.dev:
+> **Agent instruction:** Before providing SDK setup instructions, fetch the
+> latest published version from pub.dev:
 > ```bash
 > curl -s https://pub.dev/api/packages/auth0_flutter | python3 -c "import sys,json;print(json.load(sys.stdin)['latest']['version'])"
 > ```
-> Use the returned version in all dependency lines instead of any hardcoded version below. Windows support requires v2.1.0 or later.
+> This returns a bare semver (e.g. `2.2.0`) — no `v` prefix or GitHub tag
+> formatting. Use that exact value as `<VERSION>` in the Step 1 dependency
+> line below instead of any hardcoded version. Windows support requires
+> v2.1.0 or later; if the fetched version is older, use `2.1.0` and flag it
+> to the user.
 
 ## When NOT to Use
 
@@ -51,8 +49,11 @@ storage** — the app must persist the returned `Credentials` itself.
 > **Agent instruction:** Check the project directory for `pubspec.yaml` and a `windows/` platform directory. If neither is present, this is not a Flutter Windows project — ask the user.
 
 ```bash
-flutter pub add auth0_flutter
+flutter pub add auth0_flutter:^<VERSION>
 ```
+
+Replace `<VERSION>` with the pub.dev version fetched above (e.g.
+`auth0_flutter:^2.2.0`).
 
 ### Step 2 — Choose a callback pattern and configure Auth0
 
@@ -102,11 +103,11 @@ them explicitly into the vcpkg instance:
 ```powershell
 git clone https://github.com/microsoft/vcpkg
 .\vcpkg\bootstrap-vcpkg.bat
-setx VCPKG_ROOT "%CD%\vcpkg"
+$env:VCPKG_ROOT = "$PWD\vcpkg"
 ```
 
 ```powershell
-vcpkg install --recurse "cpp-httplib[core,openssl]:x64-windows" nlohmann-json:x64-windows openssl:x64-windows
+.\vcpkg\vcpkg.exe install --recurse "cpp-httplib[core,openssl]:x64-windows" nlohmann-json:x64-windows openssl:x64-windows
 ```
 
 ### Step 4 — Configure `windows/CMakeLists.txt`
@@ -198,7 +199,7 @@ waiting plugin.
 > 1. **Single-instance mutex** — a second launch triggered by the OS
 >    protocol handler forwards its URI to the already-running instance
 >    instead of opening a new window.
-> 2. **Named-pipe server** (`\\.\pipe\auth0flutter_pipe`) — the running
+> 2. **Named-pipe server** (`\\.\pipe\<scheme>_auth0_pipe`) — the running
 >    instance listens for the forwarded URI, validates it starts with the
 >    app's callback prefix (e.g. `myapp://callback`), and writes it to
 >    `PLUGIN_STARTUP_URL`. The pipe's security descriptor must restrict
@@ -209,22 +210,34 @@ waiting plugin.
 >    protocol-scheme URI, if present) is written to `PLUGIN_STARTUP_URL`
 >    before Flutter starts, after the same prefix check.
 >
-> Update `kCallbackPrefix` in the copied file to match the chosen scheme
-> (e.g. `L"myapp://callback"`).
+> The example file's mutex and pipe names are fixed strings shared by every
+> app that copies them unmodified — two different Auth0-Flutter-Windows apps
+> installed on the same machine would collide on the same mutex/pipe, and one
+> app's callback could be forwarded into the other's window. Rename both to
+> include the app's own custom scheme, e.g. `Local\<scheme>_auth0_singleton`
+> for the mutex and `\\.\pipe\<scheme>_auth0_pipe` for the pipe, and update
+> `kCallbackPrefix` to match the chosen scheme (e.g. `L"myapp://callback"`).
 
 ### Step 7 — Implement Authentication
 
 > **Agent instruction:** search the project for the main app entry point (`lib/main.dart`). Create an `AuthService` class that stores `Credentials` manually — there is no `CredentialsManager` on Windows, so the app owns persistence (e.g. via `shared_preferences` or secure storage).
 
+```bash
+flutter pub add shared_preferences
+```
+
 ```dart
 // lib/auth_service.dart
+import 'dart:convert';
 import 'package:auth0_flutter/auth0_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class AuthService {
   late final Auth0 _auth0;
   Credentials? _credentials;
 
   static const _appCustomURL = 'myapp://callback';
+  static const _credentialsKey = 'auth0_credentials';
 
   AuthService({required String domain, required String clientId}) {
     _auth0 = Auth0(domain, clientId);
@@ -233,24 +246,40 @@ class AuthService {
   bool get isAuthenticated => _credentials != null;
   UserProfile? get user => _credentials?.user;
 
-  /// Launch Web Auth via the system browser. No credentials are stored
-  /// automatically on Windows — persist the result yourself.
+  /// Restore credentials saved from a previous session, if any.
+  Future<void> restoreSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_credentialsKey);
+    if (stored != null) {
+      _credentials = Credentials.fromMap(jsonDecode(stored));
+    }
+  }
+
+  /// Launch Web Auth via the system browser and persist the result.
+  /// No credentials are stored automatically on Windows.
   Future<void> login() async {
     _credentials = await _auth0.windowsWebAuthentication().login(
       appCustomURL: _appCustomURL,
       scopes: {'openid', 'profile', 'email', 'offline_access'},
     );
-    // TODO: persist _credentials (e.g. shared_preferences / secure storage)
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_credentialsKey, jsonEncode(_credentials!.toMap()));
   }
 
-  /// Clear the browser session and drop the in-memory credentials.
+  /// Clear the browser session and drop persisted + in-memory credentials.
   Future<void> logout() async {
     await _auth0.windowsWebAuthentication().logout(appCustomURL: _appCustomURL);
     _credentials = null;
-    // TODO: also clear any persisted credentials
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_credentialsKey);
   }
 }
 ```
+
+> **Note:** `shared_preferences` stores plaintext on disk — fine for this
+> example, but for production apps handling refresh tokens prefer OS-backed
+> secure storage (e.g. `flutter_secure_storage`, which uses DPAPI on
+> Windows).
 
 ```dart
 // lib/main.dart
@@ -364,12 +393,17 @@ toolchain line (Step 4) or missing vcpkg packages (Step 3).
 in Option A, doubles as the `redirect_uri`/`returnTo` value automatically.
 
 Minimal intermediary-server implementation (Node.js/Express) for Option B —
-validate `state` server-side before forwarding, since this endpoint is an
-open-redirect target otherwise:
+validate `state` against the value stored when the auth request was initiated
+before forwarding, since this endpoint is an open-redirect target otherwise:
 
 ```javascript
 app.get('/callback', (req, res) => {
   const { code, state, error, error_description } = req.query;
+  const expectedState = pendingStates.get(state); // stored when the login request started
+  if (!state || !expectedState) {
+    return res.status(400).send('Invalid or missing state');
+  }
+  pendingStates.delete(state);
   if (error) {
     res.redirect(`myapp://callback?error=${error}&error_description=${encodeURIComponent(error_description)}`);
   } else {

--- a/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-flutter-windows/index.md
@@ -10,9 +10,11 @@ storage** — the app must persist the returned `Credentials` itself.
 
 > **Agent instruction:** Before providing SDK setup instructions, fetch the
 > latest published version from pub.dev:
+>
 > ```bash
 > curl -s https://pub.dev/api/packages/auth0_flutter | python3 -c "import sys,json;print(json.load(sys.stdin)['latest']['version'])"
 > ```
+>
 > This returns a bare semver (e.g. `2.2.0`) — no `v` prefix or GitHub tag
 > formatting. Use that exact value as `<VERSION>` in the Step 1 dependency
 > line below instead of any hardcoded version. Windows support requires
@@ -189,9 +191,11 @@ waiting plugin.
 > validation of the forwarded URI). Do not hand-write this logic from
 > memory — fetch the canonical reference implementation and adapt only the
 > callback-prefix constant to the chosen scheme:
+>
 > ```bash
 > curl -sL https://raw.githubusercontent.com/auth0/auth0-flutter/main/auth0_flutter/example/windows/runner/main.cpp
 > ```
+>
 > The three required pieces, copied from that file into the app's
 > `wWinMain`:
 > 1. **Single-instance mutex** — a second launch triggered by the OS
@@ -258,12 +262,18 @@ class AuthService {
   bool get isAuthenticated => _credentials != null;
   UserProfile? get user => _credentials?.user;
 
-  /// Restore credentials saved from a previous session, if any.
+  /// Restore credentials saved from a previous session, if still valid.
+  /// There's no refresh-token renewal here — an expired record is dropped,
+  /// leaving the user to log in again.
   Future<void> restoreSession() async {
     final prefs = await SharedPreferences.getInstance();
     final stored = prefs.getString(_credentialsKey);
-    if (stored != null) {
-      _credentials = Credentials.fromMap(jsonDecode(stored));
+    if (stored == null) return;
+    final credentials = Credentials.fromMap(jsonDecode(stored));
+    if (credentials.expiresAt.isAfter(DateTime.now())) {
+      _credentials = credentials;
+    } else {
+      await prefs.remove(_credentialsKey);
     }
   }
 
@@ -288,19 +298,25 @@ class AuthService {
   }
 
   /// Clear the browser session and drop persisted + in-memory credentials.
+  /// Local state is cleared even if the remote logout call fails, so the
+  /// app never gets stuck showing an authenticated screen with a stale
+  /// persisted record; the error is rethrown for the caller to surface.
   Future<void> logout() async {
-    final webAuth = _auth0.windowsWebAuthentication();
-    if (_returnTo == null) {
-      await webAuth.logout(appCustomURL: _appCustomURL);
-    } else {
-      await webAuth.logout(
-        appCustomURL: _appCustomURL,
-        returnTo: _returnTo!,
-      );
+    try {
+      final webAuth = _auth0.windowsWebAuthentication();
+      if (_returnTo == null) {
+        await webAuth.logout(appCustomURL: _appCustomURL);
+      } else {
+        await webAuth.logout(
+          appCustomURL: _appCustomURL,
+          returnTo: _returnTo!,
+        );
+      }
+    } finally {
+      _credentials = null;
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_credentialsKey);
     }
-    _credentials = null;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_credentialsKey);
   }
 }
 ```
@@ -336,13 +352,24 @@ class _MyAppState extends State<MyApp> {
     // redirectUrl: 'https://your-app.example.com/callback',
     // returnTo: 'https://your-app.example.com/logout',
   );
+  bool _restoring = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _authService.restoreSession().then((_) {
+      setState(() => _restoring = false);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: _authService.isAuthenticated
-          ? HomeScreen(authService: _authService, onChanged: _refresh)
-          : LoginScreen(authService: _authService, onChanged: _refresh),
+      home: _restoring
+          ? const Scaffold(body: Center(child: CircularProgressIndicator()))
+          : _authService.isAuthenticated
+              ? HomeScreen(authService: _authService, onChanged: _refresh)
+              : LoginScreen(authService: _authService, onChanged: _refresh),
     );
   }
 
@@ -391,8 +418,18 @@ class HomeScreen extends StatelessWidget {
         actions: [
           IconButton(
             onPressed: () async {
-              await authService.logout();
-              onChanged();
+              final messenger = ScaffoldMessenger.of(context);
+              try {
+                await authService.logout();
+              } on WebAuthenticationException catch (e) {
+                messenger.showSnackBar(
+                  SnackBar(content: Text('Logout error: ${e.message}')),
+                );
+              } finally {
+                // Local credentials are always cleared by logout(), so
+                // refresh to LoginScreen even if the remote call failed.
+                onChanged();
+              }
             },
             icon: const Icon(Icons.logout),
           ),
@@ -438,9 +475,9 @@ app.get('/callback', (req, res) => {
   }
   pendingStates.delete(state);
   if (error) {
-    res.redirect(`myapp://callback?error=${error}&error_description=${encodeURIComponent(error_description)}`);
+    res.redirect(`myapp://callback?error=${encodeURIComponent(error)}&error_description=${encodeURIComponent(error_description)}`);
   } else {
-    res.redirect(`myapp://callback?code=${code}&state=${state}`);
+    res.redirect(`myapp://callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`);
   }
 });
 ```

--- a/plugins/auth0/skills/auth0/scripts/validate-skill.sh
+++ b/plugins/auth0/skills/auth0/scripts/validate-skill.sh
@@ -62,7 +62,7 @@ fi
 # "every routed framework has a file and every file is routed" guarantee is
 # enforced by scripts/check_router_reachability.py (run below), which derives
 # slugs from the router itself. Keep this list in sync when adding frameworks.
-EXPECTED_FRAMEWORKS="react nextjs vue angular spa-js nuxt express flask fastify fastify-api java-mvc aspnetcore-auth aspnetcore-api php php-api express-jwt fastapi-api springboot-api go react-native expo ionic-angular ionic-react ionic-vue android swift kmp flutter-native flutter-web laravel laravel-api maui net-android net-ios winforms wpf node-auth0"
+EXPECTED_FRAMEWORKS="react nextjs vue angular spa-js nuxt express flask fastify fastify-api java-mvc aspnetcore-auth aspnetcore-api php php-api express-jwt fastapi-api springboot-api go react-native expo ionic-angular ionic-react ionic-vue android swift kmp flutter-native flutter-web flutter-windows laravel laravel-api maui net-android net-ios winforms wpf node-auth0"
 for fw in $EXPECTED_FRAMEWORKS; do
   if [ ! -f "$REFS_DIR/framework-$fw/index.md" ]; then
     echo "FAIL: missing references/framework-$fw/index.md"


### PR DESCRIPTION
## Summary
- Add `references/framework-flutter-windows/index.md`, verified directly against `auth0/auth0-flutter`'s raw README/FAQ/EXAMPLES.md and its example `windows/runner/main.cpp` source (not summarized) — covers `windowsWebAuthentication()`, vcpkg + `windows/CMakeLists.txt` toolchain wiring, Registry protocol-handler registration, the required runner mutex/named-pipe integration, and manual credential storage (no `CredentialsManager` on Windows).
- Wire `flutter-windows` into `SKILL.md`'s Tier 1/2/3 router tables, with a note to ask when a Flutter project has multiple platform folders.
- Cross-link the new reference from `framework-flutter-native`/`framework-flutter-web`'s "When NOT to Use" sections.
- Add `flutter-windows` to `validate-skill.sh`'s `EXPECTED_FRAMEWORKS` and the root `README.md` coverage table.
- Add routing, activation, and behavioral eval coverage for the new reference.