### PR TITLE
Fix OpenAI plugin submission errors for the auth0 plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -16,7 +16,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Developer tools"
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -122,6 +122,12 @@ rules:
   # point at — same class as the rule's built-in tests/ exemption. Exempt it so
   # it isn't flagged as an unreferenced/shadow file.
   #
+  # agents/openai.yaml is Codex-facing interface config (display_name,
+  # short_description, default_prompt) read directly by the Codex/ChatGPT
+  # runtime, not agent-facing content the SKILL.md router should link to —
+  # same class as validate-skill.sh above. Exempt it so it isn't flagged as
+  # unreferenced.
+  #
   # framework-*.md / tooling-*.md are routed from SKILL.md ONLY through the
   # `references/framework-{framework}.md` and `references/tooling-{tooling}.md`
   # placeholder templates in Step 4. This rule does literal substring matching
@@ -136,6 +142,7 @@ rules:
       - "scripts/validate-skill.sh"
       - "references/framework-*.md"
       - "references/tooling-*.md"
+      - "agents/openai.yaml"
 
 # Custom rules for marketplace-specific validation
 custom-rules:

--- a/.skillsaw/rules.py
+++ b/.skillsaw/rules.py
@@ -26,7 +26,7 @@ class SkillDirectoryStructureRule(Rule):
     # Allowed directories per Agent Skills spec (plus tests/ for validation
     # artifacts and agents/ for the Agent Plugins per-skill interface config,
     # e.g. agents/openai.yaml required by the OpenAI plugin submission checker)
-    ALLOWED_DIRS = {'scripts', 'references', 'assets', 'tests', 'agents'}
+    ALLOWED_DIRS = frozenset({'scripts', 'references', 'assets', 'tests', 'agents'})
 
     # Files that are allowed in skill root
     ALLOWED_ROOT_FILES = {'SKILL.md', '.gitignore', '.gitkeep'}

--- a/.skillsaw/rules.py
+++ b/.skillsaw/rules.py
@@ -20,10 +20,13 @@ class SkillDirectoryStructureRule(Rule):
     - references/  - Additional documentation
     - assets/      - Static resources (templates, images, data files)
     - tests/       - Validation artifacts (TDD transcripts, test data)
+    - agents/      - Client-specific interface config (e.g. agents/openai.yaml)
     """
 
-    # Allowed directories per Agent Skills spec (plus tests/ for validation artifacts)
-    ALLOWED_DIRS = {'scripts', 'references', 'assets', 'tests'}
+    # Allowed directories per Agent Skills spec (plus tests/ for validation
+    # artifacts and agents/ for the Agent Plugins per-skill interface config,
+    # e.g. agents/openai.yaml required by the OpenAI plugin submission checker)
+    ALLOWED_DIRS = {'scripts', 'references', 'assets', 'tests', 'agents'}
 
     # Files that are allowed in skill root
     ALLOWED_ROOT_FILES = {'SKILL.md', '.gitignore', '.gitkeep'}
@@ -34,7 +37,7 @@ class SkillDirectoryStructureRule(Rule):
 
     @property
     def description(self) -> str:
-        return "Skills must follow Agent Skills specification: only SKILL.md in root, other content in scripts/, references/, assets/, or tests/"
+        return "Skills must follow Agent Skills specification: only SKILL.md in root, other content in scripts/, references/, assets/, tests/, or agents/"
 
     def default_severity(self) -> Severity:
         return Severity.ERROR
@@ -85,7 +88,7 @@ class SkillDirectoryStructureRule(Rule):
                     violations.append(
                         self.violation(
                             f"Unexpected directory '{item_name}/' in skill root. "
-                            f"Only 'scripts/', 'references/', 'assets/', and 'tests/' "
+                            f"Only 'scripts/', 'references/', 'assets/', 'tests/', and 'agents/' "
                             f"directories are allowed. Move content to an appropriate directory.",
                             file_path=item
                         )

--- a/docs/openai-plugin.md
+++ b/docs/openai-plugin.md
@@ -11,7 +11,9 @@ plugins/auth0/
 │   └── plugin.json
 └── skills/
     └── auth0/
-        └── SKILL.md
+        ├── SKILL.md
+        └── agents/
+            └── openai.yaml
 ```
 
 The canonical skill content is shared with the Claude and Cursor packages; do

--- a/plugins/auth0/.codex-plugin/plugin.json
+++ b/plugins/auth0/.codex-plugin/plugin.json
@@ -16,7 +16,7 @@
     "shortDescription": "Add Auth0 authentication to your application",
     "longDescription": "Add Auth0 authentication to any app — login, MFA, SSO, Organizations, RBAC, ACUL, custom domains, and branding. Debug auth errors, validate JWTs, manage token lifecycles, and migrate from Clerk, Firebase, or Cognito. Covers React, Next.js, Vue, Nuxt, Angular, Express, Flask, Spring Boot, Go, Swift, Android, Flutter, Laravel, PHP, ASP.NET Core, React Native, Expo, Ionic, .NET MAUI, and more.",
     "developerName": "Auth0",
-    "category": "Developer tools",
+    "category": "Developer Tools",
     "websiteURL": "https://auth0.com",
     "privacyPolicyURL": "https://auth0.com/privacy",
     "termsOfServiceURL": "https://auth0.com/terms"

--- a/plugins/auth0/skills/auth0/agents/openai.yaml
+++ b/plugins/auth0/skills/auth0/agents/openai.yaml
@@ -1,0 +1,5 @@
+# plugins/auth0/skills/auth0/agents/openai.yaml
+interface:
+  display_name: "Auth0"
+  short_description: "Add Auth0 authentication to your application"
+  default_prompt: "Use $auth0 to add, secure, debug, or migrate authentication in any app — login, MFA, SSO, Organizations, RBAC, custom domains, and Universal Login branding."

--- a/plugins/auth0/skills/auth0/agents/openai.yaml
+++ b/plugins/auth0/skills/auth0/agents/openai.yaml
@@ -1,5 +1,5 @@
 # plugins/auth0/skills/auth0/agents/openai.yaml
 interface:
   display_name: "Auth0"
-  short_description: "Add Auth0 authentication to your application"
+  short_description: "Add, secure, debug, and migrate Auth0 authentication - login, MFA, SSO, RBAC, Organizations, custom domains, and Universal Login across 20+ frameworks"
   default_prompt: "Use $auth0 to add, secure, debug, or migrate authentication in any app — login, MFA, SSO, Organizations, RBAC, custom domains, and Universal Login branding."


### PR DESCRIPTION
## Summary
- Codex interface category was `"Developer tools"` (lowercase "tools"); OpenAI's Agent Plugins schema requires the exact enum value `"Developer Tools"` — fixes the "Unsupported plugin category" submission error.
- Add `plugins/auth0/skills/auth0/agents/openai.yaml` with the skill's interface config (`display_name`, `short_description`, `default_prompt`) — OpenAI's submission checker doesn't read interface settings from `SKILL.md` metadata, so this fixes "Skill interface settings must use agents/openai.yaml". Schema confirmed against real published examples of this convention.
- Allow an `agents/` directory in skill roots in the custom `skill-directory-structure` skillsaw rule (`.skillsaw/rules.py`), since that's where the per-skill OpenAI/Codex config lives. Without this, the new file would fail this repo's own `skillsaw --strict` CI gate.

## Test plan
- [x] `uvx skillsaw --strict` passes locally (0 errors, grade A)
- [ ] Re-run the OpenAI plugin submission checker against `plugins/auth0/` to confirm both errors clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Auth0 agent interface with guidance for adding, securing, debugging, and migrating authentication.
  * Skill directories can now include an `agents/` folder for interface configuration.
  * Added support for recognizing agent interface configuration as part of skill setup.

* **Updates**
  * Improved the Auth0 plugin’s category label for consistency across the plugin experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->