### PR TITLE
flywheel(feature-mfa): document GET 404 on individual factor endpoints

### DIFF
--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -262,7 +262,6 @@ which uses the `mfa_token` and the MFA API surface instead:
 | Sending `message_type` or `provider` to `guardian/factors/sms` directly | Returns a 400 — those fields are not accepted on that endpoint | Use `PUT guardian/factors/phone/message-types` for the message type and `PUT guardian/factors/phone/selected-provider` for the provider |
 | Using the Management API to list or remove a user's own factors during the sign-in flow | Forces the app to hold Management API admin scopes and ignores the `mfa_token` the flow already issued | List and challenge through the SDK's MFA client on the `mfa_token`; remove with a post-MFA `remove:authenticators` access token (mfa audience); reserve the Management API for admin / out-of-band |
 | Assuming an already-enrolled factor needs no challenge and jumping straight to verify | Diverges from the SDK's documented enrolled-factor flow and breaks for out-of-band factors (SMS/push), whose challenge is what delivers the code | Challenge the enrolled authenticator, then verify |
-| Verifying factor state with `GET guardian/factors/sms` or `GET guardian/factors/email` | These individual GET endpoints return 404 | Use `GET guardian/factors` (the list endpoint) to verify all factor states at once |
 
 ## Related capabilities
 

--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -203,6 +203,10 @@ auth0 api put "guardian/factors/email" --data '{"enabled": true}'
 
 # Enforce MFA for all applications (PUT replaces the whole list; wrong verb returns 404)
 auth0 api put "guardian/policies" --data '["all-applications"]'
+
+# Verify — use the list endpoint; individual factor GETs (guardian/factors/sms, guardian/factors/email) return 404
+auth0 api get "guardian/factors"
+auth0 api get "guardian/policies"
 ```
 
 The full factor set, the `confidence-score` (adaptive) policy, the Terraform

--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -258,6 +258,7 @@ which uses the `mfa_token` and the MFA API surface instead:
 | Sending `message_type` or `provider` to `guardian/factors/sms` directly | Returns a 400 — those fields are not accepted on that endpoint | Use `PUT guardian/factors/phone/message-types` for the message type and `PUT guardian/factors/phone/selected-provider` for the provider |
 | Using the Management API to list or remove a user's own factors during the sign-in flow | Forces the app to hold Management API admin scopes and ignores the `mfa_token` the flow already issued | List and challenge through the SDK's MFA client on the `mfa_token`; remove with a post-MFA `remove:authenticators` access token (mfa audience); reserve the Management API for admin / out-of-band |
 | Assuming an already-enrolled factor needs no challenge and jumping straight to verify | Diverges from the SDK's documented enrolled-factor flow and breaks for out-of-band factors (SMS/push), whose challenge is what delivers the code | Challenge the enrolled authenticator, then verify |
+| Verifying factor state with `GET guardian/factors/sms` or `GET guardian/factors/email` | These individual GET endpoints return 404 | Use `GET guardian/factors` (the list endpoint) to verify all factor states at once |
 
 ## Related capabilities
 

--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -204,9 +204,8 @@ auth0 api put "guardian/factors/email" --data '{"enabled": true}'
 # Enforce MFA for all applications (PUT replaces the whole list; wrong verb returns 404)
 auth0 api put "guardian/policies" --data '["all-applications"]'
 
-# Verify — use the list endpoint; individual factor GETs (guardian/factors/sms, guardian/factors/email) return 404
+# Verify with the list endpoint only — do not GET individual factors, they return 404
 auth0 api get "guardian/factors"
-auth0 api get "guardian/policies"
 ```
 
 The full factor set, the `confidence-score` (adaptive) policy, the Terraform


### PR DESCRIPTION
## Flywheel fix

`GET guardian/factors/sms` and `GET guardian/factors/email` return 404 — individual factor GET endpoints don't exist. Models that try to verify factor state this way waste steps retrying, which tanks the Efficiency score even when configuration is 100% correct.

Adds one row to common mistakes: use `GET guardian/factors` (the list endpoint) instead.

**Impact:** luna Efficiency 5.6/F → expected recovery once models read this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that individual SMS and email factor endpoints may return 404.
  * Recommended using the tenant’s factors list command to verify factor states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->