### PR TITLE
feat(auth0): add framework refs for auth0-auth-js and auth0-server-js

### DIFF
--- a/evals/routing-cases.json
+++ b/evals/routing-cases.json
@@ -262,6 +262,27 @@
       "framework": null,
       "tooling": "cli",
       "expect_refs": ["feature-healthcheck/index.md", "feature-audit/index.md", "feature-audit-pricing/index.md", "feature-audit-remediation/index.md", "tooling-cli/index.md"]
+    },
+    {
+      "id": "integrate-auth0-auth-js",
+      "intent": "integrate",
+      "framework": "auth0-auth-js",
+      "tooling": "cli",
+      "expect_refs": ["framework-auth0-auth-js/index.md", "tooling-cli/index.md"]
+    },
+    {
+      "id": "integrate-auth0-server-js",
+      "intent": "integrate",
+      "framework": "auth0-server-js",
+      "tooling": "cli",
+      "expect_refs": ["framework-auth0-server-js/index.md", "tooling-cli/index.md"]
+    },
+    {
+      "id": "feature-mfa-auth0-server-js-combo",
+      "intent": "feature:mfa",
+      "framework": "auth0-server-js",
+      "tooling": "cli",
+      "expect_refs": ["feature-mfa/index.md", "tooling-cli/index.md"]
     }
   ]
 }

--- a/plugins/auth0/skills/auth0/SKILL.md
+++ b/plugins/auth0/skills/auth0/SKILL.md
@@ -4,7 +4,7 @@ description: Use when adding, fixing, or improving how an app authenticates user
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
-  version: '2.1.2'
+  version: '2.2.0'
   openclaw:
     emoji: "\U0001F510"
     homepage: https://github.com/auth0/agent-skills
@@ -94,6 +94,8 @@ SDK, so check the `@capacitor/browser` rows before it.
 | `express-oauth2-jwt-bearer` | `express-jwt` |
 | `react-native-auth0` + `app.json` or `app.config.js` present | `expo` |
 | `react-native-auth0` (no Expo files) | `react-native` |
+| `@auth0/auth0-server-js` | `auth0-server-js` |
+| `@auth0/auth0-auth-js` | `auth0-auth-js` |
 | `auth0` (the bare package, not `@auth0/*`) | `node-auth0` |
 
 ### Python — check `requirements.txt` or `pyproject.toml`
@@ -207,6 +209,8 @@ request. **Stop at the first match.**
 | React SPA (not Next.js) | `react` |
 | vanilla JS / plain JS / no framework SPA | `spa-js` |
 | node-auth0 / the `auth0` npm package | `node-auth0` |
+| `@auth0/auth0-server-js` / auth0-server-js / server-side Auth0 session SDK | `auth0-server-js` |
+| `@auth0/auth0-auth-js` / auth0-auth-js / AuthClient / low-level OAuth OIDC | `auth0-auth-js` |
 | Express (web app / server-rendered) | `express` |
 | Express API / protect API routes | `express-jwt` |
 | Fastify (web) / Fastify API | `fastify` / `fastify-api` |

--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -165,7 +165,7 @@ language-neutral mechanic above. Never substitute a web search for "how to do MF
 | `@auth0/auth0-angular` (MFA) | https://raw.githubusercontent.com/auth0/auth0-angular/main/EXAMPLES.md | `## Multi-Factor Authentication (MFA)` |
 | `@auth0/auth0-angular` (step-up) | https://raw.githubusercontent.com/auth0/auth0-angular/main/EXAMPLES.md | `## Step-Up Authentication` |
 | `@auth0/auth0-spa-js` (step-up) | https://raw.githubusercontent.com/auth0/auth0-spa-js/main/examples/step-up-authentication.md | whole file |
-| `@auth0/nextjs-auth0` | https://raw.githubusercontent.com/auth0/nextjs-auth0/main/EXAMPLES.md | `## Multi-Factor Authentication (MFA)` |
+| `@auth0/nextjs-auth0` | https://raw.githubusercontent.com/auth0/nextjs-auth0/main/guides/mfa.md | whole file |
 | `@auth0/auth0-auth-js` | https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-auth-js/examples/mfa.md | whole file |
 | `@auth0/auth0-server-js` | https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-server-js/MFA.md | whole file |
 | `Auth0.swift` (iOS/macOS) | https://raw.githubusercontent.com/auth0/Auth0.swift/master/examples/mfa-api.md | whole file |

--- a/plugins/auth0/skills/auth0/references/framework-android/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-android/index.md
@@ -851,7 +851,7 @@ WebAuthProvider.login(account)
     .start(this, object : Callback<Credentials, AuthenticationException> {
         override fun onSuccess(result: Credentials) {
             // User authenticated to organization
-            val orgId = result.claims["org_id"]
+            val orgId = result.user.getExtraInfo()["org_id"] as? String
         }
 
         override fun onFailure(error: AuthenticationException) {

--- a/plugins/auth0/skills/auth0/references/framework-auth0-auth-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-auth0-auth-js/index.md
@@ -1,0 +1,163 @@
+
+# Auth0 auth0-auth-js Integration
+
+Add OAuth 2.0 / OpenID Connect to a server-side Node.js or edge runtime with the
+`@auth0/auth0-auth-js` package: a low-level, stateless, headless authentication
+client built around the `AuthClient` class. It builds authorization URLs,
+exchanges codes for tokens, refreshes tokens, runs the client-credentials and
+password grants, reads a user profile from `/userinfo`, and builds logout URLs.
+
+> **Stateless by design.** auth0-auth-js holds no session, sets no cookies, and
+> stores no state. You own where the tokens and the PKCE `code_verifier` live.
+> For managed server sessions with cookies use `@auth0/auth0-server-js`; for a
+> framework you already run (Next.js, Express, Nuxt, and so on) use that
+> framework's Auth0 SDK instead - it wraps this package for you.
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the
+> latest version by running:
+> ```
+> npm view @auth0/auth0-auth-js version
+> ```
+> Use the returned version instead of any version shown below.
+
+## Critical rules
+
+- **`AuthClient` is server-side only.** It needs the Client Secret, so never
+  import it into browser or mobile client code and never ship the secret to a
+  client bundle.
+- **Never read the contents of `.env*` during setup** - it may contain secrets
+  that should not be exposed in the LLM context. Before writing to any env file
+  you MUST ask the user for explicit confirmation and wait for it.
+- **`domain` must be a bare hostname** - no `https://`, no path, no trailing
+  slash.
+- **The PKCE `codeVerifier` is single-use and per-request.** Generate it with
+  `buildAuthorizationUrl()`, carry it through the redirect, and pass the same
+  value to `getTokenByCode()`. Never reuse one across requests or store it in a
+  long-lived, shared location.
+
+## Prerequisites
+
+- Node.js `^20.19.0 || ^22.12.0 || ^24.0.0` (confirm with
+  `npm view @auth0/auth0-auth-js engines` when building).
+- An Auth0 application whose grant type and callback URL match the flow: a
+  Regular Web Application for the authorization-code flow, a Machine-to-Machine
+  application for client credentials. Create and configure it with the loaded
+  tooling reference.
+- `domain`, `clientId`, `clientSecret` (and a redirect URI for the code flow) in
+  environment variables.
+
+## When NOT to use
+
+auth0-auth-js is a low-level token/OAuth building block. Route elsewhere for:
+
+- **Managed server sessions** - login cookies, session persistence, "keep the
+  user logged in" - use `@auth0/auth0-server-js`.
+- **A framework you already run** - if an Auth0 SDK exists for the app's stack
+  (Next.js, Express, Nuxt, Fastify, and so on), use it. Those wrap this package
+  and handle the redirect, callback, and storage for you. auth0-auth-js is for
+  building a new integration where none exists.
+- **Management API operations** - reading or writing users, applications,
+  connections - use `node-auth0` (the `auth0` npm package).
+- **Multi-factor authentication how-to** - ask for MFA (feature:mfa).
+
+## Quick start workflow
+
+### 1. Install the SDK
+
+```bash
+npm install @auth0/auth0-auth-js
+```
+
+### 2. Configure credentials
+
+Put the tenant Domain, Client ID, Client Secret, and (for the code flow) the
+redirect URI in `.env`. For all Auth0 tenant configuration (create the app, set
+the callback URL, choose grant types), use the loaded tooling reference - do not
+inline setup here.
+
+```env
+AUTH0_DOMAIN=<your-tenant-domain>
+AUTH0_CLIENT_ID=<your-client-id>
+AUTH0_CLIENT_SECRET=<your-client-secret>
+AUTH0_REDIRECT_URI=<your-callback-url>
+```
+
+### 3. Instantiate AuthClient
+
+```ts
+import { AuthClient } from "@auth0/auth0-auth-js";
+
+const authClient = new AuthClient({
+  domain: process.env.AUTH0_DOMAIN!,        // bare hostname, e.g. tenant.us.auth0.com
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!,
+  authorizationParams: { redirect_uri: process.env.AUTH0_REDIRECT_URI! },
+});
+```
+
+### 4. Authorization code + PKCE
+
+`buildAuthorizationUrl()` returns the URL to redirect to along with the
+`codeVerifier` and `state` you must persist for the callback. After Auth0
+redirects back, exchange the code:
+
+```ts
+const { authorizationUrl, codeVerifier } = await authClient.buildAuthorizationUrl();
+// redirect the user to authorizationUrl; persist codeVerifier for the callback
+
+// in the callback handler, with the full callback URL:
+const tokens = await authClient.getTokenByCode(callbackUrl, { codeVerifier });
+```
+
+### 5. Other grants and token operations
+
+```ts
+// Machine-to-machine
+const m2m = await authClient.getTokenByClientCredentials({ audience });
+
+// Refresh
+const refreshed = await authClient.getTokenByRefreshToken({ refreshToken });
+
+// User profile from an access token
+const user = await authClient.getUserInfo(accessToken);
+```
+
+### 6. Logout
+
+`buildLogoutUrl()` returns the URL to send the user to - the SDK does not issue
+the redirect itself.
+
+```ts
+const logoutUrl = authClient.buildLogoutUrl({ returnTo });
+```
+
+## Sub-clients
+
+`AuthClient` exposes feature sub-clients that share its constructor config:
+`authClient.mfa`, `authClient.passkey`, `authClient.passwordless`, and
+`authClient.database`. Their usage is covered in the package's examples (see
+References).
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| `domain: "https://tenant.auth0.com/"` | Bare hostname only - `tenant.auth0.com`. |
+| Reusing a `codeVerifier` across requests | Generate a new one per `buildAuthorizationUrl()` call. |
+| Calling `getTokenByCode()` without the verifier | Pass `{ codeVerifier }` as the second argument. |
+| Expecting cookies or a session | auth0-auth-js is stateless - use `@auth0/auth0-server-js` for sessions. |
+| Importing `AuthClient` in browser/mobile code | Server-side only - it needs the Client Secret. |
+| Using it for Management API calls | Use `node-auth0` (the `auth0` npm package). |
+
+## Related capabilities
+
+- Managed server sessions with cookies - use `@auth0/auth0-server-js`.
+- Full login integration for an existing framework - use that framework's Auth0
+  SDK (Next.js, Express, Nuxt, and so on).
+- Management API (users, apps, roles) - use `node-auth0` (the `auth0` npm
+  package).
+- Multi-factor authentication - ask for MFA (feature:mfa).
+
+## References
+- [`@auth0/auth0-auth-js` usage examples](https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-auth-js/EXAMPLES.md)
+- [Source and README](https://github.com/auth0/auth0-auth-js/tree/main/packages/auth0-auth-js)

--- a/plugins/auth0/skills/auth0/references/framework-auth0-auth-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-auth0-auth-js/index.md
@@ -119,7 +119,7 @@ const m2m = await authClient.getTokenByClientCredentials({ audience });
 const refreshed = await authClient.getTokenByRefreshToken({ refreshToken });
 
 // User profile from an access token
-const user = await authClient.getUserInfo(accessToken);
+const user = await authClient.getUserInfo({ accessToken });
 ```
 
 ### 6. Logout

--- a/plugins/auth0/skills/auth0/references/framework-auth0-auth-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-auth0-auth-js/index.md
@@ -98,8 +98,8 @@ const authClient = new AuthClient({
 ### 4. Authorization code + PKCE
 
 `buildAuthorizationUrl()` returns the URL to redirect to along with the
-`codeVerifier` and `state` you must persist for the callback. After Auth0
-redirects back, exchange the code:
+`codeVerifier` you must persist for the callback. After Auth0 redirects back,
+exchange the code:
 
 ```ts
 const { authorizationUrl, codeVerifier } = await authClient.buildAuthorizationUrl();

--- a/plugins/auth0/skills/auth0/references/framework-auth0-server-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-auth0-server-js/index.md
@@ -25,7 +25,7 @@ access token, and builds the logout URL.
 ## Critical rules
 
 - **The Client Secret and the cookie secret are server secrets.** Load
-  `clientSecret` and `cookieOptions.secret` from environment variables; never
+  `clientSecret` and the store `secret` from environment variables; never
   hardcode them or expose them to a browser.
 - **Never read the contents of `.env*` during setup** - it may contain secrets
   that should not be exposed in the LLM context. Before writing to any env file
@@ -46,7 +46,7 @@ access token, and builds the logout URL.
 - An Auth0 Regular Web Application with the redirect URI in Allowed Callback URLs
   and the logout URL in Allowed Logout URLs. Configure it with the loaded
   tooling reference.
-- A strong random string for `cookieOptions.secret` (at least 32 random bytes);
+- A strong random string for the store `secret` (at least 32 random bytes);
   generate it once and store it in an environment variable.
 - A `stateStore` and a `transactionStore`. The SDK ships `StatelessStateStore`,
   `StatefulStateStore`, and `CookieTransactionStore` as built-ins; pick a pair or
@@ -87,6 +87,10 @@ AUTH0_COOKIE_SECRET=<32+ random bytes>
 
 ### 3. Instantiate ServerClient
 
+Both built-in stores take a second argument: a `CookieHandler` you implement
+for your framework (`setCookie`, `getCookie`, `getCookies`, `deleteCookie`) so
+the store can read and write cookies on the current request/response.
+
 ```ts
 import {
   ServerClient,
@@ -94,13 +98,15 @@ import {
   StatelessStateStore,
 } from "@auth0/auth0-server-js";
 
+const cookieHandler = createCookieHandler(); // your framework's cookie adapter
+
 const serverClient = new ServerClient({
   domain: process.env.AUTH0_DOMAIN!,        // bare hostname
   clientId: process.env.AUTH0_CLIENT_ID!,
   clientSecret: process.env.AUTH0_CLIENT_SECRET!,
   authorizationParams: { redirect_uri: process.env.AUTH0_REDIRECT_URI! },
-  transactionStore: new CookieTransactionStore({ secret: process.env.AUTH0_COOKIE_SECRET! }),
-  stateStore: new StatelessStateStore({ secret: process.env.AUTH0_COOKIE_SECRET! }),
+  transactionStore: new CookieTransactionStore({ secret: process.env.AUTH0_COOKIE_SECRET! }, cookieHandler),
+  stateStore: new StatelessStateStore({ secret: process.env.AUTH0_COOKIE_SECRET! }, cookieHandler),
 });
 ```
 
@@ -120,7 +126,7 @@ await serverClient.completeInteractiveLogin(callbackUrl, storeOptions);
 const user = await serverClient.getUser(storeOptions);
 
 // Get an access token for calling an API
-const { token } = await serverClient.getAccessToken(storeOptions);
+const { accessToken } = await serverClient.getAccessToken(storeOptions);
 
 // Logout: redirect the user to the returned URL
 const logoutUrl = await serverClient.logout({ returnTo }, storeOptions);
@@ -139,20 +145,20 @@ const logoutUrl = await serverClient.logout({ returnTo }, storeOptions);
 
 ## Multi-domain / multi-tenant
 
-For per-request domain resolution, pass a `domainResolver` function instead of a
-static `domain`. Note that the `serverClient.mfa` and `serverClient.authClient`
-sub-clients are only available in static-domain mode.
+For per-request domain resolution, pass a `DomainResolver` function as `domain`
+instead of a static hostname string. Note that the `serverClient.mfa` and
+`serverClient.authClient` sub-clients are only available in static-domain mode.
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---|---|
 | Omitting `authorizationParams.redirect_uri` | Required for interactive login; must match Allowed Callback URLs. |
-| Hardcoding `cookieOptions.secret` | Load it from an env variable; treat it as a server secret. |
+| Hardcoding the store `secret` | Load it from an env variable; treat it as a server secret. |
 | `domain: "https://tenant.auth0.com/"` | Bare hostname only - `tenant.auth0.com`. |
 | Forgetting the trailing `storeOptions` | Every session method needs it; its shape depends on your framework. |
 | Hand-wiring `ServerClient` when a framework SDK exists | Use `@auth0/nextjs-auth0`, `express-openid-connect`, and so on. |
-| Accessing `serverClient.mfa` with a `domainResolver` set | Those sub-clients are unavailable in multi-domain mode. |
+| Accessing `serverClient.mfa` with a `DomainResolver` set as `domain` | Those sub-clients are unavailable in multi-domain mode. |
 
 ## Related capabilities
 

--- a/plugins/auth0/skills/auth0/references/framework-auth0-server-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-auth0-server-js/index.md
@@ -1,0 +1,170 @@
+
+# Auth0 auth0-server-js Integration
+
+Add managed server-side authentication sessions to a Node.js backend with the
+`@auth0/auth0-server-js` package: the `ServerClient` class wraps
+`@auth0/auth0-auth-js` with cookie and state handling, so it runs the login
+redirect, completes the callback, persists the session, hands back the user and
+access token, and builds the logout URL.
+
+> **This is a building block.** The README calls auth0-server-js "a building
+> block for building framework-specific authentication SDKs." If an Auth0 SDK
+> exists for your framework - `@auth0/nextjs-auth0`, `express-openid-connect`,
+> `@auth0/auth0-nuxt`, `@auth0/auth0-fastify`, and others - use it instead.
+> Those are built on top of this package and give you an idiomatic adapter.
+> Reach for auth0-server-js directly only when no higher-level SDK covers your
+> stack and you are prepared to write the request/response adapter yourself.
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the
+> latest version by running:
+> ```
+> npm view @auth0/auth0-server-js version
+> ```
+> Use the returned version instead of any version shown below.
+
+## Critical rules
+
+- **The Client Secret and the cookie secret are server secrets.** Load
+  `clientSecret` and `cookieOptions.secret` from environment variables; never
+  hardcode them or expose them to a browser.
+- **Never read the contents of `.env*` during setup** - it may contain secrets
+  that should not be exposed in the LLM context. Before writing to any env file
+  you MUST ask the user for explicit confirmation and wait for it.
+- **`domain` must be a bare hostname** - no `https://`, no path, no trailing
+  slash.
+- **`authorizationParams.redirect_uri` is required** for the interactive login
+  flow and must match an Allowed Callback URL in the Auth0 app.
+- **Every session method takes a trailing `storeOptions`.**
+  `startInteractiveLogin`, `completeInteractiveLogin`, `getUser`, `getSession`,
+  `getAccessToken`, and `logout` all need it - a small object shaped by your
+  framework's request/response so the store can read and write cookies.
+
+## Prerequisites
+
+- Node.js `^20.19.0 || ^22.12.0 || ^24.0.0` (confirm with
+  `npm view @auth0/auth0-server-js engines` when building).
+- An Auth0 Regular Web Application with the redirect URI in Allowed Callback URLs
+  and the logout URL in Allowed Logout URLs. Configure it with the loaded
+  tooling reference.
+- A strong random string for `cookieOptions.secret` (at least 32 random bytes);
+  generate it once and store it in an environment variable.
+- A `stateStore` and a `transactionStore`. The SDK ships `StatelessStateStore`,
+  `StatefulStateStore`, and `CookieTransactionStore` as built-ins; pick a pair or
+  implement the abstract interfaces.
+
+## When NOT to use
+
+- **A framework SDK exists for your stack** - `@auth0/nextjs-auth0`,
+  `express-openid-connect`, `@auth0/auth0-nuxt`, `@auth0/auth0-fastify`, and
+  others - use it. They wrap this package and remove the adapter work.
+- **Stateless token operations only** - no session needed - use
+  `@auth0/auth0-auth-js` directly.
+- **Management API operations** - reading or writing users, applications,
+  connections - use `node-auth0` (the `auth0` npm package).
+- **Multi-factor authentication how-to** - ask for MFA (feature:mfa).
+
+## Quick start workflow
+
+### 1. Install the SDK
+
+```bash
+npm install @auth0/auth0-server-js
+```
+
+### 2. Configure credentials
+
+Put the tenant Domain, Client ID, Client Secret, redirect URI, and a generated
+cookie secret in environment variables. Use the loaded tooling reference for all
+Auth0 tenant configuration.
+
+```env
+AUTH0_DOMAIN=<your-tenant-domain>
+AUTH0_CLIENT_ID=<your-client-id>
+AUTH0_CLIENT_SECRET=<your-client-secret>
+AUTH0_REDIRECT_URI=<your-callback-url>
+AUTH0_COOKIE_SECRET=<32+ random bytes>
+```
+
+### 3. Instantiate ServerClient
+
+```ts
+import {
+  ServerClient,
+  CookieTransactionStore,
+  StatelessStateStore,
+} from "@auth0/auth0-server-js";
+
+const serverClient = new ServerClient({
+  domain: process.env.AUTH0_DOMAIN!,        // bare hostname
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!,
+  authorizationParams: { redirect_uri: process.env.AUTH0_REDIRECT_URI! },
+  transactionStore: new CookieTransactionStore({ secret: process.env.AUTH0_COOKIE_SECRET! }),
+  stateStore: new StatelessStateStore({ secret: process.env.AUTH0_COOKIE_SECRET! }),
+});
+```
+
+### 4. Login, callback, session, logout
+
+Each call takes a trailing `storeOptions` built from the current request/response
+so the store can set and read cookies.
+
+```ts
+// Login route: redirect the user to the returned URL
+const url = await serverClient.startInteractiveLogin({}, storeOptions);
+
+// Callback route: completes the login, then redirect into the app
+await serverClient.completeInteractiveLogin(callbackUrl, storeOptions);
+
+// Read the session user (null when not logged in)
+const user = await serverClient.getUser(storeOptions);
+
+// Get an access token for calling an API
+const { token } = await serverClient.getAccessToken(storeOptions);
+
+// Logout: redirect the user to the returned URL
+const logoutUrl = await serverClient.logout({ returnTo }, storeOptions);
+```
+
+## Storage exports
+
+- `CookieTransactionStore` - holds the short-lived login transaction (state,
+  PKCE verifier) in a cookie.
+- `StatelessStateStore` - keeps the whole session in a signed cookie; no server
+  store needed.
+- `StatefulStateStore` - keeps a session ID in the cookie and the session in an
+  external store you provide.
+- `AbstractStateStore` / `AbstractTransactionStore` - interfaces to implement a
+  custom store.
+
+## Multi-domain / multi-tenant
+
+For per-request domain resolution, pass a `domainResolver` function instead of a
+static `domain`. Note that the `serverClient.mfa` and `serverClient.authClient`
+sub-clients are only available in static-domain mode.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Omitting `authorizationParams.redirect_uri` | Required for interactive login; must match Allowed Callback URLs. |
+| Hardcoding `cookieOptions.secret` | Load it from an env variable; treat it as a server secret. |
+| `domain: "https://tenant.auth0.com/"` | Bare hostname only - `tenant.auth0.com`. |
+| Forgetting the trailing `storeOptions` | Every session method needs it; its shape depends on your framework. |
+| Hand-wiring `ServerClient` when a framework SDK exists | Use `@auth0/nextjs-auth0`, `express-openid-connect`, and so on. |
+| Accessing `serverClient.mfa` with a `domainResolver` set | Those sub-clients are unavailable in multi-domain mode. |
+
+## Related capabilities
+
+- Stateless token/OAuth operations without a session - use
+  `@auth0/auth0-auth-js`.
+- Full login integration for Next.js, Express, Nuxt, Fastify, and so on - use
+  that framework's Auth0 SDK.
+- Management API (users, apps, roles) - use `node-auth0` (the `auth0` npm
+  package).
+- Multi-factor authentication - ask for MFA (feature:mfa).
+
+## References
+- [`@auth0/auth0-server-js` usage examples](https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-server-js/EXAMPLES.md)
+- [`@auth0/auth0-server-js` MFA examples](https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-server-js/MFA.md)
+- [Source and README](https://github.com/auth0/auth0-auth-js/tree/main/packages/auth0-server-js)

--- a/plugins/auth0/skills/auth0/references/framework-auth0-server-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-auth0-server-js/index.md
@@ -98,7 +98,7 @@ import {
   StatelessStateStore,
 } from "@auth0/auth0-server-js";
 
-const cookieHandler = createCookieHandler(); // your framework's cookie adapter
+const cookieHandler = new MyCookieHandler(); // a CookieHandler you implement; see EXAMPLES.md for a Fastify adapter
 
 const serverClient = new ServerClient({
   domain: process.env.AUTH0_DOMAIN!,        // bare hostname
@@ -122,7 +122,7 @@ const url = await serverClient.startInteractiveLogin({}, storeOptions);
 // Callback route: completes the login, then redirect into the app
 await serverClient.completeInteractiveLogin(callbackUrl, storeOptions);
 
-// Read the session user (null when not logged in)
+// Read the session user (undefined when not logged in)
 const user = await serverClient.getUser(storeOptions);
 
 // Get an access token for calling an API
@@ -136,8 +136,8 @@ const logoutUrl = await serverClient.logout({ returnTo }, storeOptions);
 
 - `CookieTransactionStore` - holds the short-lived login transaction (state,
   PKCE verifier) in a cookie.
-- `StatelessStateStore` - keeps the whole session in a signed cookie; no server
-  store needed.
+- `StatelessStateStore` - keeps the whole session in an encrypted cookie; no
+  server store needed.
 - `StatefulStateStore` - keeps a session ID in the cookie and the session in an
   external store you provide.
 - `AbstractStateStore` / `AbstractTransactionStore` - interfaces to implement a

--- a/plugins/auth0/skills/auth0/references/framework-swift/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-swift/index.md
@@ -772,6 +772,7 @@ Auth0
             credentialsManager.store(credentials: credentials)
         case .failure(let error) where error.isMultifactorRequired:
             // MFA required — see the feature:mfa reference
+            break
         case .failure(let error) where error.isNetworkError:
             showNetworkError()
         case .failure(let error):

--- a/plugins/auth0/skills/auth0/scripts/validate-skill.sh
+++ b/plugins/auth0/skills/auth0/scripts/validate-skill.sh
@@ -62,7 +62,7 @@ fi
 # "every routed framework has a file and every file is routed" guarantee is
 # enforced by scripts/check_router_reachability.py (run below), which derives
 # slugs from the router itself. Keep this list in sync when adding frameworks.
-EXPECTED_FRAMEWORKS="react nextjs vue angular spa-js nuxt express flask fastify fastify-api java-mvc aspnetcore-auth aspnetcore-api php php-api express-jwt fastapi-api springboot-api go react-native expo ionic-angular ionic-react ionic-vue android swift kmp flutter-native flutter-web laravel laravel-api maui net-android net-ios winforms wpf node-auth0"
+EXPECTED_FRAMEWORKS="react nextjs vue angular spa-js nuxt express flask fastify fastify-api java-mvc aspnetcore-auth aspnetcore-api php php-api express-jwt fastapi-api springboot-api go react-native expo ionic-angular ionic-react ionic-vue android swift kmp flutter-native flutter-web laravel laravel-api maui net-android net-ios winforms wpf node-auth0 auth0-auth-js auth0-server-js"
 for fw in $EXPECTED_FRAMEWORKS; do
   if [ ! -f "$REFS_DIR/framework-$fw/index.md" ]; then
     echo "FAIL: missing references/framework-$fw/index.md"


### PR DESCRIPTION
The unified auth0 skill routes an integrate request to a framework-* reference for each Auth0 SDK it can detect, but the two lowest-level Node packages had no reference to land on. A project with @auth0/auth0-server-js or @auth0/auth0-auth-js in its package.json got no framework match.

This adds index references for both: auth0-auth-js (the headless AuthClient OAuth/OIDC client) and auth0-server-js (the ServerClient session SDK that wraps it). Both are wired into the Step 2 detection tables so integrate resolves them, with server-js ordered ahead of auth-js so a dual-dependency project routes to the more specific one. The server-js reference steers app developers toward a framework SDK when one exists, since ServerClient is a building block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guidance for integrating Auth0’s server-side authentication and session SDKs in Node.js and edge runtimes.
  - Added routing support for the new Auth0 JavaScript framework identifiers.
  - Added MFA routing guidance for server-side Auth0 integrations.

- **Documentation**
  - Updated Auth0 framework detection guidance and examples.
  - Corrected Android organization claim access instructions.
  - Clarified Swift MFA error-handling guidance.
  - Updated MFA example references and Auth0 skill metadata to version 2.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->