### PR TITLE
chore: Adds generic rules for auth0-auth-js and auth0-server-js

### DIFF
--- a/plugins/auth0/skills/auth0/references/framework-auth0-auth-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-auth0-auth-js/index.md
@@ -30,6 +30,10 @@ password grants, reads a user profile from `/userinfo`, and builds logout URLs.
   you MUST ask the user for explicit confirmation and wait for it.
 - **`domain` must be a bare hostname** - no `https://`, no path, no trailing
   slash.
+- **The tenant `domain` and `clientId` are configuration, not code.** Read them
+  from environment variables and never hardcode them in source files. They are
+  not secrets, but inlining them pins the build to one tenant and trips
+  config/secret scanners.
 - **The PKCE `codeVerifier` is single-use and per-request.** Generate it with
   `buildAuthorizationUrl()`, carry it through the redirect, and pass the same
   value to `getTokenByCode()`. Never reuse one across requests or store it in a
@@ -143,6 +147,7 @@ References).
 | Mistake | Fix |
 |---|---|
 | `domain: "https://tenant.auth0.com/"` | Bare hostname only - `tenant.auth0.com`. |
+| Hardcoding `domain` or `clientId` in source | Read them from env/config; inlining pins the build to one tenant and trips scanners. |
 | Reusing a `codeVerifier` across requests | Generate a new one per `buildAuthorizationUrl()` call. |
 | Calling `getTokenByCode()` without the verifier | Pass `{ codeVerifier }` as the second argument. |
 | Expecting cookies or a session | auth0-auth-js is stateless - use `@auth0/auth0-server-js` for sessions. |

--- a/plugins/auth0/skills/auth0/references/framework-auth0-server-js/index.md
+++ b/plugins/auth0/skills/auth0/references/framework-auth0-server-js/index.md
@@ -27,6 +27,10 @@ access token, and builds the logout URL.
 - **The Client Secret and the cookie secret are server secrets.** Load
   `clientSecret` and the store `secret` from environment variables; never
   hardcode them or expose them to a browser.
+- **The tenant `domain` and `clientId` are configuration, not code.** Read them
+  from environment variables as well, and never hardcode them in source files.
+  They are not secrets, but inlining them pins the build to one tenant and trips
+  config/secret scanners.
 - **Never read the contents of `.env*` during setup** - it may contain secrets
   that should not be exposed in the LLM context. Before writing to any env file
   you MUST ask the user for explicit confirmation and wait for it.
@@ -155,6 +159,9 @@ instead of a static hostname string. Note that the `serverClient.mfa` and
 |---|---|
 | Omitting `authorizationParams.redirect_uri` | Required for interactive login; must match Allowed Callback URLs. |
 | Hardcoding the store `secret` | Load it from an env variable; treat it as a server secret. |
+| Hardcoding `domain` or `clientId` in source | Read them from env/config; inlining pins the build to one tenant and trips scanners. |
+| Passing `organization` only inside `authorizationParams` | Prefer the first-class `organization` option on `startInteractiveLogin` (or the `ServerClient` default); the params bag is a backwards-compatible fallback. |
+| Detecting org validation failures by string-matching `error.message` | Import `OrganizationValidationError` from `@auth0/auth0-server-js` and check `error instanceof OrganizationValidationError`. |
 | `domain: "https://tenant.auth0.com/"` | Bare hostname only - `tenant.auth0.com`. |
 | Forgetting the trailing `storeOptions` | Every session method needs it; its shape depends on your framework. |
 | Hand-wiring `ServerClient` when a framework SDK exists | Use `@auth0/nextjs-auth0`, `express-openid-connect`, and so on. |


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

- Adds generic rules in `auth0-auth-js` and `auth0-server-js` framework references around how to handle configuration and secrets. 

### References

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to load tenant domain and client ID from environment variables rather than hardcoding them.
  * Documented the preferred organization configuration option.
  * Added guidance for reliably detecting organization validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->