### PR TITLE
refactor(auth0): make feature-mfa the single source for MFA

### DIFF
--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -62,7 +62,7 @@
       "intent": "feature:mfa",
       "framework": "nextjs",
       "tooling": "cli",
-      "expect_refs": ["feature-mfa/index.md", "tooling-cli/index.md", "framework-nextjs/index.md"]
+      "expect_refs": ["feature-mfa/index.md", "tooling-cli/index.md"]
     },
     {
       "id": "feature-organizations-b2b-combo",

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -4,7 +4,7 @@ description: Use when adding, fixing, or improving how an app authenticates user
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
-  version: '2.1.1'
+  version: '2.1.2'
   openclaw:
     emoji: "\U0001F510"
     homepage: https://github.com/auth0/agent-skills

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -285,7 +285,6 @@ Use references/tooling-{tooling}/index.md for all Auth0 tenant configuration ste
 ```
 Read: references/feature-mfa/index.md
 Read: references/tooling-{tooling}/index.md
-If framework detected: Read references/framework-{framework}/index.md (for SDK-side step-up trigger)
 ```
 
 ### feature:organizations

--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -56,7 +56,7 @@ Recipe (do in order):
 
 | Your context | Verify with |
 |---|---|
-| Session-managing SDK (web app) | The `amr` claim (contains `mfa` when MFA completed) off the SDK's own session / current-user accessor - already validated, so trust it as-is. Accessor name is SDK-specific -> see the `framework-*` reference. |
+| Session-managing SDK (web app) | The `amr` claim (contains `mfa` when MFA completed) off the SDK's own session / current-user accessor - already validated, so trust it as-is. Accessor name is SDK-specific -> see the SDK's own example ("Example code snippets" below). |
 | Resource API (raw bearer token) | The high-value **scope** (e.g. `transfer:funds`) on the access token, via your *existing* JWT/scope-check middleware - see "Related capabilities". |
 | Frontend | Nothing - treat any `amr` check as UX, never enforcement. |
 
@@ -73,7 +73,7 @@ not relax it.
 
 The app collects credentials, so no browser runs the challenge: sign-in returns an
 `mfa_required` error carrying an `mfa_token`. Each step is a method on the SDK's own MFA
-client - get exact names from the `framework-*` example; never hand-roll the token grant
+client - get exact names from the SDK's own example ("Example code snippets" below); never hand-roll the token grant
 or the MFA API URLs.
 
 Recipe (do in order):
@@ -116,7 +116,7 @@ and what the app must get right:
 
 SDK-specific symbols (an SDK's own method or option name - e.g. the silent-token call,
 the `mfa_required`/`MfaRequiredError` handling, the interactive re-auth option, refresh-token
-requirements) are **not** listed here; they belong in the relevant `framework-*` reference.
+requirements) are **not** listed here; get them from the SDK's own example (see "Example code snippets").
 
 ### `amr` claim values
 
@@ -255,8 +255,9 @@ which uses the `mfa_token` and the MFA API surface instead:
 
 - **Tenant setup and Actions** - `tooling-cli` and `tooling-terraform` own Guardian
   factor/policy configuration and Action deployment (`auth0 actions ...`).
-- **SDK-side step-up trigger** - the detected `framework-*` reference owns the SDK's own
-  step-up call, its `mfa_required` handling, and any refresh-token requirement.
+- **SDK-side step-up trigger** - the SDK's own step-up call, its `mfa_required` handling,
+  and any refresh-token requirement live in that SDK's own example (see "Example code
+  snippets"), not in a `framework-*` reference.
 - **Server-side MFA enforcement** - the API `framework-*` references (JWT validation) own
   the scope/claim-check middleware; on a resource API gate the sensitive endpoint on the
   high-value scope (access tokens carry no `amr` by default), and on a web/session backend

--- a/plugins/auth0/skills/auth0/references/framework-android/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-android/index.md
@@ -141,6 +141,7 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
 | Missing `<uses-permission android:name="android.permission.INTERNET" />` | Add the INTERNET permission to `AndroidManifest.xml`. The SDK requires network access for authentication. |
 | Custom scheme in lowercase | Android requires scheme names to be lowercase. Use `https` (recommended) or lowercase custom scheme like `myapp://callback`. |
 | Forgetting `.validateClaims()` on direct auth calls | Always call `.validateClaims()` when using `AuthenticationAPIClient` directly (for database, passwordless, or API login). Web Auth validates automatically. |
+| Reading ID-token claims via a `credentials.claims` map | No such property exists on Auth0.Android `Credentials`. Standard claims are accessors on `credentials.user` (a `UserProfile`); custom / namespaced claims come from `credentials.user.getExtraInfo()`. |
 | Storing tokens in SharedPreferences without encryption | Use `SecureCredentialsManager` to store credentials. Never store tokens manually in plain text. The manager encrypts tokens at rest. |
 | Missing manifest placeholders | Add `manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "@string/com_auth0_scheme"]` to your `build.gradle` `defaultConfig` block. |
 
@@ -159,7 +160,7 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
 |-------|---------|
 | `Auth0` | Entry point for SDK, holds app credentials |
 | `WebAuthProvider` | OAuth 2.0 login/logout via browser |
-| `AuthenticationAPIClient` | Direct API calls (database login, passwordless, MFA) |
+| `AuthenticationAPIClient` | Direct API calls (database login, passwordless) |
 | `SecureCredentialsManager` | Secure storage and retrieval of credentials |
 | `Credentials` | User tokens and expiration |
 
@@ -171,7 +172,6 @@ Add authentication to Android applications using `com.auth0.android:auth0`.
 - Require biometric authentication (see the Biometric-Protected Credentials section below)
 - Database login (see the Database Login section below)
 - Passwordless authentication (see the Passwordless Authentication section below)
-- Handle MFA (see the MFA Handling section below)
 - Call protected APIs (see the Calling Protected APIs section below)
 
 ## References
@@ -375,7 +375,6 @@ authentication.login(email, password, realm)
 authentication.signUp(email, password, username, connection)
 authentication.passwordlessWithEmail(email, type)
 authentication.loginWithEmail(email, code)
-authentication.mfaClient(mfaToken)
 ```
 
 ### SecureCredentialsManager
@@ -405,11 +404,11 @@ val expiresAt = credentials.expiresAt          // Expiration timestamp
 val scope = credentials.scope                  // Granted scopes
 val type = credentials.type                    // "Bearer"
 
-// ID token claims
-val sub = credentials.claims["sub"]            // Subject (user ID)
-val name = credentials.claims["name"]
-val email = credentials.claims["email"]
-val emailVerified = credentials.claims["email_verified"]
+// ID token claims — Auth0.Android has NO credentials.claims property.
+// Standard claims are accessors on credentials.user (a UserProfile);
+// custom / namespaced claims come from getExtraInfo().
+val sub = credentials.user.getId()             // Subject (user ID)
+val roles = credentials.user.getExtraInfo()["https://myapp.example.com/roles"] as? List<*>
 ```
 
 ### LocalAuthenticationOptions
@@ -684,7 +683,7 @@ authentication.login(
         override fun onFailure(error: AuthenticationException) {
             when {
                 error.isMultifactorRequired -> {
-                    // MFA required - see MFA Handling section
+                    // MFA required — see the feature:mfa reference
                 }
                 error.statusCode == 403 -> {
                     // Invalid credentials
@@ -839,86 +838,6 @@ manager.getCredentials(object : Callback<Credentials, CredentialsManagerExceptio
 })
 ```
 
-## MFA Handling
-
-Handle multi-factor authentication challenges:
-
-### Detect MFA Required
-
-```kotlin
-authentication.login(...)
-    .validateClaims()
-    .start(object : Callback<Credentials, AuthenticationException> {
-        override fun onFailure(error: AuthenticationException) {
-            if (error.isMultifactorRequired) {
-                val mfaToken = error.mfaRequiredErrorPayload?.mfaToken
-                // Proceed to enrollment or challenge screen
-            }
-        }
-    })
-```
-
-### Enroll in MFA
-
-```kotlin
-val mfaToken = error.mfaRequiredErrorPayload?.mfaToken ?: return
-val mfaClient = authentication.mfaClient(mfaToken)
-
-// Enroll in OTP
-mfaClient.enroll(MfaEnrollmentType.Otp)
-    .start(object : Callback<MfaEnrollment, AuthenticationException> {
-        override fun onSuccess(enrollment: MfaEnrollment) {
-            val recoveryCode = enrollment.recoveryCode
-            val secret = enrollment.secret  // For OTP app
-            // Show QR code to user
-        }
-
-        override fun onFailure(error: AuthenticationException) {
-            Log.e("MFA", error.message.orEmpty())
-        }
-    })
-```
-
-### Challenge MFA
-
-```kotlin
-mfaClient.challenge(
-    authenticatorId = "dev_abc123",  // From enrollments list
-    challengeType = MfaChallengeType.OTP
-)
-    .start(object : Callback<MfaChallenge, AuthenticationException> {
-        override fun onSuccess(challenge: MfaChallenge) {
-            val challengeId = challenge.challengeId
-            // Show user OTP input screen
-        }
-
-        override fun onFailure(error: AuthenticationException) {
-            Log.e("MFA", error.message.orEmpty())
-        }
-    })
-```
-
-### Verify Challenge
-
-```kotlin
-mfaClient.verifyChallenge(
-    challengeId = "Fe26...session_id",
-    otp = "123456"  // User's one-time password
-)
-    .validateClaims()
-    .start(object : Callback<Credentials, AuthenticationException> {
-        override fun onSuccess(result: Credentials) {
-            // MFA verified - user now authenticated
-            manager.saveCredentials(result)
-        }
-
-        override fun onFailure(error: AuthenticationException) {
-            // Invalid OTP or expired challenge
-            Log.e("MFA", error.message.orEmpty())
-        }
-    })
-```
-
 ## Organizations
 
 Use Organizations for enterprise SSO and multi-tenancy:
@@ -963,7 +882,7 @@ authentication.login(...)
         override fun onFailure(error: AuthenticationException) {
             when {
                 error.isMultifactorRequired -> {
-                    // MFA enrollment or challenge required
+                    // MFA required — see the feature:mfa reference
                 }
                 error.isBrowserAppNotAvailable -> {
                     // No browser available

--- a/plugins/auth0/skills/auth0/references/framework-ionic-react/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-react/index.md
@@ -814,7 +814,7 @@ const App: React.FC = () => {
 | `consent_required` | User hasn't consented to requested scopes | Re-trigger login with `prompt: 'consent'` |
 | `invalid_grant` | Refresh token expired or revoked | Clear session and re-authenticate |
 | `access_denied` | User denied consent or rule blocked access | Check Auth0 Actions/Rules for blocks |
-| `mfa_required` | MFA is required for the user | Handle MFA enrollment flow |
+| `mfa_required` | MFA is required for the user | See the feature:mfa reference |
 
 ## Testing Patterns
 

--- a/plugins/auth0/skills/auth0/references/framework-ionic-vue/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-ionic-vue/index.md
@@ -933,7 +933,7 @@ const { error, isLoading } = useAuth0();
 | `consent_required` | User hasn't consented to requested scopes | Re-trigger login with `prompt: 'consent'` |
 | `invalid_grant` | Refresh token expired or revoked | Clear session and re-authenticate |
 | `access_denied` | User denied consent or rule blocked access | Check Auth0 Actions/Rules for blocks |
-| `mfa_required` | MFA is required for the user | Handle MFA enrollment flow |
+| `mfa_required` | MFA is required for the user | See the feature:mfa reference |
 
 ## Testing Patterns
 

--- a/plugins/auth0/skills/auth0/references/framework-react/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-react/index.md
@@ -121,10 +121,6 @@ npm start    # CRA
 | Missing Auth0Provider wrapper | Entire app must be wrapped in `<Auth0Provider>` |
 | Provider not at root level | Auth0Provider must wrap all components that use auth hooks |
 | Wrong import path for env vars | Vite uses `import.meta.env.VITE_*`, CRA uses `process.env.REACT_APP_*` |
-| Using `acr_values` redirect for in-app MFA | Use `useAuth0().mfa` API for in-app enrollment/challenge/verify flows |
-| Not catching `MfaRequiredError` | Wrap `getAccessTokenSilently` in try/catch and check `instanceof MfaRequiredError` |
-| Making direct HTTP calls to MFA endpoints | Use the `mfa` property from `useAuth0()` — it handles token management automatically |
-| Forgetting refresh tokens for step-up MFA | Set `useRefreshTokens={true}` on Auth0Provider when using `interactiveErrorHandler="popup"` |
 
 ## Related Skills
 
@@ -144,23 +140,13 @@ npm start    # CRA
 - `loginWithRedirect()` - Initiate login
 - `logout()` - Log out user
 - `getAccessTokenSilently()` - Get access token for API calls
-- `mfa` - MFA API client for enrollment, challenge, and verification
-  - `mfa.getAuthenticators(mfaToken)` - List enrolled authenticators
-  - `mfa.getEnrollmentFactors(mfaToken)` - Get available enrollment factors
-  - `mfa.enroll(params)` - Enroll new authenticator (OTP, SMS, Email, Voice, Push)
-  - `mfa.challenge(params)` - Initiate MFA challenge
-  - `mfa.verify(params)` - Verify MFA challenge and complete authentication
-
-**MFA Error Types (import from `@auth0/auth0-react`):**
-- `MfaRequiredError` - Thrown by `getAccessTokenSilently` when MFA is needed (has `mfa_token` and `mfa_requirements`)
-- `MfaEnrollmentError`, `MfaChallengeError`, `MfaVerifyError` - Thrown by respective `mfa.*` methods
 
 **Common Use Cases:**
 - Login/Logout buttons → See Step 4 above
 - Protected routes → see the Protected Routes section below
 - API calls with tokens → see the Calling APIs section below
 - Error handling → see the Error Handling section below
-- MFA handling → see the MFA Handling section below
+- MFA / step-up → ask for MFA (feature:mfa)
 
 ## References
 
@@ -209,9 +195,6 @@ import { Auth0Provider } from '@auth0/auth0-react';
   useRefreshTokensFallback={false} // Fall back to iframe if refresh token exchange fails (default: false)
   useMrrt={false} // Enable Multi-Refresh-Token for multi-tenant apps (default: false)
 
-  // MFA / Step-up
-  interactiveErrorHandler="popup" // Automatically handle MFA via popup (requires useRefreshTokens)
-
   // Advanced options
   skipRedirectCallback={false} // Skip automatic callback handling
   context={Auth0Context} // Custom React context
@@ -242,7 +225,6 @@ import { Auth0Provider } from '@auth0/auth0-react';
 | `useMrrt` | boolean | `false` | Enable Multi-Refresh-Token support for multi-tenant apps. Requires `useRefreshTokens` and `useRefreshTokensFallback` to be `true` |
 | `workerUrl` | string | - | Custom worker script URL for token calls. Useful for CSP compliance when using `useRefreshTokens: true` with `cacheLocation: 'memory'` |
 | `context` | React.Context | - | Custom React context for nested Auth0Providers. Allows multiple Auth0Providers in same app |
-| `interactiveErrorHandler` | `'popup'` | - | Automatically handle MFA via popup when `getAccessTokenSilently` encounters `mfa_required`. Requires `useRefreshTokens={true}` |
 | `skipRedirectCallback` | boolean | `false` | Skip automatic callback handling |
 | `onRedirectCallback` | function | - | Callback after successful login |
 
@@ -283,9 +265,6 @@ const {
   getAccessTokenWithPopup,
   getIdTokenClaims,
   handleRedirectCallback,
-
-  // MFA API
-  mfa,
 } = useAuth0();
 ```
 
@@ -542,95 +521,6 @@ interface RedirectLoginResult {
 }
 ```
 
-#### mfa
-
-The `mfa` property provides access to the MFA API client for in-app Multi-Factor Authentication flows.
-
-**Methods:**
-
-| Method | Description |
-|--------|-------------|
-| `mfa.getAuthenticators(mfaToken)` | List enrolled authenticators for the user |
-| `mfa.getEnrollmentFactors(mfaToken)` | Get available enrollment factors (when user needs to enroll) |
-| `mfa.enroll(params)` | Enroll a new authenticator (OTP, SMS, Email, Voice, Push) |
-| `mfa.challenge(params)` | Initiate an MFA challenge for an enrolled authenticator |
-| `mfa.verify(params)` | Verify an MFA challenge and complete authentication |
-
-**Enroll params:**
-
-```typescript
-// OTP enrollment
-await mfa.enroll({ mfaToken, factorType: 'otp' });
-// Returns: { barcodeUri, recoveryCodes, ... }
-
-// SMS enrollment
-await mfa.enroll({ mfaToken, factorType: 'sms', phoneNumber: '+12025551234' });
-
-// Email enrollment
-await mfa.enroll({ mfaToken, factorType: 'email', email: 'user@example.com' });
-
-// Voice enrollment
-await mfa.enroll({ mfaToken, factorType: 'voice', phoneNumber: '+12025551234' });
-
-// Push enrollment
-await mfa.enroll({ mfaToken, factorType: 'push' });
-```
-
-**Challenge params:**
-
-```typescript
-// OTP challenge (optional — code is already in authenticator app)
-await mfa.challenge({ mfaToken, challengeType: 'otp', authenticatorId });
-
-// SMS/Voice/Email/Push challenge (required — sends code to user)
-await mfa.challenge({ mfaToken, challengeType: 'oob', authenticatorId });
-// Returns: { oobCode }
-```
-
-**Verify params:**
-
-```typescript
-// Verify with OTP code
-const tokens = await mfa.verify({ mfaToken, otp: '123456' });
-
-// Verify with OOB code (SMS/Voice/Email)
-const tokens = await mfa.verify({ mfaToken, oobCode, bindingCode: '123456' });
-
-// Verify with recovery code
-const tokens = await mfa.verify({ mfaToken, recoveryCode: 'recovery-code-here' });
-```
-
----
-
-### MFA Error Types
-
-All MFA error types are importable from `@auth0/auth0-react`.
-
-| Error | When thrown | Key properties |
-|-------|-----------|----------------|
-| `MfaRequiredError` | `getAccessTokenSilently()` encounters an MFA requirement | `mfa_token`, `mfa_requirements` |
-| `MfaEnrollmentError` | `mfa.enroll()` fails | `error_description` |
-| `MfaChallengeError` | `mfa.challenge()` fails | `error_description` |
-| `MfaVerifyError` | `mfa.verify()` fails (e.g., invalid OTP code) | `error_description` |
-| `MfaListAuthenticatorsError` | `mfa.getAuthenticators()` fails | `error_description` |
-| `MfaEnrollmentFactorsError` | `mfa.getEnrollmentFactors()` fails | `error_description` |
-
-**MfaRequiredError properties:**
-- `mfa_token` — Token used for all subsequent MFA operations
-- `mfa_requirements.enroll` — Array of factor types the user can enroll in (present when user needs to set up MFA)
-- `mfa_requirements.challenge` — Array of factor types the user can challenge (present when user has enrolled authenticators)
-
-**Import:**
-
-```typescript
-import {
-  MfaRequiredError,
-  MfaEnrollmentError,
-  MfaChallengeError,
-  MfaVerifyError,
-} from '@auth0/auth0-react';
-```
-
 ---
 
 ## Custom Hooks
@@ -748,20 +638,6 @@ import type {
   PopupLoginOptions,
   LogoutOptions,
   GetTokenSilentlyOptions,
-  MfaApiClient,
-  Authenticator,
-  EnrollParams,
-  ChallengeResponse,
-  VerifyParams,
-  EnrollmentFactor,
-} from '@auth0/auth0-react';
-
-// MFA error types (value imports, not type-only)
-import {
-  MfaRequiredError,
-  MfaEnrollmentError,
-  MfaChallengeError,
-  MfaVerifyError,
 } from '@auth0/auth0-react';
 ```
 
@@ -999,193 +875,6 @@ export function App() {
 | Logout doesn't work | Include `returnTo` URL in logout options and configure in Auth0 "Allowed Logout URLs" |
 | CORS errors when calling API | Add your application URL to "Allowed Web Origins" in Auth0 application settings |
 | Tokens not refreshing | Enable `useRefreshTokens={true}` in Auth0Provider and ensure refresh token rotation is enabled in Auth0 |
-
----
-
-## MFA Handling
-
-The `@auth0/auth0-react` SDK provides a built-in MFA API for handling Multi-Factor Authentication entirely within your app — no redirects to Universal Login required. Access it via the `mfa` property from `useAuth0()`.
-
-> **Note:** MFA support via SDKs is currently in Early Access. For a simpler approach that uses Universal Login to handle MFA automatically (no custom UI), see the [Step-Up via Popup](#step-up-via-popup-simpler-approach) section below.
-
-### Catching MfaRequiredError
-
-When `getAccessTokenSilently()` encounters an MFA requirement, it throws `MfaRequiredError`. Catch it and inspect `mfa_requirements` to determine the flow:
-
-```tsx
-import { useAuth0, MfaRequiredError } from '@auth0/auth0-react';
-import { useState } from 'react';
-
-export function ProtectedApiCall() {
-  const { getAccessTokenSilently, mfa } = useAuth0();
-  const [mfaToken, setMfaToken] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const callApi = async () => {
-    try {
-      const token = await getAccessTokenSilently();
-      // Use token to call API...
-    } catch (err) {
-      if (err instanceof MfaRequiredError) {
-        setMfaToken(err.mfa_token);
-
-        // Check if enrollment or challenge is needed
-        const factors = await mfa.getEnrollmentFactors(err.mfa_token);
-        if (factors.length > 0) {
-          // User needs to enroll — show enrollment UI
-        } else {
-          // User has authenticators — show challenge UI
-          const authenticators = await mfa.getAuthenticators(err.mfa_token);
-          // Let user pick authenticator and proceed with challenge
-        }
-      } else {
-        setError(err.message);
-      }
-    }
-  };
-
-  return <button onClick={callApi}>Call Protected API</button>;
-}
-```
-
-### OTP Enrollment
-
-When the user needs to set up MFA for the first time:
-
-```tsx
-import { useAuth0, MfaEnrollmentError } from '@auth0/auth0-react';
-import { useState } from 'react';
-
-export function OtpEnrollment({ mfaToken }: { mfaToken: string }) {
-  const { mfa } = useAuth0();
-  const [barcodeUri, setBarcodeUri] = useState<string | null>(null);
-  const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const startEnrollment = async () => {
-    try {
-      const enrollment = await mfa.enroll({ mfaToken, factorType: 'otp' });
-      setBarcodeUri(enrollment.barcodeUri);
-      setRecoveryCodes(enrollment.recoveryCodes);
-    } catch (err) {
-      if (err instanceof MfaEnrollmentError) {
-        setError(err.error_description);
-      }
-    }
-  };
-
-  return (
-    <div>
-      <button onClick={startEnrollment}>Set up authenticator app</button>
-      {barcodeUri && (
-        <div>
-          <p>Scan this QR code with your authenticator app:</p>
-          {/* Render barcodeUri as QR code using a library like qrcode.react */}
-          <code>{barcodeUri}</code>
-        </div>
-      )}
-      {recoveryCodes && (
-        <div>
-          <p>Save these recovery codes:</p>
-          <ul>
-            {recoveryCodes.map((code, i) => <li key={i}>{code}</li>)}
-          </ul>
-        </div>
-      )}
-    </div>
-  );
-}
-```
-
-### Challenge and Verify
-
-When the user already has enrolled authenticators:
-
-```tsx
-import {
-  useAuth0,
-  MfaChallengeError,
-  MfaVerifyError,
-} from '@auth0/auth0-react';
-import { useState } from 'react';
-
-export function MfaChallenge({ mfaToken }: { mfaToken: string }) {
-  const { mfa } = useAuth0();
-  const [otp, setOtp] = useState('');
-  const [error, setError] = useState<string | null>(null);
-
-  const handleVerify = async () => {
-    try {
-      // For OTP authenticators, you can skip challenge() and go straight to verify()
-      const tokens = await mfa.verify({ mfaToken, otp });
-      // User is now authenticated — tokens are cached by the SDK
-      // Access token available at tokens.access_token
-    } catch (err) {
-      if (err instanceof MfaVerifyError) {
-        setError('Invalid code. Please try again.');
-      } else if (err instanceof MfaChallengeError) {
-        setError('Challenge failed: ' + err.error_description);
-      }
-    }
-  };
-
-  return (
-    <div>
-      <h3>Enter your verification code</h3>
-      <input
-        type="text"
-        value={otp}
-        onChange={(e) => setOtp(e.target.value)}
-        placeholder="6-digit code"
-        maxLength={6}
-      />
-      <button onClick={handleVerify}>Verify</button>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
-    </div>
-  );
-}
-```
-
-### SMS/Email Challenge (Out-of-Band)
-
-For SMS, Email, Voice, or Push authenticators, you must call `challenge()` first to send the code:
-
-```tsx
-// Initiate challenge to send code via SMS/Email
-const response = await mfa.challenge({
-  mfaToken,
-  challengeType: 'oob',
-  authenticatorId: authenticator.id,
-});
-
-// Verify with the OOB code and the binding code the user received
-const tokens = await mfa.verify({
-  mfaToken,
-  oobCode: response.oobCode,
-  bindingCode: userEnteredCode,
-});
-```
-
-### Step-Up via Popup (Simpler Approach)
-
-If you don't need a custom MFA UI, configure `interactiveErrorHandler` to let the SDK handle MFA automatically via a Universal Login popup:
-
-```tsx
-<Auth0Provider
-  domain={import.meta.env.VITE_AUTH0_DOMAIN}
-  clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
-  authorizationParams={{
-    redirect_uri: window.location.origin,
-    audience: 'https://your-api-identifier',
-  }}
-  useRefreshTokens={true}
-  interactiveErrorHandler="popup"
->
-  <App />
-</Auth0Provider>
-```
-
-With this setup, `getAccessTokenSilently()` automatically opens a popup when MFA is required. No error handling needed — the token is returned after the user completes MFA in the popup.
 
 ---
 

--- a/plugins/auth0/skills/auth0/references/framework-spa-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-spa-js/index.md
@@ -184,7 +184,7 @@ const response = await fetch('https://your-api.example.com/data', {
 - API calls with tokens → see the Calling Protected APIs section below
 - Refresh tokens → see the Refresh Token Rotation section below
 - Organizations → see the Organizations section below
-- MFA handling → see the MFA Handling section below
+- MFA / step-up → ask for MFA (feature:mfa)
 - Error handling → see the Error Handling section below
 
 ## References
@@ -269,13 +269,8 @@ process.env.REACT_APP_AUTH0_DOMAIN
 | `PopupTimeoutError` | `@auth0/auth0-spa-js` | `loginWithPopup` — user didn't complete in time |
 | `PopupCancelledError` | `@auth0/auth0-spa-js` | `loginWithPopup` — popup was closed by the user |
 | `PopupOpenError` | `@auth0/auth0-spa-js` | `loginWithPopup` — `window.open` returned null (popups blocked) |
-| `MfaRequiredError` | `@auth0/auth0-spa-js` | `getTokenSilently` — MFA step required; access `error.mfa_token` |
 | `MissingRefreshTokenError` | `@auth0/auth0-spa-js` | `getTokenSilently` — refresh token not available |
 | `ConnectError` | `@auth0/auth0-spa-js` | `handleRedirectCallback` — error in connected accounts flow |
-| `MfaListAuthenticatorsError` | `@auth0/auth0-spa-js` | `auth0.mfa.getAuthenticators()` failed |
-| `MfaEnrollmentError` | `@auth0/auth0-spa-js` | `auth0.mfa.enroll()` failed |
-| `MfaChallengeError` | `@auth0/auth0-spa-js` | `auth0.mfa.challenge()` failed |
-| `MfaVerifyError` | `@auth0/auth0-spa-js` | `auth0.mfa.verify()` failed |
 
 ---
 
@@ -698,29 +693,6 @@ if (organization && invitation) {
 
 ---
 
-## MFA Handling
-
-Handle MFA when `getTokenSilently()` requires a second factor:
-
-```js
-import { MfaRequiredError } from '@auth0/auth0-spa-js';
-
-try {
-  const token = await auth0.getTokenSilently();
-} catch (error) {
-  if (error instanceof MfaRequiredError) {
-    // Trigger MFA challenge via popup or redirect
-    await auth0.loginWithPopup({
-      authorizationParams: {
-        mfa_token: error.mfa_token
-      }
-    });
-  }
-}
-```
-
----
-
 ## DPoP (Device-Bound Tokens)
 
 Enable DPoP to bind access tokens to the client's cryptographic key pair:
@@ -755,7 +727,6 @@ import {
   PopupTimeoutError,
   PopupCancelledError,
   PopupOpenError,
-  MfaRequiredError,
   MissingRefreshTokenError
 } from '@auth0/auth0-spa-js';
 

--- a/plugins/auth0/skills/auth0/references/framework-swift/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift/index.md
@@ -771,32 +771,13 @@ Auth0
             // Access token available at credentials.accessToken
             credentialsManager.store(credentials: credentials)
         case .failure(let error) where error.isMultifactorRequired:
-            // Extract MFA token for MFA challenge flow
-            if let mfaPayload = error.mfaRequiredErrorPayload {
-                startMFAChallenge(mfaToken: mfaPayload.mfaToken)
-            }
+            // MFA required — see the feature:mfa reference
         case .failure(let error) where error.isNetworkError:
             showNetworkError()
         case .failure(let error):
             print("Auth error code: \(error.code), description: \(error.localizedDescription)")
         }
     }
-```
-
----
-
-## MFA (Multi-Factor Authentication)
-
-### Handling MFA Required Error
-
-```swift
-// When login returns isMultifactorRequired = true, challenge with OTP
-func verifyMFA(mfaToken: String, otp: String) async throws -> Credentials {
-    return try await Auth0
-        .authentication()
-        .multifactorChallenge(mfaToken: mfaToken, types: ["otp"])
-        .start()
-}
 ```
 
 ---


### PR DESCRIPTION
The feature-mfa reference now owns MFA end to end. The auth0 skill routes any MFA request straight to it, and the framework references no longer carry their own MFA implementation, step-up recipes, or MFA client/error catalogs — so there is a single, consistent source instead of MFA guidance that drifted per SDK.

SDK-specific MFA symbols are delegated to each SDK's own examples through the links feature-mfa already maintains. SDK version-upgrade notes (Auth0.Android MfaApiClient, Auth0.swift MFAClient) stay in the framework references, since those are upgrade concerns rather than MFA how-to.

Also corrects the Android reference, which taught a non-existent credentials.claims property; ID-token claims are read via credentials.user accessors and getExtraInfo().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Consolidated multi-factor authentication guidance into the dedicated MFA documentation.
  - Updated framework-specific references to direct readers to centralized MFA guidance and SDK examples.
  - Removed outdated MFA workflows and API details from React, SPA, Android, Ionic, and Swift references.
  - Corrected Android ID-token claims guidance with accurate user-profile and custom-claims access details.
  - Updated routing expectations for combined MFA and Next.js documentation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->