### PR TITLE
test: point Auth0.Android MFA doc row at fix-branch (pending Auth0.Android#1067)

### DIFF
--- a/plugins/auth0/skills/auth0/references/feature-mfa/index.md
+++ b/plugins/auth0/skills/auth0/references/feature-mfa/index.md
@@ -169,7 +169,7 @@ language-neutral mechanic above. Never substitute a web search for "how to do MF
 | `@auth0/auth0-auth-js` | https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-auth-js/examples/mfa.md | whole file |
 | `@auth0/auth0-server-js` | https://raw.githubusercontent.com/auth0/auth0-auth-js/main/packages/auth0-server-js/MFA.md | whole file |
 | `Auth0.swift` (iOS/macOS) | https://raw.githubusercontent.com/auth0/Auth0.swift/master/examples/mfa-api.md | whole file |
-| `Auth0.Android` | https://raw.githubusercontent.com/auth0/Auth0.Android/main/examples/authentication-api/mfa-flexible-factors.md | whole file |
+| `Auth0.Android` | https://raw.githubusercontent.com/auth0/Auth0.Android/fix/mfa-flexible-factors-remove-stale-early-access-note/examples/authentication-api/mfa-flexible-factors.md | whole file |
 | `auth0-server-python` (MFA flow) | https://raw.githubusercontent.com/auth0/auth0-server-python/main/examples/MFA.md | whole file |
 | `auth0-server-python` (step-up) | https://raw.githubusercontent.com/auth0/auth0-server-python/main/examples/StepUpAuthentication.md | whole file |
 


### PR DESCRIPTION
## Summary

Temporarily points the `Auth0.Android` row in `feature-mfa/index.md`'s example-doc table at the fix branch from [auth0/Auth0.Android#1067](https://github.com/auth0/Auth0.Android/pull/1067), instead of `main`, so `android_mfa`-style evals can be re-run against the corrected doc before that PR merges.

## Background

`auth0-evals` ran the `android_mfa` eval (agent+skills mode) against two models (`gpt-5.6-terra`, `claude-sonnet-5`) using this skill. Both models fetched the `Auth0.Android` row's linked doc, which opens with:

> "Multi Factor Authentication support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative."

That banner is stale — the MFA client API it warns about has been GA since the old MFA APIs were deprecated (`Auth0.Android#932`) and removed (`#947`), with continued feature work since (`#992` DPoP support, `#998` `getAuthenticators` filtering fix). Decompiling the published `com.auth0.android:auth0:4.0.1` Maven artifact confirms every class/method the doc uses (`MfaApiClient`, `MfaEnrollmentType.Otp`, `MfaVerificationType.Oob`/`.Otp`, `MfaException.MfaChallengeException`/`MfaVerifyException`, `TotpEnrollmentChallenge.barcodeUri`) is present with matching signatures.

**Effect on the models:** both treated the banner as a real signal that the API might not be shipped, and burned significant tool calls re-verifying it before writing code — one decompiled the `.aar` and ran `javap`, the other made ~20 separate `curl` calls against raw GitHub source files, the CHANGELOG, and the GitHub code-search API. An LLM-as-judge grader also took the banner at face value and flagged the resulting (correct) code as using a "fabricated" API that "predates the MFA client API" — a false failure.

[auth0/Auth0.Android#1067](https://github.com/auth0/Auth0.Android/pull/1067) removes the stale banner at the source. This PR is scoped to letting us confirm the fix actually resolves the eval-side symptoms (excess tool calls / false hallucination flags) before that upstream PR lands.

## Follow-up (do not merge as-is)

Revert this pointer back to `main` once `auth0/Auth0.Android#1067` merges — this branch reference should never ship permanently.

## Test plan

- [ ] Re-run `android_mfa` eval (agent+skills, `gpt-5.6-terra` and `claude-sonnet-5`) against this branch and confirm reduced tool-call count / no false "fabricated API" judge failure.
- [ ] Revert to `main` after auth0/Auth0.Android#1067 merges.
