### PR TITLE
chore: Adds a row pointing to the auth0-api-js example

### DIFF
--- a/plugins/auth0/skills/auth0/references/feature-organizations/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-organizations/index.md
@@ -94,6 +94,13 @@ if (!allowedOrgIds.has(orgId)) { /* reject: untrusted organization (e.g. 403) */
 // then scope every data lookup by orgId
 ```
 
+For richer per-SDK examples (org switching, reading org claims) read the SDK's own file, only
+the named section (from that heading to the next heading of the same or higher level):
+
+| SDK | Raw example file (markdown) | Find section |
+|---|---|---|
+| `@auth0/auth0-api-js` | https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-api-js/README.md | `### 3. Verify the Access Token` |
+
 ---
 
 ## Tenant Configuration (via chosen tooling)


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
- Adds a row for `auth0-api-js` pointing to an example on its github repo of how to validate `org_id`.


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an SDK reference table to the Auth0 Organizations documentation.
  * Included a link to access-token verification examples in the Auth0 API SDK README.
  * This helps developers find SDK-specific guidance for validating organization access tokens on the backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->